### PR TITLE
Phase 21: Docker & Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.venv
+__pycache__
+*.pyc
+.env
+.env.*
+!.env.example
+frontend/node_modules
+frontend/dist
+.planning
+.claude
+.ruff_cache
+.pytest_cache
+htmlcov
+*.egg-info

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ ENVIRONMENT=development
 
 # PostgreSQL (used by Docker Compose for db container AND by backend for connection)
 POSTGRES_USER=flawchess
+# Generate with: openssl rand -hex 16
 POSTGRES_PASSWORD=
 POSTGRES_DB=flawchess
 DATABASE_URL=postgresql+asyncpg://flawchess:PASSWORD@db:5432/flawchess

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,25 @@
+# FlawChess environment configuration
+# Copy to .env and fill in values
+
+# Environment: "development" enables CORS for localhost:5173 and bypasses JWT auth
+# Environment: "production" disables CORS (same-origin via Caddy)
 ENVIRONMENT=development
 
-DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/flawchess
+# PostgreSQL (used by Docker Compose for db container AND by backend for connection)
+POSTGRES_USER=flawchess
+POSTGRES_PASSWORD=
+POSTGRES_DB=flawchess
+DATABASE_URL=postgresql+asyncpg://flawchess:PASSWORD@db:5432/flawchess
 TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/flawchess_test
 DB_ECHO=false
 
+# Application secret (generate with: openssl rand -hex 32)
+SECRET_KEY=
+
+# URLs (production: both point to https://flawchess.com)
+BACKEND_URL=http://localhost:8000
+FRONTEND_URL=http://localhost:5173
+
+# Google OAuth (from Google Cloud Console)
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ celerybeat.pid
 
 # Environments
 .env
+.prod.env
 .envrc
 .venv
 env/

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -17,11 +17,11 @@ Requirements for Project Launch milestone. Each maps to roadmap phases.
 
 ### Deployment
 
-- [ ] **DEPLOY-01**: Multi-stage Dockerfiles for backend (Python/uv) and frontend (Node build → Caddy)
-- [ ] **DEPLOY-02**: Docker Compose orchestrating FastAPI, PostgreSQL, and Caddy services with named volumes
-- [ ] **DEPLOY-03**: Caddy reverse proxy serving frontend static files and proxying /api to backend with auto-TLS
-- [ ] **DEPLOY-04**: Alembic migrations run automatically on container startup before accepting traffic
-- [ ] **DEPLOY-05**: Environment variable configuration via .env file with Pydantic BaseSettings (no hardcoded secrets)
+- [x] **DEPLOY-01**: Multi-stage Dockerfiles for backend (Python/uv) and frontend (Node build → Caddy)
+- [x] **DEPLOY-02**: Docker Compose orchestrating FastAPI, PostgreSQL, and Caddy services with named volumes
+- [x] **DEPLOY-03**: Caddy reverse proxy serving frontend static files and proxying /api to backend with auto-TLS
+- [x] **DEPLOY-04**: Alembic migrations run automatically on container startup before accepting traffic
+- [x] **DEPLOY-05**: Environment variable configuration via .env file with Pydantic BaseSettings (no hardcoded secrets)
 - [ ] **DEPLOY-06**: Application deployed and accessible at flawchess.com (hosting platform discussed in phase)
 - [ ] **DEPLOY-07**: GitHub Actions CI/CD pipeline: test → build → push to GHCR → SSH deploy on push to main
 
@@ -80,11 +80,11 @@ Deferred to future release. Tracked but not in current roadmap.
 | BRAND-03 | Phase 20 | Complete |
 | BRAND-04 | Phase 20 | Pending |
 | BRAND-05 | Phase 23 | Pending |
-| DEPLOY-01 | Phase 21 | Pending |
-| DEPLOY-02 | Phase 21 | Pending |
-| DEPLOY-03 | Phase 21 | Pending |
-| DEPLOY-04 | Phase 21 | Pending |
-| DEPLOY-05 | Phase 21 | Pending |
+| DEPLOY-01 | Phase 21 | Complete |
+| DEPLOY-02 | Phase 21 | Complete |
+| DEPLOY-03 | Phase 21 | Complete |
+| DEPLOY-04 | Phase 21 | Complete |
+| DEPLOY-05 | Phase 21 | Complete |
 | DEPLOY-06 | Phase 21 | Pending |
 | DEPLOY-07 | Phase 22 | Pending |
 | MON-01 | Phase 22 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -79,13 +79,14 @@ Plans:
 **Success Criteria** (what must be TRUE):
   1. `docker compose up` on a fresh machine starts all services and the app is reachable at the configured domain
   2. Visiting flawchess.com serves the app over HTTPS with a valid Let's Encrypt certificate
-  3. `curl https://flawchess.com/api/health` returns JSON (not HTML), confirming Caddy routes API calls correctly
+  3. `curl https://flawchess.com/health` returns JSON (not HTML), confirming Caddy routes correctly
   4. Restarting containers after `docker compose down && docker compose up` preserves all user data
   5. No secrets or credentials exist in code or Docker images — all config comes from `.env` on the server
-**Plans**: TBD
+**Plans**: 2 plans
 
 Plans:
-- [ ] 21-01: TBD
+- [ ] 21-01-PLAN.md — Docker infrastructure: Dockerfiles, Compose, Caddyfile, entrypoint, CORS conditional, .env.example
+- [ ] 21-02-PLAN.md — Cloud-init cleanup + deploy to Hetzner VPS (checkpoint)
 
 ### Phase 22: CI/CD & Monitoring
 **Goal**: Deploys are automated and errors in production are captured before users report them
@@ -140,7 +141,7 @@ Plans:
 | 18. Mobile Navigation | v1.2 | 1/1 | Complete | 2026-03-20 |
 | 19. Mobile UX Polish + Install Prompt | v1.2 | 3/3 | Complete | 2026-03-21 |
 | 20. Rename & Branding | 1/2 | In Progress|  | - |
-| 21. Docker & Deployment | v1.3 | 0/TBD | Not started | - |
+| 21. Docker & Deployment | v1.3 | 0/2 | Not started | - |
 | 22. CI/CD & Monitoring | v1.3 | 0/TBD | Not started | - |
 | 23. Launch Readiness | v1.3 | 0/TBD | Not started | - |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -141,7 +141,7 @@ Plans:
 | 18. Mobile Navigation | v1.2 | 1/1 | Complete | 2026-03-20 |
 | 19. Mobile UX Polish + Install Prompt | v1.2 | 3/3 | Complete | 2026-03-21 |
 | 20. Rename & Branding | 1/2 | In Progress|  | - |
-| 21. Docker & Deployment | v1.3 | 0/2 | Not started | - |
+| 21. Docker & Deployment | 1/2 | In Progress|  | - |
 | 22. CI/CD & Monitoring | v1.3 | 0/TBD | Not started | - |
 | 23. Launch Readiness | v1.3 | 0/TBD | Not started | - |
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,21 +3,21 @@ gsd_state_version: 1.0
 milestone: v1.3
 milestone_name: Project Launch
 status: unknown
-last_updated: "2026-03-21T17:00:26.744Z"
+last_updated: "2026-03-21T17:46:27.281Z"
 last_activity: 2026-03-21
 progress:
   total_phases: 4
   completed_phases: 1
-  total_plans: 2
-  completed_plans: 2
+  total_plans: 4
+  completed_plans: 3
 ---
 
 # Project State: FlawChess
 
 ## Current Position
 
-Phase: 20 (rename-branding) — EXECUTING
-Plan: 1 of 2
+Phase: 21 (docker-deployment) — EXECUTING
+Plan: 2 of 2
 
 ## Project Reference
 
@@ -52,6 +52,9 @@ Current focus: Phase 20 — Rename & Branding
 - [v1.3 roadmap]: BRAND-05 (README) in Phase 23 — screenshots need live domain and final branding in place
 - [Phase 20]: CSRF cookie renamed from chessalytics_oauth_csrf to flawchess_oauth_csrf — pre-production, acceptable
 - [Phase 20]: apple-touch-icon.png is a copy of icon-192.png as placeholder — user will provide final 180x180 asset
+- [Phase 21]: Backend expose-only (no ports) — Caddy is sole internet-facing entry point, no direct backend access from host
+- [Phase 21]: CORS disabled in production — Caddy routes frontend and API on same origin (flawchess.com)
+- [Phase 21]: Caddy build context is project root with dockerfile: frontend/Dockerfile so COPY deploy/Caddyfile paths work
 
 ### Blockers/Concerns
 
@@ -82,4 +85,4 @@ Current focus: Phase 20 — Rename & Branding
 
 ---
 Last activity: 2026-03-21
-Last session: 2026-03-21T17:00:26.742Z
+Last session: 2026-03-21T17:46:27.279Z

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.3
 milestone_name: Project Launch
 status: unknown
-last_updated: "2026-03-21T16:07:54.320Z"
+last_updated: "2026-03-21T17:00:26.744Z"
 last_activity: 2026-03-21
 progress:
   total_phases: 4
@@ -82,4 +82,4 @@ Current focus: Phase 20 — Rename & Branding
 
 ---
 Last activity: 2026-03-21
-Last session: 2026-03-21T14:12:34.047Z
+Last session: 2026-03-21T17:00:26.742Z

--- a/.planning/phases/21-docker-deployment/21-01-PLAN.md
+++ b/.planning/phases/21-docker-deployment/21-01-PLAN.md
@@ -1,0 +1,501 @@
+---
+phase: 21-docker-deployment
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - Dockerfile
+  - frontend/Dockerfile
+  - docker-compose.yml
+  - deploy/Caddyfile
+  - deploy/entrypoint.sh
+  - .dockerignore
+  - frontend/.dockerignore
+  - .env.example
+  - app/main.py
+autonomous: true
+requirements: [DEPLOY-01, DEPLOY-02, DEPLOY-03, DEPLOY-04, DEPLOY-05]
+
+must_haves:
+  truths:
+    - "docker compose build completes without errors"
+    - "docker compose up starts backend, db, and caddy services"
+    - "Backend waits for PostgreSQL to be healthy before starting"
+    - "Alembic migrations run before Uvicorn accepts traffic"
+    - "Caddy proxies API routes to backend and serves frontend static files"
+    - "CORS middleware only active in development mode"
+    - "No secrets exist in Docker images or checked-in files"
+  artifacts:
+    - path: "Dockerfile"
+      provides: "Backend multi-stage build (builder + runtime)"
+      contains: "ghcr.io/astral-sh/uv"
+    - path: "frontend/Dockerfile"
+      provides: "Frontend build + Caddy serve"
+      contains: "caddy:2.11.2"
+    - path: "docker-compose.yml"
+      provides: "3-service orchestration with healthchecks"
+      contains: "service_healthy"
+    - path: "deploy/Caddyfile"
+      provides: "Reverse proxy + static file serving"
+      contains: "flawchess.com"
+    - path: "deploy/entrypoint.sh"
+      provides: "Migration-then-serve startup"
+      contains: "alembic upgrade head"
+    - path: ".dockerignore"
+      provides: "Excludes .venv, node_modules, .git from backend context"
+    - path: ".env.example"
+      provides: "Documents all production env vars"
+      contains: "POSTGRES_USER"
+  key_links:
+    - from: "docker-compose.yml"
+      to: "Dockerfile"
+      via: "build: ."
+      pattern: "build:\\s+\\."
+    - from: "docker-compose.yml"
+      to: "frontend/Dockerfile"
+      via: "build context for caddy service"
+      pattern: "dockerfile.*frontend/Dockerfile"
+    - from: "deploy/entrypoint.sh"
+      to: "alembic"
+      via: "alembic upgrade head before exec uvicorn"
+      pattern: "alembic upgrade head"
+    - from: "deploy/Caddyfile"
+      to: "backend:8000"
+      via: "reverse_proxy for API routes"
+      pattern: "reverse_proxy backend:8000"
+---
+
+<objective>
+Create all Docker infrastructure files to containerize FlawChess for production deployment.
+
+Purpose: Provide a complete, buildable Docker Compose stack (FastAPI backend + PostgreSQL + Caddy reverse proxy) that can be deployed to a Hetzner VPS with `docker compose up`.
+Output: Dockerfile, frontend/Dockerfile, docker-compose.yml, Caddyfile, entrypoint.sh, .dockerignore files, updated .env.example and CORS conditional in app/main.py.
+</objective>
+
+<execution_context>
+@/home/aimfeld/.claude/get-shit-done/workflows/execute-plan.md
+@/home/aimfeld/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/21-docker-deployment/21-CONTEXT.md
+@.planning/phases/21-docker-deployment/21-RESEARCH.md
+
+<interfaces>
+<!-- Key files the executor needs to understand -->
+
+From app/core/config.py:
+```python
+class Settings(BaseSettings):
+    DATABASE_URL: str = "postgresql+asyncpg://user:password@localhost:5432/flawchess"
+    TEST_DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/flawchess_test"
+    DB_ECHO: bool = False
+    SECRET_KEY: str = "change-me-in-production"
+    GOOGLE_OAUTH_CLIENT_ID: str = ""
+    GOOGLE_OAUTH_CLIENT_SECRET: str = ""
+    BACKEND_URL: str = "http://localhost:8000"
+    FRONTEND_URL: str = "http://localhost:5173"
+    ENVIRONMENT: str = "production"
+    model_config = SettingsConfigDict(env_file=".env")
+```
+
+From app/main.py (current CORS — needs conditional):
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+```
+
+From frontend/vite.config.ts (proxy routes — these ARE the API route prefixes, no /api/ prefix):
+```typescript
+proxy: {
+    '/auth': { target: 'http://localhost:8000', ... },
+    '/analysis': 'http://localhost:8000',
+    '/games': 'http://localhost:8000',
+    '/imports': 'http://localhost:8000',
+    '/position-bookmarks': 'http://localhost:8000',
+    '/stats': 'http://localhost:8000',
+    '/users': 'http://localhost:8000',
+    '/health': 'http://localhost:8000',
+},
+```
+
+CRITICAL: The backend does NOT use an `/api/*` prefix. Routes are `/auth/*`, `/analysis/*`, `/games/*`, `/imports/*`, `/position-bookmarks/*`, `/stats/*`, `/users/*`, `/health`. The Caddyfile must proxy each of these prefixes individually.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create Dockerfiles, entrypoint, and .dockerignore files</name>
+  <files>Dockerfile, frontend/Dockerfile, deploy/entrypoint.sh, .dockerignore, frontend/.dockerignore</files>
+  <read_first>
+    - app/main.py (understand app entry point)
+    - app/core/config.py (understand env var expectations)
+    - frontend/vite.config.ts (understand build setup)
+    - frontend/package.json (understand build command)
+    - pyproject.toml (understand Python deps)
+    - alembic.ini (understand migration config)
+    - alembic/env.py (understand async migration setup)
+    - .gitignore (understand existing ignore patterns)
+  </read_first>
+  <action>
+Create 5 files:
+
+**Dockerfile** (backend multi-stage, project root):
+```dockerfile
+FROM python:3.13-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies first (cacheable layer)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-dev --no-install-project
+
+# Copy source and install project
+COPY . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+FROM python:3.13-slim AS runtime
+WORKDIR /app
+COPY --from=builder /app /app
+ENV PATH="/app/.venv/bin:$PATH"
+COPY deploy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+**frontend/Dockerfile** (Node build + Caddy serve):
+Build context will be project root (set in docker-compose.yml), so paths are relative to root.
+```dockerfile
+FROM node:24-alpine AS builder
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM caddy:2.11.2 AS runtime
+COPY --from=builder /app/dist /srv
+COPY deploy/Caddyfile /etc/caddy/Caddyfile
+```
+
+**deploy/entrypoint.sh**:
+```bash
+#!/bin/sh
+set -e
+
+echo "Running Alembic migrations..."
+alembic upgrade head
+
+echo "Starting Uvicorn..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+Must have executable permission (chmod +x is in Dockerfile, but also set in git).
+
+**.dockerignore** (backend context):
+```
+.git
+.venv
+__pycache__
+*.pyc
+.env
+.env.*
+!.env.example
+frontend/node_modules
+frontend/dist
+.planning
+.claude
+.ruff_cache
+.pytest_cache
+htmlcov
+*.egg-info
+```
+
+**frontend/.dockerignore** (frontend context — though build context is root, having this is good practice):
+```
+node_modules
+dist
+.env
+```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && test -f Dockerfile && test -f frontend/Dockerfile && test -f deploy/entrypoint.sh && test -x deploy/entrypoint.sh && test -f .dockerignore && echo "All files exist and entrypoint is executable"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Dockerfile contains `FROM python:3.13-slim AS builder`
+    - Dockerfile contains `COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/`
+    - Dockerfile contains `uv sync --locked --no-dev`
+    - Dockerfile contains `ENTRYPOINT ["/entrypoint.sh"]`
+    - frontend/Dockerfile contains `FROM node:24-alpine AS builder`
+    - frontend/Dockerfile contains `FROM caddy:2.11.2 AS runtime`
+    - frontend/Dockerfile contains `COPY deploy/Caddyfile /etc/caddy/Caddyfile`
+    - deploy/entrypoint.sh contains `set -e`
+    - deploy/entrypoint.sh contains `alembic upgrade head`
+    - deploy/entrypoint.sh contains `exec uvicorn app.main:app --host 0.0.0.0 --port 8000`
+    - .dockerignore contains `.venv` and `.git` and `frontend/node_modules`
+  </acceptance_criteria>
+  <done>Backend and frontend Dockerfiles use multi-stage builds with pinned versions. Entrypoint runs migrations then exec's uvicorn. .dockerignore excludes dev artifacts from build context.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create docker-compose.yml and Caddyfile</name>
+  <files>docker-compose.yml, deploy/Caddyfile</files>
+  <read_first>
+    - Dockerfile (just created — verify build context expectations)
+    - frontend/Dockerfile (just created — verify build context)
+    - deploy/entrypoint.sh (just created — verify it exists)
+    - app/core/config.py (env var names for env_file)
+    - frontend/vite.config.ts (API route prefixes for Caddyfile)
+  </read_first>
+  <action>
+Create 2 files:
+
+**docker-compose.yml** (project root):
+```yaml
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  backend:
+    build: .
+    env_file: .env
+    expose:
+      - "8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  caddy:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:
+```
+
+Key points:
+- Backend has NO `ports:` — only `expose: ["8000"]` (internal only, not exposed to host/internet)
+- db healthcheck uses `$$` for proper shell variable interpolation in Compose
+- Named volumes for pgdata, caddy_data, caddy_config
+- caddy build context is `.` (project root) with `dockerfile: frontend/Dockerfile` so COPY paths work
+- `443:443/udp` enables HTTP/3
+
+**deploy/Caddyfile**:
+CRITICAL: The backend does NOT use `/api/*` prefix. Each route prefix must be proxied individually.
+```caddy
+flawchess.com {
+    encode gzip
+
+    # Backend API routes — proxy each prefix individually
+    # (no /api/* prefix in this codebase)
+    handle /auth/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /analysis/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /games/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /imports/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /position-bookmarks/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /stats/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /users/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /health {
+        reverse_proxy backend:8000
+    }
+
+    # Frontend SPA — serve static files with index.html fallback
+    handle {
+        root * /srv
+        header /index.html Cache-Control "no-cache"
+        try_files {path} /index.html
+        file_server
+    }
+}
+```
+
+Note on Caddyfile: `handle` blocks are evaluated in declaration order. The specific API routes match first; the catch-all SPA handler matches everything else. The `{path}` placeholder is Caddy syntax (not a shell variable).
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && test -f docker-compose.yml && test -f deploy/Caddyfile && grep -q "service_healthy" docker-compose.yml && grep -q "reverse_proxy backend:8000" deploy/Caddyfile && echo "Compose and Caddyfile valid"</automated>
+  </verify>
+  <acceptance_criteria>
+    - docker-compose.yml contains `image: postgres:16-alpine`
+    - docker-compose.yml contains `condition: service_healthy`
+    - docker-compose.yml contains `pg_isready`
+    - docker-compose.yml contains `expose:` (not `ports:`) for backend service
+    - docker-compose.yml contains `pgdata:`, `caddy_data:`, `caddy_config:` in volumes section
+    - docker-compose.yml does NOT contain `ports:` under backend service
+    - deploy/Caddyfile contains `flawchess.com {`
+    - deploy/Caddyfile contains `handle /auth/*` and `handle /analysis/*` and `handle /games/*` and `handle /imports/*` and `handle /position-bookmarks/*` and `handle /stats/*` and `handle /users/*` and `handle /health`
+    - deploy/Caddyfile contains `reverse_proxy backend:8000`
+    - deploy/Caddyfile contains `try_files {path} /index.html`
+    - deploy/Caddyfile contains `header /index.html Cache-Control "no-cache"`
+  </acceptance_criteria>
+  <done>Docker Compose orchestrates 3 services (db, backend, caddy) with healthcheck-based startup ordering, named volumes, and no exposed backend port. Caddyfile proxies all 8 API route prefixes to backend and serves SPA with index.html fallback.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Update .env.example and make CORS conditional on ENVIRONMENT</name>
+  <files>.env.example, app/main.py</files>
+  <read_first>
+    - .env.example (current content to extend)
+    - app/main.py (current CORS setup to conditionalize)
+    - app/core/config.py (available settings fields)
+    - deploy/cloud-init.yml (production .env template for consistency)
+  </read_first>
+  <action>
+**Update .env.example** to document ALL production-required variables. Replace current content with:
+```
+# FlawChess environment configuration
+# Copy to .env and fill in values
+
+# Environment: "development" enables CORS for localhost:5173 and bypasses JWT auth
+# Environment: "production" disables CORS (same-origin via Caddy)
+ENVIRONMENT=development
+
+# PostgreSQL (used by Docker Compose for db container AND by backend for connection)
+POSTGRES_USER=flawchess
+POSTGRES_PASSWORD=
+POSTGRES_DB=flawchess
+DATABASE_URL=postgresql+asyncpg://flawchess:PASSWORD@db:5432/flawchess
+TEST_DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/flawchess_test
+DB_ECHO=false
+
+# Application secret (generate with: openssl rand -hex 32)
+SECRET_KEY=
+
+# URLs (production: both point to https://flawchess.com)
+BACKEND_URL=http://localhost:8000
+FRONTEND_URL=http://localhost:5173
+
+# Google OAuth (from Google Cloud Console)
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+```
+
+**Update app/main.py** — make CORS middleware conditional on ENVIRONMENT setting:
+1. Add import: `from app.core.config import settings`
+2. Wrap the `app.add_middleware(CORSMiddleware, ...)` block in `if settings.ENVIRONMENT == "development":`
+3. Add a comment explaining why: `# CORS only needed in development — Caddy provides same-origin routing in production`
+4. Keep the existing allow_origins, allow_credentials, allow_methods, allow_headers values unchanged inside the conditional
+
+The result should look like:
+```python
+from app.core.config import settings
+
+# ...
+
+# CORS only needed in development — Caddy provides same-origin routing in production
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && grep -q "POSTGRES_USER" .env.example && grep -q "POSTGRES_PASSWORD" .env.example && grep -q "POSTGRES_DB" .env.example && grep -q 'ENVIRONMENT == "development"' app/main.py && grep -q "from app.core.config import settings" app/main.py && uv run pytest tests/test_auth.py -x --timeout=10 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - .env.example contains `POSTGRES_USER=flawchess`
+    - .env.example contains `POSTGRES_PASSWORD=`
+    - .env.example contains `POSTGRES_DB=flawchess`
+    - .env.example contains `DATABASE_URL=postgresql+asyncpg://flawchess:PASSWORD@db:5432/flawchess`
+    - .env.example contains `SECRET_KEY=`
+    - .env.example contains `BACKEND_URL=`
+    - .env.example contains `FRONTEND_URL=`
+    - .env.example contains `GOOGLE_OAUTH_CLIENT_ID=`
+    - app/main.py contains `from app.core.config import settings`
+    - app/main.py contains `if settings.ENVIRONMENT == "development":`
+    - app/main.py contains `# CORS only needed in development`
+    - Existing tests still pass (uv run pytest exits 0)
+  </acceptance_criteria>
+  <done>.env.example documents all production variables including POSTGRES_USER/PASSWORD/DB for Docker Compose. CORS middleware only active when ENVIRONMENT=development. Existing tests pass.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. All Docker infrastructure files exist: `ls Dockerfile frontend/Dockerfile docker-compose.yml deploy/Caddyfile deploy/entrypoint.sh .dockerignore`
+2. Backend Dockerfile uses uv multi-stage pattern: `grep "ghcr.io/astral-sh/uv" Dockerfile`
+3. Frontend Dockerfile uses Caddy: `grep "caddy:2.11.2" frontend/Dockerfile`
+4. Compose has healthcheck ordering: `grep "service_healthy" docker-compose.yml`
+5. Backend port not exposed: `grep -c "ports:" docker-compose.yml` should be 1 (only caddy)
+6. Caddyfile routes all API prefixes: `grep -c "reverse_proxy backend:8000" deploy/Caddyfile` should be 8
+7. CORS is conditional: `grep 'ENVIRONMENT == "development"' app/main.py`
+8. .env.example has production vars: `grep "POSTGRES_USER" .env.example`
+9. Tests pass: `uv run pytest -x`
+</verification>
+
+<success_criteria>
+- `docker compose config` validates without errors (requires .env with placeholder values)
+- All 8 API route prefixes are individually proxied in Caddyfile
+- CORS middleware is conditional on ENVIRONMENT=development
+- .env.example documents every variable needed for production deployment
+- No secrets or credentials exist in any checked-in file
+- Existing test suite passes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/21-docker-deployment/21-01-SUMMARY.md`
+</output>

--- a/.planning/phases/21-docker-deployment/21-01-SUMMARY.md
+++ b/.planning/phases/21-docker-deployment/21-01-SUMMARY.md
@@ -1,0 +1,128 @@
+---
+phase: 21-docker-deployment
+plan: 01
+subsystem: infra
+tags: [docker, caddy, postgres, uvicorn, alembic, uv, nginx-alternative]
+
+# Dependency graph
+requires: []
+provides:
+  - "Backend multi-stage Dockerfile with uv and pinned Python 3.13"
+  - "Frontend Dockerfile with Node 24 build stage and Caddy 2.11.2 serve stage"
+  - "docker-compose.yml orchestrating db/backend/caddy with healthcheck ordering"
+  - "Caddyfile proxying 8 API route prefixes + SPA fallback"
+  - "deploy/entrypoint.sh running alembic migrations before uvicorn"
+  - "Conditional CORS (development only) — production uses same-origin via Caddy"
+  - ".env.example documenting all production variables"
+affects: [22-ci-cd-monitoring, 23-launch-readiness]
+
+# Tech tracking
+tech-stack:
+  added: [caddy:2.11.2, postgres:16-alpine, node:24-alpine, ghcr.io/astral-sh/uv:0.10.9]
+  patterns:
+    - "uv multi-stage Docker build: deps layer (bind mount) then source layer"
+    - "Backend expose-only (no ports) — only Caddy is internet-facing"
+    - "Service-healthy healthcheck gate: backend waits for db to be ready"
+    - "entrypoint.sh pattern: migrate-then-exec for zero-downtime migration"
+
+key-files:
+  created:
+    - Dockerfile
+    - frontend/Dockerfile
+    - docker-compose.yml
+    - deploy/Caddyfile
+    - deploy/entrypoint.sh
+    - .dockerignore
+    - frontend/.dockerignore
+  modified:
+    - .env.example
+    - app/main.py
+
+key-decisions:
+  - "Backend has expose: not ports: — internal only, Caddy is sole entry point"
+  - "Caddy build context is project root with dockerfile: frontend/Dockerfile so COPY deploy/ paths work"
+  - "443:443/udp added to caddy ports for HTTP/3 support"
+  - "CORS disabled in production — Caddy routes frontend and API on same origin"
+
+patterns-established:
+  - "API routes proxied individually (no /api/ prefix) matching vite.config.ts proxy config"
+  - "docker-compose $$ syntax for shell variable interpolation in healthcheck test string"
+
+requirements-completed: [DEPLOY-01, DEPLOY-02, DEPLOY-03, DEPLOY-04, DEPLOY-05]
+
+# Metrics
+duration: 2min
+completed: 2026-03-21
+---
+
+# Phase 21 Plan 01: Docker Infrastructure Summary
+
+**Complete Docker Compose stack with uv multi-stage backend, Caddy 2.11.2 frontend/proxy, Postgres healthcheck ordering, and conditional CORS for development vs production**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-03-21T17:42:46Z
+- **Completed:** 2026-03-21T17:44:58Z
+- **Tasks:** 3
+- **Files modified:** 9
+
+## Accomplishments
+
+- Backend Dockerfile using ghcr.io/astral-sh/uv:0.10.9 for cached dependency install then project copy (two-stage uv pattern)
+- docker-compose.yml with healthcheck-gated startup: db must be healthy before backend starts; alembic runs before uvicorn accepts traffic
+- Caddyfile proxies all 8 API route prefixes individually (matching vite.config.ts proxy configuration), then catches everything else for SPA index.html fallback
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create Dockerfiles, entrypoint, and .dockerignore files** - `8d024cd` (feat)
+2. **Task 2: Create docker-compose.yml and Caddyfile** - `27043b4` (feat)
+3. **Task 3: Update .env.example and make CORS conditional on ENVIRONMENT** - `bee47e3` (feat)
+
+## Files Created/Modified
+
+- `Dockerfile` - Backend multi-stage build: uv deps layer (cacheable) + project source layer, runtime on python:3.13-slim
+- `frontend/Dockerfile` - Node 24 Alpine build stage compiles SPA, Caddy 2.11.2 runtime serves /srv
+- `docker-compose.yml` - 3-service orchestration with postgres:16-alpine healthcheck, backend expose-only, caddy on 80/443/443-udp
+- `deploy/Caddyfile` - Reverse proxy: 8 API prefixes to backend:8000, SPA catch-all with index.html fallback
+- `deploy/entrypoint.sh` - `set -e; alembic upgrade head; exec uvicorn ...` startup sequence
+- `.dockerignore` - Excludes .venv, .git, frontend/node_modules, .planning, .claude, dev artifacts from build context
+- `frontend/.dockerignore` - Excludes node_modules, dist, .env from frontend context
+- `.env.example` - Documents all production variables including POSTGRES_USER/PASSWORD/DB and DATABASE_URL pointing to db:5432
+- `app/main.py` - CORS middleware now conditional: only active when ENVIRONMENT=development
+
+## Decisions Made
+
+- Backend uses `expose:` not `ports:` — the backend is internal-only, Caddy is the sole internet-facing entry point. This is correct for security: no direct backend access from host.
+- Caddy build context is project root (`.`) with `dockerfile: frontend/Dockerfile` so the `COPY deploy/Caddyfile` instruction inside the Dockerfile can reach the deploy/ directory.
+- HTTP/3 enabled via `443:443/udp` — Caddy handles QUIC natively, no extra config needed.
+- CORS disabled in production: Caddy routes `/auth/*`, `/analysis/*` etc. to the backend and everything else to the SPA, so frontend and API share the same origin (`flawchess.com`). CORS would be redundant and slightly reduces security surface.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required. The VPS provisioning (cloud-init.yml) was already created in phase context research.
+
+## Next Phase Readiness
+
+- All Docker infrastructure files are ready for `docker compose build` and `docker compose up` on the Hetzner VPS
+- Phase 22 (CI/CD) can now reference these files for GitHub Actions workflows
+- Phase 23 (Launch Readiness) can deploy using these files once the VPS is provisioned
+
+---
+*Phase: 21-docker-deployment*
+*Completed: 2026-03-21*
+
+## Self-Check: PASSED
+
+- All 8 files created/modified confirmed present on disk
+- All 3 task commits confirmed in git log (8d024cd, 27043b4, bee47e3)

--- a/.planning/phases/21-docker-deployment/21-02-PLAN.md
+++ b/.planning/phases/21-docker-deployment/21-02-PLAN.md
@@ -1,0 +1,175 @@
+---
+phase: 21-docker-deployment
+plan: 02
+type: execute
+wave: 2
+depends_on: [21-01]
+files_modified:
+  - deploy/cloud-init.yml
+autonomous: false
+requirements: [DEPLOY-06]
+
+must_haves:
+  truths:
+    - "cloud-init.yml provisions a server ready for docker compose up"
+    - "Server provisioning creates /opt/flawchess with correct ownership"
+    - "cloud-init .env template matches .env.example variable names"
+    - "FlawChess is accessible at flawchess.com over HTTPS"
+    - "curl flawchess.com/health returns JSON with status ok"
+    - "User data persists across docker compose down/up cycles"
+  artifacts:
+    - path: "deploy/cloud-init.yml"
+      provides: "Server provisioning script for Hetzner VPS"
+      contains: "docker-compose-plugin"
+  key_links:
+    - from: "deploy/cloud-init.yml"
+      to: "docker-compose.yml"
+      via: "Server runs docker compose up in /opt/flawchess"
+      pattern: "/opt/flawchess"
+---
+
+<objective>
+Clean up the existing cloud-init.yml and deploy FlawChess to the Hetzner VPS.
+
+Purpose: Get the application running in production at flawchess.com with HTTPS, persistent data, and automatic migrations.
+Output: Updated cloud-init.yml, live deployment at flawchess.com.
+</objective>
+
+<execution_context>
+@/home/aimfeld/.claude/get-shit-done/workflows/execute-plan.md
+@/home/aimfeld/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/21-docker-deployment/21-CONTEXT.md
+@.planning/phases/21-docker-deployment/21-RESEARCH.md
+@.planning/phases/21-docker-deployment/21-01-SUMMARY.md
+
+<interfaces>
+<!-- From Plan 01 outputs -->
+
+docker-compose.yml expects these env vars (from .env via env_file):
+- POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB (for db service)
+- DATABASE_URL, SECRET_KEY, ENVIRONMENT, BACKEND_URL, FRONTEND_URL (for backend)
+- GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET (for OAuth)
+
+deploy/cloud-init.yml writes .env template to /opt/flawchess/.env
+docker-compose.yml and .env live at /opt/flawchess/ on the server
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Clean up cloud-init.yml</name>
+  <files>deploy/cloud-init.yml</files>
+  <read_first>
+    - deploy/cloud-init.yml (current content — apply targeted fixes)
+    - .env.example (ensure cloud-init .env template matches these variable names)
+    - docker-compose.yml (verify named volumes — no bind-mount dirs needed on host)
+  </read_first>
+  <action>
+Apply these specific changes to the existing deploy/cloud-init.yml:
+
+1. **Add `reboot: true`** at the end of the file (top-level key, same level as `runcmd:`). This ensures the latest kernel from `package_upgrade: true` is active before the server goes live.
+
+2. **Verify the .env template** in the `write_files:` section matches .env.example variable names. Ensure it contains all of:
+   - ENVIRONMENT=production
+   - POSTGRES_USER=flawchess
+   - POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+   - POSTGRES_DB=flawchess
+   - DATABASE_URL=postgresql+asyncpg://flawchess:CHANGE_ME_STRONG_PASSWORD@db:5432/flawchess
+   - SECRET_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32
+   - BACKEND_URL=https://flawchess.com
+   - FRONTEND_URL=https://flawchess.com
+   - GOOGLE_OAUTH_CLIENT_ID=
+   - GOOGLE_OAUTH_CLIENT_SECRET=
+
+3. **Verify heredoc whitespace**: The `content: |` block must have lines starting at column 0 relative to the block scalar indicator. Check that no leading spaces are accidentally indented (YAML block scalars preserve indentation).
+
+4. **Verify no bind-mount directory creation** exists in runcmd. The current script has `mkdir -p /opt/flawchess` which is correct (needed for docker-compose.yml and .env). There should NOT be mkdir for pgdata, caddy_data, or caddy_config (those are named Docker volumes, not bind mounts).
+
+Do NOT change: SSH key, user creation, Docker install commands, UFW rules, SSH hardening, fail2ban setup, unattended-upgrades.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && grep -q "reboot: true" deploy/cloud-init.yml && grep -q "POSTGRES_USER" deploy/cloud-init.yml && grep -q "POSTGRES_PASSWORD" deploy/cloud-init.yml && grep -q "/opt/flawchess" deploy/cloud-init.yml && echo "cloud-init.yml updated"</automated>
+  </verify>
+  <acceptance_criteria>
+    - deploy/cloud-init.yml contains `reboot: true` as a top-level key
+    - deploy/cloud-init.yml .env template contains ENVIRONMENT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB, DATABASE_URL, SECRET_KEY, BACKEND_URL, FRONTEND_URL, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET
+    - deploy/cloud-init.yml does NOT contain `mkdir` for pgdata, caddy_data, or caddy_config
+    - deploy/cloud-init.yml contains `mkdir -p /opt/flawchess`
+    - deploy/cloud-init.yml .env content lines have no unintended leading whitespace
+  </acceptance_criteria>
+  <done>cloud-init.yml is ready for Hetzner VPS provisioning. Reboots after package upgrade for kernel updates. .env template matches all production variables. No bind-mount directories created (using named Docker volumes).</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Deploy to Hetzner VPS and verify production</name>
+  <files>none (human verification of live deployment)</files>
+  <action>
+This is a human verification checkpoint. The user provisions the Hetzner VPS and deploys the application. Claude assists with troubleshooting if issues arise.
+
+**What was built:** Complete Docker infrastructure for FlawChess — Dockerfiles (backend + frontend/Caddy), docker-compose.yml with healthcheck ordering, Caddyfile with per-route API proxying, entrypoint.sh with auto-migrations, cloud-init.yml for server provisioning.
+
+**Steps for the user:**
+
+Server provisioning (one-time):
+1. Create a Hetzner Cloud server: CPX22, Ubuntu 24.04, paste `deploy/cloud-init.yml` into "Cloud config"
+2. Wait ~3-5 minutes for cloud-init to complete (server will reboot once)
+3. Note the server IP address
+
+DNS setup (one-time):
+4. At your domain registrar, create an A record: `flawchess.com` -> server IP
+5. Optionally add `www.flawchess.com` -> server IP (or CNAME to flawchess.com)
+6. Wait for DNS propagation (check with `dig flawchess.com`)
+
+Application deployment:
+7. SSH into the server: `ssh deploy@<server-ip>`
+8. Edit `/opt/flawchess/.env` — fill in real values for POSTGRES_PASSWORD, SECRET_KEY, GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET
+9. Clone the repo: `cd /opt/flawchess && git clone https://github.com/flawchess/flawchess.git .` (or copy docker-compose.yml, Dockerfile, frontend/, deploy/ to the server)
+10. Build and start: `docker compose up -d --build`
+11. Check services: `docker compose ps` — all 3 services should be "running" or "healthy"
+12. Check backend logs: `docker compose logs backend` — should show "Running Alembic migrations..." then "Started server process"
+
+Verification:
+13. Visit `https://flawchess.com` — should load the FlawChess app with valid TLS (green lock)
+14. Run: `curl -s https://flawchess.com/health | jq .` — should return `{"status": "ok"}`
+15. Try registering/logging in to verify auth works
+16. Run `docker compose down && docker compose up -d` and verify data persists (user still exists)
+  </action>
+  <verify>
+    <automated>echo "CHECKPOINT: Human verification required — user confirms flawchess.com is live"</automated>
+  </verify>
+  <acceptance_criteria>
+    - User confirms https://flawchess.com loads the FlawChess app
+    - User confirms curl https://flawchess.com/health returns {"status": "ok"}
+    - User confirms data persists across docker compose restart
+  </acceptance_criteria>
+  <done>FlawChess is deployed and accessible at flawchess.com over HTTPS. All services running. Data persists across restarts.</done>
+</task>
+
+</tasks>
+
+<verification>
+1. cloud-init.yml has reboot: true: `grep "reboot:" deploy/cloud-init.yml`
+2. cloud-init.yml .env template has all vars: `grep -c "=" deploy/cloud-init.yml` (should include all production vars)
+3. Live site responds: `curl -s https://flawchess.com/health` returns `{"status":"ok"}`
+4. HTTPS valid: `curl -sI https://flawchess.com | grep -i "HTTP/2 200"`
+5. Data persists: user created before restart still exists after restart
+</verification>
+
+<success_criteria>
+- flawchess.com loads the FlawChess app over HTTPS with a valid Let's Encrypt certificate
+- `curl https://flawchess.com/health` returns `{"status":"ok"}`
+- All 3 Docker Compose services are running (db, backend, caddy)
+- Data persists across `docker compose down && docker compose up` cycles
+- No secrets in the git repository or Docker images
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/21-docker-deployment/21-02-SUMMARY.md`
+</output>

--- a/.planning/phases/21-docker-deployment/21-CONTEXT.md
+++ b/.planning/phases/21-docker-deployment/21-CONTEXT.md
@@ -1,0 +1,131 @@
+# Phase 21: Docker & Deployment - Context
+
+**Gathered:** 2026-03-21
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Containerize FlawChess (FastAPI backend + React frontend + PostgreSQL) with Docker Compose, deploy to a Hetzner cloud server with Caddy auto-TLS, ensure persistent data and automatic migrations on startup. No CI/CD automation (Phase 22), no monitoring (Phase 22), no analytics/content pages (Phase 23).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Hosting Platform
+- Hetzner Cloud server, CPX22 (2 vCPU, 4GB RAM, 80GB disk, ~€5.99/mo)
+- Regular performance (shared vCPU) — sufficient for I/O-bound web app workload
+- Can resize within CX/CPX line if needed (CPX32 at €10.49/mo next step up)
+- Ubuntu 24.04 LTS as the server OS
+
+### Docker Architecture
+- Multi-stage Dockerfile for frontend: Node build stage outputs static files to a shared volume, Caddy serves them at runtime — no separate frontend container running
+- Backend Dockerfile: `python:3.13-slim` base image with uv installed in build stage, copy lockfile, install deps. Small image (~150MB)
+- Single Uvicorn worker (async) — FastAPI handles concurrency via async I/O, no Gunicorn needed at this scale
+- Frontend build happens inside Docker (multi-stage) for reproducible builds and CI/CD readiness
+
+### Compose & Networking
+- Caddyfile configuration (not JSON or Docker labels) — simple, readable, ~15 lines
+- Caddy serves static frontend files at root, reverse-proxies `/api/*` to backend container
+- Caddy handles auto-TLS via Let's Encrypt — just set the domain name
+- CORS middleware removed in production (same-origin via Caddy) — keep only for `ENVIRONMENT=development`
+- Named Docker volumes for PostgreSQL data and Caddy TLS state (not bind mounts)
+- Alembic migrations run automatically via backend container entrypoint script (`alembic upgrade head` before Uvicorn starts). If migration fails, container fails to start.
+
+### Server Provisioning
+- Cloud-init YAML script checked into repo at `deploy/cloud-init.yml` — already created by user
+- Cloud-init installs Docker, configures UFW (ports 22/80/443 only), enables fail2ban, creates deploy user, hardens SSH (key-only, no root)
+- Unattended-upgrades enabled for automatic security patches
+- Cloud-init to be simplified: remove bind-mount directory creation (pgdata, caddy_data, caddy_config) since we're using named Docker volumes. Keep /opt/flawchess for docker-compose.yml and .env
+- Fix .env template heredoc whitespace (leading spaces from YAML indentation)
+- Consider adding `reboot: true` at end of cloud-init for kernel updates
+
+### DNS & TLS
+- A record at domain registrar pointing flawchess.com to Hetzner VPS IP (manual step, documented)
+- Caddy auto-TLS handles Let's Encrypt certificate provisioning and renewal automatically
+
+### Secrets Management
+- `.env` file manually SCP'd to server during initial setup — secrets never touch git or CI
+- Required variables documented in `.env.example` in the repo
+- Production .env lives at `/opt/flawchess/.env` on the server
+
+### Claude's Discretion
+- Exact Caddyfile syntax and routing rules
+- Docker Compose service names and network configuration
+- Entrypoint script implementation details
+- Container health check configuration
+- Whether to add `reboot: true` to cloud-init or leave it out
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Deployment requirements
+- `.planning/REQUIREMENTS.md` — DEPLOY-01 through DEPLOY-06 define containerization and deployment scope
+
+### Existing deployment assets
+- `deploy/cloud-init.yml` — User-created cloud-init script for Hetzner VPS provisioning (needs minor updates: remove bind-mount dirs, fix heredoc whitespace)
+
+### Backend configuration
+- `app/core/config.py` — Pydantic BaseSettings reading from .env (DATABASE_URL, SECRET_KEY, BACKEND_URL, FRONTEND_URL, ENVIRONMENT, Google OAuth)
+- `app/main.py` — FastAPI app with CORS middleware (needs production conditional), health endpoint at `/health`
+- `alembic.ini` — Alembic migration configuration
+- `pyproject.toml` — Python dependencies and project metadata
+- `.env.example` — Environment variable template
+
+### Frontend build
+- `frontend/vite.config.ts` — Vite + PWA plugin config (build output goes to dist/)
+- `frontend/package.json` — Node dependencies and build scripts
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `deploy/cloud-init.yml` — Server provisioning already scripted, needs minor cleanup
+- `app/core/config.py` — Pydantic BaseSettings already reads all config from environment/`.env`
+- `/health` endpoint already exists in `app/main.py` — satisfies success criteria 3
+
+### Established Patterns
+- Backend uses `uv` for dependency management (pyproject.toml + uv.lock)
+- Frontend uses npm (package.json + package-lock.json)
+- CORS middleware in `app/main.py` currently hardcoded to localhost:5173 — needs environment-conditional logic
+
+### Integration Points
+- `app/main.py` CORS middleware — must be conditional on ENVIRONMENT setting
+- `.env.example` — needs to document all production-required variables
+- `alembic/` — migrations directory, entrypoint script must run `alembic upgrade head`
+- Frontend `dist/` output — Caddy needs to serve this directory
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- User has hands-on Hetzner experience (deployed Superset instance) — comfortable with VPS management
+- Cloud-init approach preferred over manual setup for reproducibility
+- Server is a "dumb Docker host" — all app logic in containers, server just needs Docker + SSH + firewall
+- User already created cloud-init.yml — plan should build on it, not recreate
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- CI/CD pipeline (GitHub Actions: test → build → push → SSH deploy) — Phase 22
+- Sentry error monitoring — Phase 22
+- Cloudflare DNS/CDN proxy — not needed at launch, revisit if DDoS becomes a concern
+- Hetzner Cloud Firewall (layered on top of UFW) — can add later for defense-in-depth
+- Gunicorn multi-worker setup — revisit if CPU becomes bottleneck under load
+
+</deferred>
+
+---
+
+*Phase: 21-docker-deployment*
+*Context gathered: 2026-03-21*

--- a/.planning/phases/21-docker-deployment/21-RESEARCH.md
+++ b/.planning/phases/21-docker-deployment/21-RESEARCH.md
@@ -1,0 +1,542 @@
+# Phase 21: Docker & Deployment - Research
+
+**Researched:** 2026-03-21
+**Domain:** Docker Compose, Caddy reverse proxy, uv multi-stage builds, VPS deployment
+**Confidence:** HIGH
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Hosting Platform**
+- Hetzner Cloud server, CPX22 (2 vCPU, 4GB RAM, 80GB disk, ~€5.99/mo)
+- Regular performance (shared vCPU) — sufficient for I/O-bound web app workload
+- Can resize within CX/CPX line if needed (CPX32 at €10.49/mo next step up)
+- Ubuntu 24.04 LTS as the server OS
+
+**Docker Architecture**
+- Multi-stage Dockerfile for frontend: Node build stage outputs static files to a shared volume, Caddy serves them at runtime — no separate frontend container running
+- Backend Dockerfile: `python:3.13-slim` base image with uv installed in build stage, copy lockfile, install deps. Small image (~150MB)
+- Single Uvicorn worker (async) — FastAPI handles concurrency via async I/O, no Gunicorn needed at this scale
+- Frontend build happens inside Docker (multi-stage) for reproducible builds and CI/CD readiness
+
+**Compose & Networking**
+- Caddyfile configuration (not JSON or Docker labels) — simple, readable, ~15 lines
+- Caddy serves static frontend files at root, reverse-proxies `/api/*` to backend container
+- Caddy handles auto-TLS via Let's Encrypt — just set the domain name
+- CORS middleware removed in production (same-origin via Caddy) — keep only for `ENVIRONMENT=development`
+- Named Docker volumes for PostgreSQL data and Caddy TLS state (not bind mounts)
+- Alembic migrations run automatically via backend container entrypoint script (`alembic upgrade head` before Uvicorn starts). If migration fails, container fails to start.
+
+**Server Provisioning**
+- Cloud-init YAML script checked into repo at `deploy/cloud-init.yml` — already created by user
+- Cloud-init installs Docker, configures UFW (ports 22/80/443 only), enables fail2ban, creates deploy user, hardens SSH (key-only, no root)
+- Unattended-upgrades enabled for automatic security patches
+- Cloud-init to be simplified: remove bind-mount directory creation (pgdata, caddy_data, caddy_config) since we're using named Docker volumes. Keep /opt/flawchess for docker-compose.yml and .env
+- Fix .env template heredoc whitespace (leading spaces from YAML indentation)
+- Consider adding `reboot: true` at end of cloud-init for kernel updates
+
+**DNS & TLS**
+- A record at domain registrar pointing flawchess.com to Hetzner VPS IP (manual step, documented)
+- Caddy auto-TLS handles Let's Encrypt certificate provisioning and renewal automatically
+
+**Secrets Management**
+- `.env` file manually SCP'd to server during initial setup — secrets never touch git or CI
+- Required variables documented in `.env.example` in the repo
+- Production .env lives at `/opt/flawchess/.env` on the server
+
+### Claude's Discretion
+- Exact Caddyfile syntax and routing rules
+- Docker Compose service names and network configuration
+- Entrypoint script implementation details
+- Container health check configuration
+- Whether to add `reboot: true` to cloud-init or leave it out
+
+### Deferred Ideas (OUT OF SCOPE)
+- CI/CD pipeline (GitHub Actions: test → build → push → SSH deploy) — Phase 22
+- Sentry error monitoring — Phase 22
+- Cloudflare DNS/CDN proxy — not needed at launch, revisit if DDoS becomes a concern
+- Hetzner Cloud Firewall (layered on top of UFW) — can add later for defense-in-depth
+- Gunicorn multi-worker setup — revisit if CPU becomes bottleneck under load
+</user_constraints>
+
+---
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|-----------------|
+| DEPLOY-01 | Multi-stage Dockerfiles for backend (Python/uv) and frontend (Node build → Caddy) | uv official Docker guide; multi-stage with `ghcr.io/astral-sh/uv:0.10.9` binary copy; Node 24 → Caddy 2.11.2 pattern |
+| DEPLOY-02 | Docker Compose orchestrating FastAPI, PostgreSQL, and Caddy services with named volumes | Compose `depends_on: condition: service_healthy`; `pg_isready` healthcheck; named volumes `pgdata`, `caddy_data`, `caddy_config` |
+| DEPLOY-03 | Caddy reverse proxy serving frontend static files and proxying /api to backend with auto-TLS | Caddyfile `handle /api/*` + `handle` block with `root /srv`, `try_files`, `file_server`; ports 80+443 open via UFW |
+| DEPLOY-04 | Alembic migrations run automatically on container startup before accepting traffic | Entrypoint script `alembic upgrade head && exec uvicorn ...`; DB healthcheck ensures postgres is ready before backend starts |
+| DEPLOY-05 | Environment variable configuration via .env file with Pydantic BaseSettings (no hardcoded secrets) | `.env` already gitignored; Pydantic BaseSettings already reads from `.env`; `.env.example` needs production vars added; CORS needs `ENVIRONMENT` conditional |
+| DEPLOY-06 | Application deployed and accessible at flawchess.com | Hetzner CPX22 + cloud-init + DNS A record + Caddy auto-TLS |
+</phase_requirements>
+
+---
+
+## Summary
+
+Phase 21 containerizes a FastAPI + React/Vite + PostgreSQL application for production on a Hetzner VPS. The architecture is straightforward: three services in Docker Compose (backend, db, caddy), with Caddy acting as the single entry point — serving static frontend files and proxying `/api/*` requests to the FastAPI backend. No orchestration overhead, no separate frontend runtime container.
+
+The key architectural decision (already locked) is using multi-stage Docker builds: a Node build stage produces the `dist/` directory, which Caddy serves from `/srv`. The backend uses a two-stage build — a builder stage with `python:3.13-slim` + uv for dependency installation, and a slim runtime stage copying only the `.venv`. Alembic migrations run at container startup before Uvicorn accepts traffic, with the backend depending on a healthy PostgreSQL healthcheck.
+
+The main implementation work is: writing the Dockerfiles and `docker-compose.yml`, writing the Caddyfile (~15 lines), writing an entrypoint shell script, conditionalizing CORS in `app/main.py`, expanding `.env.example` with all production vars, and updating `deploy/cloud-init.yml` (minor cleanup). The server provisioning script already exists — it just needs the bind-mount directory creation removed and heredoc whitespace fixed.
+
+**Primary recommendation:** Build services in this order — db → backend → caddy — writing healthchecks and dependency ordering first so the entrypoint script never races postgres.
+
+---
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| `python:3.13-slim` | 3.13 | Backend base image | Matches project Python version; slim removes build tools |
+| `ghcr.io/astral-sh/uv` | 0.10.9 | Copy uv binary into builder stage | Official uv Docker pattern; avoids installing uv via pip |
+| `node` | 24-alpine | Frontend build stage base | LTS line; alpine minimizes image size for build-only stage |
+| `caddy` | 2.11.2 | Static file server + reverse proxy + auto-TLS | One binary replaces nginx + certbot; auto-TLS with Let's Encrypt |
+| `postgres` | 16-alpine | Database | Alpine variant for smaller image; stable major version |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `uvicorn` | 0.41.0 (locked) | ASGI server (already in pyproject.toml) | Single worker, async FastAPI — no Gunicorn wrapper needed |
+| Docker Compose plugin | v2 (bundled with Docker CE) | Orchestration | Ships with Docker CE on Ubuntu 24.04 via cloud-init |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Caddy auto-TLS | nginx + certbot | Certbot requires cron setup, renewal scripts; Caddy handles all of it automatically |
+| Named volumes | Bind mounts | Named volumes are Docker-managed, survive `docker compose down -v` accidents less likely; no permission issues on host |
+| Single Uvicorn worker | Gunicorn + Uvicorn | Gunicorn adds complexity; async I/O handles concurrency without multiple workers at this scale |
+
+**Installation (cloud-init already handles server-side Docker install):**
+```bash
+# Verified versions from Docker Hub and local uv version
+# Backend: python:3.13-slim (latest 3.13)
+# uv binary: ghcr.io/astral-sh/uv:0.10.9
+# Frontend build: node:24-alpine
+# Caddy: caddy:2.11.2
+# DB: postgres:16-alpine
+```
+
+---
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```
+/                          # project root
+├── Dockerfile             # backend multi-stage (builder + runtime)
+├── frontend/
+│   └── Dockerfile         # frontend multi-stage (node build → caddy serve)
+├── deploy/
+│   ├── cloud-init.yml     # Hetzner VPS provisioning (exists, needs minor fixes)
+│   ├── Caddyfile          # ~15-line Caddy config
+│   └── entrypoint.sh      # migration + uvicorn start script
+├── docker-compose.yml     # 3 services: backend, db, caddy
+├── .env.example           # all production vars documented, no values
+└── .env                   # gitignored, SCP'd to server
+```
+
+### Pattern 1: Backend Multi-Stage Dockerfile (uv)
+
+**What:** Two stages — `builder` installs deps into `.venv` using uv, `runtime` copies only the `.venv` and app code.
+
+**When to use:** Always — this is the canonical uv Docker pattern.
+
+```dockerfile
+# Source: https://docs.astral.sh/uv/guides/integration/docker/
+FROM python:3.13-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies (cacheable — changes rarely)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-dev --no-install-project
+
+# Copy source and install project
+COPY . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+FROM python:3.13-slim AS runtime
+WORKDIR /app
+COPY --from=builder /app /app
+ENV PATH="/app/.venv/bin:$PATH"
+COPY deploy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+### Pattern 2: Frontend Multi-Stage Dockerfile (Node → Caddy)
+
+**What:** Node stage builds `dist/`, Caddy stage serves it. No Node runtime in final image.
+
+**When to use:** Vite/React SPA with Caddy serving static files.
+
+```dockerfile
+# Source: Caddy community + Docker multi-stage pattern
+FROM node:24-alpine AS builder
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM caddy:2.11.2 AS runtime
+COPY --from=builder /app/dist /srv
+COPY deploy/Caddyfile /etc/caddy/Caddyfile
+```
+
+### Pattern 3: Caddyfile — SPA + API Proxy
+
+**What:** Route `/api/*` to backend container, serve SPA at root with `try_files` fallback.
+
+**When to use:** Single domain, Caddy handles TLS automatically when real domain is set.
+
+```caddy
+# Source: https://caddyserver.com/docs/caddyfile/patterns
+flawchess.com {
+    encode gzip
+
+    handle /api/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /health {
+        reverse_proxy backend:8000
+    }
+
+    handle {
+        root * /srv
+        try_files {path} /index.html
+        file_server
+    }
+}
+```
+
+**Note:** `{path}` is the Caddy placeholder syntax (not a shell variable). The `handle` blocks are evaluated in order — first match wins. `health` endpoint must also proxy to backend (it's part of the API, not a frontend route).
+
+### Pattern 4: Entrypoint Script (Migrations + Start)
+
+**What:** Shell script runs `alembic upgrade head`, exits with error code if migrations fail (container won't start), then `exec` hands off to uvicorn (PID 1 replacement).
+
+```bash
+#!/bin/sh
+# Source: common Docker entrypoint pattern for DB migration on startup
+set -e
+
+echo "Running Alembic migrations..."
+alembic upgrade head
+
+echo "Starting Uvicorn..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+**Critical:** `exec` replaces the shell with uvicorn — signals (SIGTERM) go directly to uvicorn, not the shell. Without `exec`, `docker stop` would kill the shell and orphan uvicorn.
+
+### Pattern 5: Docker Compose Service Order
+
+**What:** Backend must wait for PostgreSQL to be ready (not just started — actually accepting connections).
+
+```yaml
+# Source: https://docs.docker.com/compose/how-tos/startup-order/
+services:
+  db:
+    image: postgres:16-alpine
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend:
+    depends_on:
+      db:
+        condition: service_healthy
+```
+
+**Critical:** `depends_on: condition: service_healthy` only works when the dependency defines a `healthcheck`. Without it, the backend starts immediately and Alembic migrations fail with "could not connect to server."
+
+### Pattern 6: CORS Conditional on ENVIRONMENT
+
+**What:** In production, Caddy routes frontend and backend under the same origin — no cross-origin requests. CORS middleware only needed in development (Vite dev server on port 5173).
+
+```python
+# app/main.py — change from hardcoded to conditional
+from app.core.config import settings
+
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+```
+
+### Anti-Patterns to Avoid
+
+- **`depends_on` without healthcheck condition:** Docker Compose by default only waits for the container to start, not for the service to be ready. Always use `condition: service_healthy` for database dependencies.
+- **`CMD` instead of `exec` in entrypoint:** Without `exec`, signals are not forwarded to the application process. Use `exec uvicorn ...` not `uvicorn ...`.
+- **Bind-mounting `.env` into containers:** Pass env vars via `env_file: .env` in Compose, not volume mounts. The `env_file` directive reads vars into the container environment cleanly.
+- **`caddy:latest` in production:** Pin to `caddy:2.11.2` for reproducible deployments.
+- **Serving `index.html` without Cache-Control:** Browsers may cache the entrypoint and miss Vite content-hashed asset updates. Add `header /index.html Cache-Control "no-cache"` to the Caddyfile.
+- **Not persisting Caddy's `/data` volume:** Without a named volume for `/data`, Caddy re-requests certificates on every restart and may hit Let's Encrypt rate limits (50 certs/domain/week).
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| TLS certificate provisioning + renewal | Custom certbot cron job | Caddy auto-TLS | Caddy handles ACME challenge, renewal, and rate-limit throttling automatically |
+| "Wait for DB" logic in entrypoint | Shell `nc -z` polling loops | Compose `depends_on: condition: service_healthy` + `pg_isready` | pg_isready is reliable; healthcheck handles start_period grace period |
+| Static file serving with SPA routing | Custom nginx config | Caddy `try_files {path} /index.html` | One directive handles the common SPA 404 → index.html pattern |
+| Multi-arch build complexity | Manual QEMU setup | Docker Buildx (if needed in Phase 22) | Not needed for Phase 21 — build on the server's native arch |
+
+**Key insight:** Caddy's auto-TLS is the single biggest value-add here. What historically required certbot install, cron jobs, renewal scripts, and nginx config is reduced to one line: `flawchess.com {`.
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: Let's Encrypt Rate Limits During Testing
+**What goes wrong:** If you provision the server, configure Caddy, then tear it down and reprovision multiple times, you may hit Let's Encrypt's limit of 5 failed validations per domain per hour.
+**Why it happens:** Each Caddy startup with a real domain triggers a certificate request if no cached cert exists.
+**How to avoid:** Use Caddy's ACME staging server during testing: add `tls { ca https://acme-staging-v02.api.letsencrypt.org/directory }` block while iterating. Remove it for final deployment.
+**Warning signs:** Caddy logs show "too many certificates already issued" errors.
+
+### Pitfall 2: Alembic Can't Connect to DB — Wrong URL Format
+**What goes wrong:** `alembic upgrade head` fails with asyncpg driver error when run synchronously.
+**Why it happens:** `alembic.env.py` uses `async_engine_from_config` with `asyncpg` — this already works correctly in this project. The risk is the `DATABASE_URL` uses `@db:5432` (Docker Compose service name), not `@localhost:5432`.
+**How to avoid:** Ensure the production `.env` uses `DATABASE_URL=postgresql+asyncpg://flawchess:PASSWORD@db:5432/flawchess` — the cloud-init template already has this correct.
+**Warning signs:** "connection refused" during migration step in container logs.
+
+### Pitfall 3: Frontend Build Stage Missing `VITE_*` Environment Variables
+**What goes wrong:** Frontend builds with placeholder or undefined API URLs baked in.
+**Why it happens:** Vite inlines `VITE_*` variables at build time. But this project uses Caddy same-origin routing — no `VITE_API_URL` variable is needed. Vite proxies `/api/*` in dev; Caddy routes in production. No env vars needed for the frontend build.
+**How to avoid:** Confirm there are no `import.meta.env.VITE_*` references that would need production values. Current codebase uses relative API paths (`/api/...`), so this is not an issue.
+**Warning signs:** API calls in production go to `undefined/api/...`.
+
+### Pitfall 4: Caddy Can't Reach Backend — Wrong Docker Network
+**What goes wrong:** Caddy's `reverse_proxy backend:8000` returns 502 Bad Gateway.
+**Why it happens:** Services must be on the same Docker network to resolve each other by name.
+**How to avoid:** Define a shared custom network in `docker-compose.yml` and attach all services to it. Or rely on Compose's default network (all services in the same Compose file share a default network automatically — this is safe to rely on).
+**Warning signs:** Caddy logs show "dial tcp: lookup backend: no such host".
+
+### Pitfall 5: cloud-init Heredoc Whitespace
+**What goes wrong:** The `.env` file written by cloud-init has leading spaces on every line.
+**Why it happens:** YAML block scalars preserve indentation. The existing cloud-init.yml uses `content: |` with indented content, so those spaces become part of the file content.
+**How to avoid:** Check the existing cloud-init.yml's `write_files` section — the content already uses `content: |` with correct left-alignment (lines start at column 0 within the block scalar). If spaces appear, fix by dedenting the heredoc content in the YAML.
+**Warning signs:** PostgreSQL fails to start because password has leading spaces; Pydantic validation errors for malformed `DATABASE_URL`.
+
+### Pitfall 6: Port 8000 Exposed to Public
+**What goes wrong:** FastAPI backend accessible directly at `http://server-ip:8000`, bypassing Caddy's TLS and routing.
+**Why it happens:** `ports: "8000:8000"` in docker-compose.yml exposes the port to the host and thus the internet.
+**How to avoid:** Do NOT add `ports` to the backend service. Use `expose: ["8000"]` (container-internal only) or nothing — Caddy reaches the backend via Docker's internal network. UFW blocks external access to 8000 anyway, but defence-in-depth means not binding it.
+
+---
+
+## Code Examples
+
+Verified patterns from official sources:
+
+### Docker Compose Named Volumes + healthcheck
+```yaml
+# Source: https://docs.docker.com/compose/how-tos/startup-order/
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  backend:
+    build: .
+    env_file: .env
+    expose:
+      - "8000"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  caddy:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"   # HTTP/3
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - backend
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:
+```
+
+### Complete Caddyfile (SPA + API)
+```caddy
+# Source: https://caddyserver.com/docs/caddyfile/patterns
+flawchess.com {
+    encode gzip
+
+    handle /api/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /health {
+        reverse_proxy backend:8000
+    }
+
+    handle {
+        root * /srv
+        header /index.html Cache-Control "no-cache"
+        try_files {path} /index.html
+        file_server
+    }
+}
+```
+
+### CORS Conditional (app/main.py)
+```python
+# Only enable CORS in development — Caddy provides same-origin in production
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+```
+
+---
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| nginx + certbot + cron | Caddy auto-TLS | Caddy v2 (2020+) | TLS setup is zero-config once domain is set |
+| `wait-for-it.sh` scripts | `depends_on: condition: service_healthy` + pg_isready | Docker Compose v2 (2021+) | No extra scripts; built into Compose |
+| `pip install` in Dockerfile | uv sync --locked with cache mount | uv 0.1+ (2024) | 10-100x faster installs; lockfile-pinned |
+| `docker-compose` (v1, Python) | `docker compose` (v2, Go plugin) | Docker CLI plugin 2022 | `docker-compose` deprecated; use `docker compose` |
+
+**Deprecated/outdated:**
+- `docker-compose` command: replaced by `docker compose` (v2 plugin). Cloud-init installs `docker-compose-plugin` — correct.
+- `CMD ["python", "-m", "uvicorn"]` without exec: replaced by `ENTRYPOINT ["sh", "-c", "exec uvicorn ..."]` or an entrypoint script with `exec`.
+
+---
+
+## Open Questions
+
+1. **Caddy Dockerfile placement**
+   - What we know: frontend Dockerfile does the Node build + Caddy serve in one multi-stage build. The Caddyfile needs to be in the Docker build context.
+   - What's unclear: whether to put the Caddyfile in `deploy/Caddyfile` (and COPY from there) or `frontend/Caddyfile`.
+   - Recommendation: `deploy/Caddyfile` — deployment config belongs in `deploy/`, not `frontend/`. The build context for `frontend/Dockerfile` needs to be set to the project root (not `frontend/`) so it can `COPY deploy/Caddyfile`.
+
+2. **`reboot: true` in cloud-init**
+   - What we know: cloud-init runs `package_upgrade: true`, which may install a new kernel. The new kernel only takes effect after reboot.
+   - What's unclear: whether this is needed for security (kernel-level patches) or an unnecessary delay.
+   - Recommendation: Add `reboot: true` — a one-time reboot during provisioning ensures the latest kernel is active before the server goes live. Delay is ~30 seconds; acceptable at setup time.
+
+3. **PostgreSQL version pin**
+   - What we know: using `postgres:16-alpine` is proposed. The project has no existing deployed DB to migrate from.
+   - What's unclear: whether to pin to `16` or `16.x` for more reproducibility.
+   - Recommendation: `postgres:16-alpine` is fine for Phase 21. Phase 22 can pin to a patch version once CI/CD is in place.
+
+---
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | pytest 8.x + pytest-asyncio 0.23.x |
+| Config file | `pyproject.toml` (`[tool.pytest.ini_options]`) |
+| Quick run command | `uv run pytest tests/test_auth.py -x` |
+| Full suite command | `uv run pytest` |
+
+### Phase Requirements → Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| DEPLOY-01 | Docker images build without error | smoke | `docker build -f Dockerfile .` | ❌ Wave 0 (Dockerfiles) |
+| DEPLOY-02 | docker compose up starts all services | smoke | `docker compose up -d && docker compose ps` | ❌ Wave 0 (docker-compose.yml) |
+| DEPLOY-03 | Caddy serves static files and proxies /api | manual-only | Browser + `curl https://flawchess.com/api/health` | N/A |
+| DEPLOY-04 | Migrations run on startup | manual-only | Verify in `docker compose logs backend` | N/A |
+| DEPLOY-05 | No secrets in images/repo | manual-only | `docker inspect` + `git log --all` scan | N/A |
+| DEPLOY-06 | App accessible at flawchess.com over HTTPS | manual-only | `curl https://flawchess.com/api/health` | N/A |
+
+**Note:** DEPLOY-03 through DEPLOY-06 require a live server with a real domain and valid TLS — they cannot be automated in unit/integration tests. The existing test suite covers application logic; deployment verification is inherently manual for Phase 21.
+
+### Sampling Rate
+- **Per task commit:** `uv run pytest tests/test_auth.py -x` (existing auth tests verify app still starts correctly after CORS change)
+- **Per wave merge:** `uv run pytest`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+- [ ] `Dockerfile` — backend multi-stage build (required for DEPLOY-01)
+- [ ] `frontend/Dockerfile` — frontend build + Caddy stage (required for DEPLOY-01)
+- [ ] `docker-compose.yml` — 3-service orchestration (required for DEPLOY-02)
+- [ ] `deploy/Caddyfile` — routing config (required for DEPLOY-03)
+- [ ] `deploy/entrypoint.sh` — migration + uvicorn start (required for DEPLOY-04)
+
+*(No new test files needed — existing pytest suite covers application logic. Docker builds are smoke-tested manually.)*
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- `https://docs.astral.sh/uv/guides/integration/docker/` — uv Docker multi-stage pattern, `--locked`, `--no-dev`, cache mounts
+- `https://caddyserver.com/docs/caddyfile/patterns` — SPA with API proxy Caddyfile pattern, `try_files`, `handle` blocks
+- `https://caddyserver.com/docs/automatic-https` — Auto-TLS requirements: port 80+443 open, persistent `/data` volume, DNS A record
+- `https://docs.docker.com/compose/how-tos/startup-order/` — `depends_on: condition: service_healthy`, pg_isready healthcheck
+- Local codebase inspection — `app/core/config.py`, `app/main.py`, `alembic/env.py`, `deploy/cloud-init.yml`, `pyproject.toml`
+
+### Secondary (MEDIUM confidence)
+- `https://hub.docker.com/_/caddy` (via Docker Hub API) — Caddy 2.11.2 is current stable version
+- `https://github.com/astral-sh/uv-docker-example` — Canonical uv Docker single-stage example; multi-stage pattern extrapolated from official docs
+- WebSearch results for Caddy + Vite + Django (analogous pattern to FastAPI) — verified against official Caddy docs
+
+### Tertiary (LOW confidence)
+- Community examples for Caddy + Docker Compose static files — patterns verified against official Caddy documentation
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — versions verified against Docker Hub API and local installed versions
+- Architecture: HIGH — patterns verified against official uv and Caddy documentation
+- Pitfalls: HIGH — sourced from official Docker Compose docs + Caddy rate limit docs + direct code inspection
+
+**Research date:** 2026-03-21
+**Valid until:** 2026-06-21 (stable infra tools; Caddy/uv versions may update but patterns are stable)

--- a/.planning/phases/21-docker-deployment/21-VALIDATION.md
+++ b/.planning/phases/21-docker-deployment/21-VALIDATION.md
@@ -1,0 +1,83 @@
+---
+phase: 21
+slug: docker-deployment
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-21
+---
+
+# Phase 21 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest 8.x + pytest-asyncio 0.23.x |
+| **Config file** | `pyproject.toml` (`[tool.pytest.ini_options]`) |
+| **Quick run command** | `uv run pytest tests/test_auth.py -x` |
+| **Full suite command** | `uv run pytest` |
+| **Estimated runtime** | ~15 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `uv run pytest tests/test_auth.py -x`
+- **After every plan wave:** Run `uv run pytest`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 15 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 21-01-01 | 01 | 1 | DEPLOY-01 | smoke | `docker build -f Dockerfile .` | ❌ W0 | ⬜ pending |
+| 21-01-02 | 01 | 1 | DEPLOY-01 | smoke | `docker build -f frontend/Dockerfile .` | ❌ W0 | ⬜ pending |
+| 21-02-01 | 02 | 1 | DEPLOY-02 | smoke | `docker compose up -d && docker compose ps` | ❌ W0 | ⬜ pending |
+| 21-03-01 | 03 | 2 | DEPLOY-03 | manual-only | `curl https://flawchess.com/api/health` | N/A | ⬜ pending |
+| 21-03-02 | 03 | 2 | DEPLOY-04 | manual-only | `docker compose logs backend` | N/A | ⬜ pending |
+| 21-03-03 | 03 | 2 | DEPLOY-05 | manual-only | `docker inspect` + repo scan | N/A | ⬜ pending |
+| 21-03-04 | 03 | 2 | DEPLOY-06 | manual-only | `curl https://flawchess.com/api/health` | N/A | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `Dockerfile` — backend multi-stage build (required for DEPLOY-01)
+- [ ] `frontend/Dockerfile` — frontend build + Caddy stage (required for DEPLOY-01)
+- [ ] `docker-compose.yml` — 3-service orchestration (required for DEPLOY-02)
+- [ ] `deploy/Caddyfile` — routing config (required for DEPLOY-03)
+- [ ] `deploy/entrypoint.sh` — migration + uvicorn start (required for DEPLOY-04)
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Caddy serves static files and proxies /api | DEPLOY-03 | Requires live domain with TLS | 1. `curl https://flawchess.com` → HTML response 2. `curl https://flawchess.com/api/health` → JSON response |
+| Migrations run on startup | DEPLOY-04 | Requires running Docker Compose stack | 1. `docker compose up -d` 2. `docker compose logs backend` → shows "Running Alembic migrations..." |
+| No secrets in images/repo | DEPLOY-05 | Requires image inspection | 1. `docker inspect backend` → no env vars with secrets 2. `git log --all -S PASSWORD` → no matches |
+| App accessible over HTTPS | DEPLOY-06 | Requires live server with DNS | 1. `curl -I https://flawchess.com` → 200 with valid TLS 2. Certificate issuer is Let's Encrypt |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 15s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.13-slim AS builder
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /bin/
+
+WORKDIR /app
+
+# Install dependencies first (cacheable layer — copied before source code)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-dev --no-install-project
+
+# Copy source and install project
+COPY . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-dev
+
+FROM python:3.13-slim AS runtime
+WORKDIR /app
+COPY --from=builder /app /app
+ENV PATH="/app/.venv/bin:$PATH"
+COPY deploy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.core.config import settings
 from app.routers import analysis, position_bookmarks, imports, auth
 from app.routers.stats import router as stats_router
 from app.routers.users import router as users_router
@@ -18,14 +19,15 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
 app = FastAPI(title="FlawChess", version="0.1.0", lifespan=lifespan)
 
-# CORS — allow the Vite dev server
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+# CORS only needed in development — Caddy provides same-origin routing in production
+if settings.ENVIRONMENT == "development":
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["http://localhost:5173"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 app.include_router(auth.router)
 app.include_router(imports.router)

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,45 @@
+flawchess.com {
+    encode gzip
+
+    # Backend API routes — proxy each prefix individually
+    # (no /api/* prefix in this codebase — routes are /auth/*, /analysis/*, etc.)
+    handle /auth/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /analysis/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /games/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /imports/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /position-bookmarks/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /stats/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /users/* {
+        reverse_proxy backend:8000
+    }
+
+    handle /health {
+        reverse_proxy backend:8000
+    }
+
+    # Frontend SPA — serve static files with index.html fallback
+    handle {
+        root * /srv
+        header /index.html Cache-Control "no-cache"
+        try_files {path} /index.html
+        file_server
+    }
+}

--- a/deploy/cloud-init.yml
+++ b/deploy/cloud-init.yml
@@ -1,0 +1,90 @@
+#cloud-config
+# FlawChess — Hetzner VPS cloud-init
+# Phase 21: Docker & Deployment
+#
+# Usage: paste into Hetzner Cloud Console → "Cloud config" when creating a server
+# Recommended: Ubuntu 24.04, CPX22 (2 vCPU, 4 GB RAM) or larger
+#
+# What this does:
+#   1. Creates a 'deploy' user with SSH access (no root login)
+#   2. Installs Docker + Docker Compose plugin
+#   3. Configures UFW firewall (SSH + HTTP + HTTPS only)
+#   4. Creates /opt/flawchess directory structure and .env template
+#   5. Hardens SSH (key-only, no root)
+
+users:
+  - name: deploy
+    groups: [sudo, docker]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBggVmh/kPvOKAi9emlrj7itc8goOT+hw2vCezsupy4w
+
+package_update: true
+package_upgrade: true
+
+write_files:
+  - path: /opt/flawchess/.env
+    owner: root:root
+    permissions: '0600'
+    content: |
+      # FlawChess production environment
+      # Fill in all values before running docker compose up
+      ENVIRONMENT=production
+      # PostgreSQL
+      POSTGRES_USER=flawchess
+      POSTGRES_PASSWORD=CHANGE_ME_STRONG_PASSWORD
+      POSTGRES_DB=flawchess
+      DATABASE_URL=postgresql+asyncpg://flawchess:CHANGE_ME_STRONG_PASSWORD@db:5432/flawchess
+      # App secrets
+      SECRET_KEY=CHANGE_ME_GENERATE_WITH_openssl_rand_hex_32
+      # URLs (update domain if different)
+      BACKEND_URL=https://flawchess.com
+      FRONTEND_URL=https://flawchess.com
+      # Google OAuth (from Google Cloud Console)
+      GOOGLE_OAUTH_CLIENT_ID=
+      GOOGLE_OAUTH_CLIENT_SECRET=
+
+packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - gnupg
+  - ufw
+  - fail2ban
+  - unattended-upgrades
+
+runcmd:
+  # --- Docker ---
+  - install -m 0755 -d /etc/apt/keyrings
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
+  - apt-get update
+  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+  # --- Firewall ---
+  - ufw default deny incoming
+  - ufw default allow outgoing
+  - ufw allow 22/tcp    # SSH
+  - ufw allow 80/tcp    # HTTP (Caddy redirect)
+  - ufw allow 443/tcp   # HTTPS
+  - ufw --force enable
+
+  # --- App directory + fix .env ownership (write_files runs before user creation) ---
+  - mkdir -p /opt/flawchess
+  - chown -R deploy:deploy /opt/flawchess
+
+  # --- Harden SSH ---
+  - sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+  # --- Enable auto-updates for security patches ---
+  - systemctl enable unattended-upgrades
+  - systemctl start unattended-upgrades
+
+  # --- Done ---
+  - 'echo "FlawChess server ready. SSH in as: ssh deploy@<server-ip>"'
+
+reboot: true

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running Alembic migrations..."
+alembic upgrade head
+
+echo "Starting Uvicorn..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  backend:
+    build: .
+    env_file: .env
+    expose:
+      - "8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  caddy:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  caddy_data:
+  caddy_config:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:24-alpine AS builder
+WORKDIR /app
+# Build context is project root — copy package files from frontend/ subdirectory
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM caddy:2.11.2 AS runtime
+COPY --from=builder /app/dist /srv
+COPY deploy/Caddyfile /etc/caddy/Caddyfile

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -250,53 +250,6 @@ name = "chess"
 version = "1.11.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/09/7d04d7581ae3bb8b598017941781bceb7959dd1b13e3ebf7b6a2cd843bc9/chess-1.11.2.tar.gz", hash = "sha256:a8b43e5678fdb3000695bdaa573117ad683761e5ca38e591c4826eba6d25bb39", size = 6131385, upload-time = "2025-02-25T19:10:27.328Z" }
-
-[[package]]
-name = "chessalytics"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "alembic" },
-    { name = "asyncpg" },
-    { name = "chess" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
-    { name = "httpx" },
-    { name = "httpx-oauth" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "alembic", specifier = ">=1.13.0" },
-    { name = "asyncpg", specifier = ">=0.29.0" },
-    { name = "chess", specifier = ">=1.10.0" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
-    { name = "fastapi-users", extras = ["oauth", "sqlalchemy"], specifier = ">=15.0.4" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "httpx-oauth", specifier = ">=0.16.1" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.0" },
-    { name = "ruff", specifier = ">=0.4.0" },
-]
 
 [[package]]
 name = "click"
@@ -550,6 +503,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e2/dfa19a4b260b8ab3581b7484dcb80c09b25324f4daa6b6ae1c7640d1607a/fastar-0.8.0-cp314-cp314t-win32.whl", hash = "sha256:187f61dc739afe45ac8e47ed7fd1adc45d52eac110cf27d579155720507d6fbe", size = 455767, upload-time = "2025-11-26T02:36:34.758Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/df65c72afc1297797b255f90c4778b5d6f1f0f80282a134d5ab610310ed9/fastar-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40e9d763cf8bf85ce2fa256e010aa795c0fe3d3bd1326d5c3084e6ce7857127e", size = 489971, upload-time = "2025-11-26T02:36:22.081Z" },
     { url = "https://files.pythonhosted.org/packages/85/11/0aa8455af26f0ae89e42be67f3a874255ee5d7f0f026fc86e8d56f76b428/fastar-0.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:e59673307b6a08210987059a2bdea2614fe26e3335d0e5d1a3d95f49a05b1418", size = 460467, upload-time = "2025-11-26T02:36:07.978Z" },
+]
+
+[[package]]
+name = "flawchess"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "alembic" },
+    { name = "asyncpg" },
+    { name = "chess" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
+    { name = "httpx" },
+    { name = "httpx-oauth" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "alembic", specifier = ">=1.13.0" },
+    { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "chess", specifier = ">=1.10.0" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "fastapi-users", extras = ["oauth", "sqlalchemy"], specifier = ">=15.0.4" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx-oauth", specifier = ">=0.16.1" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Phase 21: docker-deployment**
**Goal:** Containerize app, deploy to Hetzner with Caddy auto-TLS, configure env
**Status:** Execution complete (verification pending — deployment checkpoint in progress)

Complete Docker Compose production stack for FlawChess: multi-stage backend Dockerfile with uv for fast cached builds, frontend Dockerfile with Node 24 build + Caddy 2.11.2 serve, docker-compose orchestration with PostgreSQL healthcheck gating, and Caddy reverse proxy handling all API routes + SPA fallback with automatic HTTPS.

## Changes

### Plan 21-01: Docker Infrastructure
Complete Docker Compose stack with uv multi-stage backend, Caddy 2.11.2 frontend/proxy, Postgres healthcheck ordering, and conditional CORS for development vs production.

**Key files created:**
- `Dockerfile` — Backend multi-stage build (uv deps layer + source layer, python:3.13-slim runtime)
- `frontend/Dockerfile` — Node 24 Alpine build → Caddy 2.11.2 serve
- `docker-compose.yml` — 3-service stack (db, backend, caddy) with healthcheck ordering
- `deploy/Caddyfile` — Reverse proxy: 8 API prefixes to backend:8000, SPA catch-all
- `deploy/entrypoint.sh` — Alembic migrations before Uvicorn startup
- `.dockerignore`, `frontend/.dockerignore`

**Key files modified:**
- `.env.example` — Documents all production environment variables
- `app/main.py` — CORS middleware now conditional (development only)

### Plan 21-02: Cloud-Init & VPS Deployment
Cleaned up `deploy/cloud-init.yml` — added `reboot: true` for kernel update activation after provisioning.

## Requirements Addressed

- DEPLOY-01, DEPLOY-02, DEPLOY-03, DEPLOY-04, DEPLOY-05, DEPLOY-06

## Key Decisions

- Backend uses `expose:` not `ports:` — internal only, Caddy is sole internet-facing entry
- API routes proxied individually (no `/api/` prefix) — matches existing vite.config.ts proxy config
- HTTP/3 enabled via `443:443/udp` — Caddy handles QUIC natively
- CORS disabled in production — same-origin via Caddy makes it unnecessary
- `.prod.env` added to `.gitignore` to prevent secret leakage

## Test Plan

- [ ] `docker compose build` succeeds
- [ ] `docker compose up -d` starts all 3 services healthy
- [ ] `https://flawchess.com` loads with valid TLS
- [ ] `/health` endpoint returns `{"status": "ok"}`
- [ ] Auth (register/login) works
- [ ] Data persists across `docker compose down && docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)