### PR TITLE
feat: add Umami self-hosted analytics infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,10 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 # Sentry error monitoring (from sentry.io project settings -> Client Keys)
 SENTRY_DSN=
 VITE_SENTRY_DSN=
+
+# Umami analytics (self-hosted at analytics.flawchess.com)
+UMAMI_DB_USER=umami
+# Generate with: openssl rand -hex 16
+UMAMI_DB_PASSWORD=
+# Generate with: openssl rand -hex 32
+UMAMI_APP_SECRET=

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -12,8 +12,8 @@ Requirements for v1.4 Improvements milestone.
 - [ ] **ANLY-01**: Site owner can view page visit counts and trends over time
 - [ ] **ANLY-02**: Site owner can see top pages/routes by visit count
 - [ ] **ANLY-03**: Site owner can see visitor referrer sources
-- [ ] **ANLY-04**: Analytics collection respects user privacy (no cookie consent banner required)
-- [ ] **ANLY-05**: Analytics solution has minimal server resource footprint (RAM/CPU)
+- [x] **ANLY-04**: Analytics collection respects user privacy (no cookie consent banner required)
+- [x] **ANLY-05**: Analytics solution has minimal server resource footprint (RAM/CPU)
 
 ## Future Requirements
 
@@ -33,8 +33,8 @@ Requirements for v1.4 Improvements milestone.
 | ANLY-01 | Phase 24 | Pending |
 | ANLY-02 | Phase 24 | Pending |
 | ANLY-03 | Phase 24 | Pending |
-| ANLY-04 | Phase 24 | Pending |
-| ANLY-05 | Phase 24 | Pending |
+| ANLY-04 | Phase 24 | Complete |
+| ANLY-05 | Phase 24 | Complete |
 
 **Coverage:**
 - v1.4 requirements: 5 total

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -63,7 +63,7 @@
   - **Goal:** Add privacy-friendly, low-resource web analytics to track page visits, top routes, and referrer sources
   - **Requirements:** ANLY-01, ANLY-02, ANLY-03, ANLY-04, ANLY-05
   - **Plans:** 2 plans
-    - [ ] 24-01-PLAN.md — Add Umami service to Docker Compose, Caddy subdomain, and env vars
+    - [x] 24-01-PLAN.md — Add Umami service to Docker Compose, Caddy subdomain, and env vars
     - [ ] 24-02-PLAN.md — Deploy Umami, add tracking script to frontend, verify end-to-end
   - **Success criteria:**
     1. Site owner can view a dashboard showing page visit counts and trends
@@ -99,4 +99,4 @@
 | 21. Docker & Deployment | v1.3 | 2/2 | Complete | 2026-03-21 |
 | 22. CI/CD & Monitoring | v1.3 | 2/2 | Complete | 2026-03-21 |
 | 23. Launch Readiness | v1.3 | 4/4 | Complete | 2026-03-22 |
-| 24. Web Analytics | v1.4 | 0/2 | Not started | — |
+| 24. Web Analytics | v1.4 | 1/2 | In Progress|  |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -59,9 +59,12 @@
 
 ### v1.4 Improvements
 
-- [ ] Phase 24: Web Analytics (0/0 plans) — not started
+- [ ] Phase 24: Web Analytics (0/2 plans) — not started
   - **Goal:** Add privacy-friendly, low-resource web analytics to track page visits, top routes, and referrer sources
   - **Requirements:** ANLY-01, ANLY-02, ANLY-03, ANLY-04, ANLY-05
+  - **Plans:** 2 plans
+    - [ ] 24-01-PLAN.md — Add Umami service to Docker Compose, Caddy subdomain, and env vars
+    - [ ] 24-02-PLAN.md — Deploy Umami, add tracking script to frontend, verify end-to-end
   - **Success criteria:**
     1. Site owner can view a dashboard showing page visit counts and trends
     2. Top pages by visit count are visible
@@ -96,4 +99,4 @@
 | 21. Docker & Deployment | v1.3 | 2/2 | Complete | 2026-03-21 |
 | 22. CI/CD & Monitoring | v1.3 | 2/2 | Complete | 2026-03-21 |
 | 23. Launch Readiness | v1.3 | 4/4 | Complete | 2026-03-22 |
-| 24. Web Analytics | v1.4 | 0/0 | Not started | — |
+| 24. Web Analytics | v1.4 | 0/2 | Not started | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,25 +2,22 @@
 gsd_state_version: 1.0
 milestone: v1.4
 milestone_name: Improvements
-status: in_progress
-stopped_at: null
-last_updated: "2026-03-22T00:00:00.000Z"
-last_activity: "2026-03-22 - Started v1.4 Improvements milestone"
+status: unknown
+last_updated: "2026-03-22T17:22:31.905Z"
+last_activity: 2026-03-22
 progress:
   total_phases: 1
   completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
+  total_plans: 2
+  completed_plans: 1
 ---
 
 # Project State: FlawChess
 
 ## Current Position
 
-Phase: 24 — Web Analytics
-Plan: —
-Status: Not started (phase needs planning)
-Last activity: 2026-03-22 — Milestone v1.4 started
+Phase: 24 (web-analytics) — EXECUTING
+Plan: 2 of 2
 
 ## Project Reference
 
@@ -47,6 +44,7 @@ Current focus: Web Analytics
 ### Decisions
 
 - [v1.4 roadmap]: Analytics tool choice deferred to phase planning — candidates: Plausible, Umami, GoAccess
+- [Phase 24-web-analytics]: Umami shares existing db PostgreSQL container (no separate DB); Node.js heap capped at 256 MB; no Caddy-level auth on analytics subdomain
 
 ### Roadmap Evolution
 

--- a/.planning/phases/24-web-analytics/24-01-PLAN.md
+++ b/.planning/phases/24-web-analytics/24-01-PLAN.md
@@ -1,0 +1,184 @@
+---
+phase: 24-web-analytics
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - docker-compose.yml
+  - deploy/Caddyfile
+  - .env.example
+autonomous: true
+requirements:
+  - ANLY-04
+  - ANLY-05
+
+must_haves:
+  truths:
+    - "Umami service is defined in docker-compose.yml sharing the existing db container"
+    - "Caddy proxies analytics.flawchess.com to umami:3000"
+    - "Umami Node.js heap is capped at 256 MB via NODE_OPTIONS"
+    - "No separate PostgreSQL container is created for Umami"
+  artifacts:
+    - path: "docker-compose.yml"
+      provides: "Umami service definition"
+      contains: "umami"
+    - path: "deploy/Caddyfile"
+      provides: "Analytics subdomain reverse proxy"
+      contains: "analytics.flawchess.com"
+    - path: ".env.example"
+      provides: "Umami environment variable documentation"
+      contains: "UMAMI_DB_USER"
+  key_links:
+    - from: "docker-compose.yml (umami service)"
+      to: "docker-compose.yml (db service)"
+      via: "DATABASE_URL referencing db:5432"
+      pattern: "DATABASE_URL.*db:5432/umami"
+    - from: "deploy/Caddyfile"
+      to: "docker-compose.yml (umami service)"
+      via: "reverse_proxy umami:3000"
+      pattern: "reverse_proxy umami:3000"
+---
+
+<objective>
+Add Umami analytics infrastructure to the Docker Compose stack and Caddy reverse proxy.
+
+Purpose: Enable self-hosted, privacy-friendly web analytics (per D-01) that shares the existing PostgreSQL container (per D-02) and is accessible at analytics.flawchess.com (per D-03).
+Output: Updated docker-compose.yml, Caddyfile, and .env.example ready for production deployment.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/24-web-analytics/24-CONTEXT.md
+@.planning/phases/24-web-analytics/24-RESEARCH.md
+
+@docker-compose.yml
+@deploy/Caddyfile
+@.env.example
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add Umami service to Docker Compose and update .env.example</name>
+  <files>docker-compose.yml, .env.example</files>
+  <read_first>docker-compose.yml, .env.example</read_first>
+  <action>
+Add the `umami` service to `docker-compose.yml` after the `backend` service and before the `caddy` service. The umami service definition:
+
+```yaml
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    environment:
+      DATABASE_URL: postgresql://${UMAMI_DB_USER}:${UMAMI_DB_PASSWORD}@db:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+      NODE_OPTIONS: "--max-old-space-size=256"
+    expose:
+      - "3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+```
+
+Key points per user decisions:
+- Per D-02: connects to the EXISTING `db` service (no separate PostgreSQL container). Uses `db:5432` as the host.
+- Per D-01: uses official Umami image from GitHub Container Registry (not Docker Hub).
+- Per ANLY-05: `NODE_OPTIONS: "--max-old-space-size=256"` caps Node.js heap to guard against memory spikes on the resource-constrained VPS.
+- No `ports:` mapping — Umami is only accessible via Caddy reverse proxy, not directly from the host. Use `expose:` to document the internal port.
+- `depends_on` with `condition: service_healthy` ensures PostgreSQL is ready before Umami starts.
+
+Also update the `caddy` service `depends_on` to include `umami` (so Caddy starts after Umami is available):
+```yaml
+    depends_on:
+      - backend
+      - umami
+```
+
+Add these variables to `.env.example` at the end, under a new `# Umami analytics` section:
+
+```
+# Umami analytics (self-hosted at analytics.flawchess.com)
+UMAMI_DB_USER=umami
+# Generate with: openssl rand -hex 16
+UMAMI_DB_PASSWORD=
+# Generate with: openssl rand -hex 32
+UMAMI_APP_SECRET=
+```
+  </action>
+  <verify>
+    <automated>grep -q "umami:" docker-compose.yml && grep -q "ghcr.io/umami-software/umami" docker-compose.yml && grep -q "UMAMI_DB_USER" .env.example && grep -q "max-old-space-size=256" docker-compose.yml && echo "PASS" || echo "FAIL"</automated>
+  </verify>
+  <acceptance_criteria>
+    - docker-compose.yml contains service named `umami` with image `ghcr.io/umami-software/umami:postgresql-latest`
+    - docker-compose.yml umami service has `DATABASE_URL: postgresql://${UMAMI_DB_USER}:${UMAMI_DB_PASSWORD}@db:5432/umami`
+    - docker-compose.yml umami service has `APP_SECRET: ${UMAMI_APP_SECRET}`
+    - docker-compose.yml umami service has `NODE_OPTIONS: "--max-old-space-size=256"`
+    - docker-compose.yml umami service has `expose: - "3000"` (NOT `ports:`)
+    - docker-compose.yml umami service has `depends_on: db: condition: service_healthy`
+    - docker-compose.yml caddy service depends_on includes `umami`
+    - .env.example contains `UMAMI_DB_USER=umami`
+    - .env.example contains `UMAMI_DB_PASSWORD=`
+    - .env.example contains `UMAMI_APP_SECRET=`
+    - No separate PostgreSQL container for Umami exists in docker-compose.yml (only the existing `db` service)
+  </acceptance_criteria>
+  <done>Umami service defined in docker-compose.yml using shared db, env vars documented in .env.example</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add analytics subdomain to Caddyfile</name>
+  <files>deploy/Caddyfile</files>
+  <read_first>deploy/Caddyfile</read_first>
+  <action>
+Add a new server block to `deploy/Caddyfile` for the analytics subdomain (per D-03). Place it BEFORE the `flawchess.com` block (after the `.org` redirect block):
+
+```
+analytics.flawchess.com {
+    reverse_proxy umami:3000
+}
+```
+
+This is all that's needed. Caddy automatically obtains a TLS certificate for `analytics.flawchess.com` via ACME/Let's Encrypt. No additional TLS, gzip, or header configuration is required for Umami — it serves its own dashboard UI and tracking script.
+
+Do NOT add any authentication at the Caddy level — per D-04 and D-05, Umami handles its own login (built-in user/password system, default admin account on first run).
+  </action>
+  <verify>
+    <automated>grep -q "analytics.flawchess.com" deploy/Caddyfile && grep -q "reverse_proxy umami:3000" deploy/Caddyfile && echo "PASS" || echo "FAIL"</automated>
+  </verify>
+  <acceptance_criteria>
+    - deploy/Caddyfile contains `analytics.flawchess.com {` server block
+    - deploy/Caddyfile contains `reverse_proxy umami:3000` inside that block
+    - The analytics block does NOT contain any `basicauth` or authentication directives
+    - The analytics block appears as a separate server block (not nested inside flawchess.com)
+  </acceptance_criteria>
+  <done>Caddy configured to reverse proxy analytics.flawchess.com to umami:3000 with auto-TLS</done>
+</task>
+
+</tasks>
+
+<verification>
+1. `grep "umami:" docker-compose.yml` shows the umami service
+2. `grep "analytics.flawchess.com" deploy/Caddyfile` shows the subdomain block
+3. `grep "UMAMI_" .env.example` shows all three Umami env vars
+4. docker-compose.yml has NO second postgres service (only `db:`)
+5. `npm run build` in frontend/ still succeeds (no frontend changes in this plan)
+</verification>
+
+<success_criteria>
+- docker-compose.yml defines umami service connected to existing db container
+- Caddyfile proxies analytics.flawchess.com to umami:3000
+- .env.example documents all required Umami environment variables
+- No separate database container created for Umami
+- Node.js heap capped at 256 MB
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/24-web-analytics/24-01-SUMMARY.md`
+</output>

--- a/.planning/phases/24-web-analytics/24-01-SUMMARY.md
+++ b/.planning/phases/24-web-analytics/24-01-SUMMARY.md
@@ -1,0 +1,121 @@
+---
+phase: 24-web-analytics
+plan: 01
+subsystem: infra
+tags: [umami, analytics, docker, caddy, postgresql]
+
+# Dependency graph
+requires:
+  - phase: 23-launch
+    provides: Docker Compose stack and Caddyfile that this extends
+provides:
+  - Umami self-hosted analytics service in Docker Compose sharing existing PostgreSQL
+  - analytics.flawchess.com reverse proxy via Caddy with auto-TLS
+  - Environment variable documentation for Umami credentials
+affects: [24-web-analytics plan 02, future infra phases]
+
+# Tech tracking
+tech-stack:
+  added: [umami (ghcr.io/umami-software/umami:postgresql-latest)]
+  patterns:
+    - Umami shares existing db service via DATABASE_URL pointing to db:5432/umami
+    - Internal-only services use expose not ports; Caddy is sole internet-facing entry point
+    - NODE_OPTIONS max-old-space-size caps Node.js heap for resource-constrained VPS
+
+key-files:
+  created: []
+  modified:
+    - docker-compose.yml
+    - deploy/Caddyfile
+    - .env.example
+
+key-decisions:
+  - "Umami connects to existing db service (no separate PostgreSQL container) per D-02"
+  - "Node.js heap capped at 256 MB via NODE_OPTIONS to guard VPS memory (3.7 GB RAM + 2 GB swap)"
+  - "No Caddy-level auth on analytics subdomain — Umami handles its own login per D-04/D-05"
+  - "caddy service depends_on umami to ensure Umami is available before Caddy accepts traffic"
+
+patterns-established:
+  - "Analytics subdomain as separate Caddyfile server block for clean TLS isolation"
+
+requirements-completed: [ANLY-04, ANLY-05]
+
+# Metrics
+duration: 5min
+completed: 2026-03-22
+---
+
+# Phase 24 Plan 01: Web Analytics Infrastructure Summary
+
+**Umami analytics service added to Docker Compose sharing existing PostgreSQL, proxied via Caddy at analytics.flawchess.com with 256 MB Node.js heap cap**
+
+## Performance
+
+- **Duration:** ~5 min
+- **Started:** 2026-03-22T17:20:00Z
+- **Completed:** 2026-03-22T17:21:44Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+
+- Added Umami service to docker-compose.yml connected to existing db container (no separate DB)
+- Added analytics.flawchess.com server block to Caddyfile for auto-TLS reverse proxy to umami:3000
+- Documented UMAMI_DB_USER, UMAMI_DB_PASSWORD, UMAMI_APP_SECRET in .env.example
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add Umami service to Docker Compose and update .env.example** - `e9a11ff` (feat)
+2. **Task 2: Add analytics subdomain to Caddyfile** - `b699dec` (feat)
+
+**Plan metadata:** (pending docs commit)
+
+## Files Created/Modified
+
+- `docker-compose.yml` - Added umami service with shared db, 256 MB heap cap, and updated caddy depends_on
+- `deploy/Caddyfile` - Added analytics.flawchess.com server block with reverse_proxy to umami:3000
+- `.env.example` - Added Umami analytics section with UMAMI_DB_USER, UMAMI_DB_PASSWORD, UMAMI_APP_SECRET
+
+## Decisions Made
+
+- Umami shares existing db PostgreSQL container — no new container added, matching decision D-02
+- NODE_OPTIONS set to --max-old-space-size=256 to guard memory on the resource-constrained VPS
+- No basicauth on Caddy level — Umami has built-in login, first run creates default admin account
+- caddy depends_on includes umami so Caddy does not start before Umami is available
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+Before deploying to production, the operator must:
+
+1. Create the `umami` PostgreSQL database and user:
+   ```sql
+   CREATE USER umami WITH PASSWORD '<UMAMI_DB_PASSWORD>';
+   CREATE DATABASE umami OWNER umami;
+   ```
+2. Set the following in `/opt/flawchess/.env` on the server:
+   - `UMAMI_DB_USER=umami`
+   - `UMAMI_DB_PASSWORD=<generated with openssl rand -hex 16>`
+   - `UMAMI_APP_SECRET=<generated with openssl rand -hex 32>`
+3. Add DNS A record: `analytics.flawchess.com` pointing to the server IP
+4. Deploy and verify: `https://analytics.flawchess.com` should show Umami login page
+
+Umami will auto-create its schema on first startup. Default credentials: `admin` / `umami` — change immediately.
+
+## Next Phase Readiness
+
+- Infrastructure is ready for Plan 02 (tracking script integration into the frontend)
+- analytics.flawchess.com will be live once deployed with correct env vars and DNS record
+
+---
+*Phase: 24-web-analytics*
+*Completed: 2026-03-22*

--- a/.planning/phases/24-web-analytics/24-02-PLAN.md
+++ b/.planning/phases/24-web-analytics/24-02-PLAN.md
@@ -1,0 +1,226 @@
+---
+phase: 24-web-analytics
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - 24-01
+files_modified:
+  - frontend/index.html
+autonomous: false
+requirements:
+  - ANLY-01
+  - ANLY-02
+  - ANLY-03
+
+must_haves:
+  truths:
+    - "Umami tracking script is embedded in the frontend HTML"
+    - "Tracking only fires on production domain (flawchess.com), not localhost"
+    - "SPA route changes are tracked automatically via History API"
+    - "Site owner can view page visit counts and trends in Umami dashboard"
+    - "Top pages by visit count are visible in Umami dashboard"
+    - "Referrer sources are tracked and displayed in Umami dashboard"
+  artifacts:
+    - path: "frontend/index.html"
+      provides: "Umami tracking script tag"
+      contains: "analytics.flawchess.com/script.js"
+  key_links:
+    - from: "frontend/index.html (script tag)"
+      to: "analytics.flawchess.com/script.js"
+      via: "deferred script load with data-website-id"
+      pattern: 'src="https://analytics.flawchess.com/script.js"'
+
+user_setup:
+  - service: umami
+    why: "Self-hosted analytics platform requires production database and DNS setup"
+    env_vars:
+      - name: UMAMI_DB_USER
+        source: "Set to 'umami' (matches CREATE USER SQL below)"
+      - name: UMAMI_DB_PASSWORD
+        source: "Generate with: openssl rand -hex 16"
+      - name: UMAMI_APP_SECRET
+        source: "Generate with: openssl rand -hex 32"
+    dashboard_config:
+      - task: "Create 'umami' database and user in production PostgreSQL"
+        location: "ssh flawchess, then: docker compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB -c \"CREATE USER umami WITH PASSWORD 'your-password'; CREATE DATABASE umami OWNER umami; GRANT ALL PRIVILEGES ON DATABASE umami TO umami;\" && docker compose exec db psql -U $POSTGRES_USER -d umami -c \"GRANT ALL ON SCHEMA public TO umami;\""
+      - task: "Add UMAMI_DB_USER, UMAMI_DB_PASSWORD, UMAMI_APP_SECRET to /opt/flawchess/.env"
+        location: "ssh flawchess, then edit /opt/flawchess/.env"
+      - task: "Add DNS A record for analytics.flawchess.com pointing to the same server IP as flawchess.com"
+        location: "Domain registrar DNS management panel"
+      - task: "Deploy updated stack: ssh flawchess 'cd /opt/flawchess && git pull origin main && docker compose up -d --build'"
+        location: "Terminal"
+      - task: "Change default Umami admin password (default: admin/umami)"
+        location: "https://analytics.flawchess.com -> login -> Settings -> Profile"
+      - task: "Add website in Umami: Settings -> Websites -> Add website (domain: flawchess.com). Copy the generated website ID."
+        location: "https://analytics.flawchess.com -> Settings -> Websites"
+---
+
+<objective>
+Add Umami tracking script to the frontend and verify the full analytics pipeline end-to-end.
+
+Purpose: Complete the analytics integration by embedding the tracking script (requires website ID from deployed Umami) and verifying that pageviews, top pages, and referrers appear in the dashboard.
+Output: Updated frontend/index.html with live tracking, verified analytics dashboard.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/execute-plan.md
+@~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/24-web-analytics/24-CONTEXT.md
+@.planning/phases/24-web-analytics/24-RESEARCH.md
+@.planning/phases/24-web-analytics/24-01-SUMMARY.md
+
+@frontend/index.html
+</context>
+
+<tasks>
+
+<task type="checkpoint:human-action" gate="blocking">
+  <name>Task 1: Deploy Umami infrastructure and obtain website ID</name>
+  <files>n/a (production server only)</files>
+  <action>
+Before the tracking script can be added to the frontend, Umami must be deployed and a website must be registered to get the `data-website-id`. This requires human actions that Claude cannot perform (SSH to production, DNS changes, password changes).
+
+Steps for the user:
+
+1. **Create DNS record**: Add an A record for `analytics.flawchess.com` pointing to the same IP as `flawchess.com` in your domain registrar's DNS panel.
+
+2. **Create Umami database and user on production server**:
+   ```bash
+   ssh flawchess
+   cd /opt/flawchess
+   # Create the umami user and database (replace YOUR_PASSWORD with a strong password)
+   docker compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB -c "CREATE USER umami WITH PASSWORD 'YOUR_PASSWORD';"
+   docker compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB -c "CREATE DATABASE umami OWNER umami;"
+   docker compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB -c "GRANT ALL PRIVILEGES ON DATABASE umami TO umami;"
+   docker compose exec db psql -U $POSTGRES_USER -d umami -c "GRANT ALL ON SCHEMA public TO umami;"
+   ```
+
+3. **Add env vars to production .env**:
+   ```bash
+   # Still on the server, edit /opt/flawchess/.env and add:
+   UMAMI_DB_USER=umami
+   UMAMI_DB_PASSWORD=YOUR_PASSWORD    # same as CREATE USER above
+   UMAMI_APP_SECRET=<run: openssl rand -hex 32>
+   ```
+
+4. **Deploy the updated stack**:
+   ```bash
+   cd /opt/flawchess
+   git pull origin main
+   docker compose up -d --build
+   ```
+
+5. **Verify Umami is running**: Visit `https://analytics.flawchess.com`. You should see the Umami login page.
+
+6. **Change default admin password**: Log in with `admin` / `umami`, then go to Settings -> Profile and change the password immediately.
+
+7. **Register the website**: Go to Settings -> Websites -> Add website. Set domain to `flawchess.com`. Copy the generated **Website ID** (a UUID like `a1b2c3d4-e5f6-...`).
+  </action>
+  <verify>User confirms Umami is running at analytics.flawchess.com and provides the website ID UUID</verify>
+  <done>Umami deployed, admin password changed, website registered, website ID obtained</done>
+  <resume-signal>Provide the Umami website ID (UUID) from step 7, e.g.: "Website ID: a1b2c3d4-e5f6-7890-abcd-ef1234567890"</resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add Umami tracking script to frontend index.html</name>
+  <files>frontend/index.html</files>
+  <read_first>frontend/index.html</read_first>
+  <action>
+Add the Umami tracking script tag to `frontend/index.html` inside the `<head>` section, after the Twitter/X Card meta tags and before the closing `</head>`. Use the website ID provided by the user in Task 1.
+
+Insert this block:
+
+```html
+    <!-- Umami analytics (privacy-friendly, no cookies) -->
+    <script
+      defer
+      src="https://analytics.flawchess.com/script.js"
+      data-website-id="WEBSITE_ID_FROM_TASK_1"
+      data-domains="flawchess.com"
+    ></script>
+```
+
+Replace `WEBSITE_ID_FROM_TASK_1` with the actual UUID the user provided.
+
+Key attributes:
+- `defer`: does not block page render
+- `src`: points to the Umami tracking script on the analytics subdomain
+- `data-website-id`: the UUID registered in Umami (from Task 1)
+- `data-domains="flawchess.com"`: restricts tracking to production only — the script silently no-ops on localhost, so dev environments are not tracked
+
+No React code changes needed. Umami's tracker automatically patches `history.pushState` and `history.replaceState` to track SPA route changes via the History API. React Router uses these APIs, so all navigation is tracked without any additional hooks or wrappers.
+  </action>
+  <verify>
+    <automated>grep -q "analytics.flawchess.com/script.js" frontend/index.html && grep -q "data-domains" frontend/index.html && grep -q "data-website-id" frontend/index.html && echo "PASS" || echo "FAIL"</automated>
+  </verify>
+  <acceptance_criteria>
+    - frontend/index.html contains `<script` tag with `src="https://analytics.flawchess.com/script.js"`
+    - frontend/index.html contains `data-website-id="` followed by a UUID (not a placeholder like REPLACE or TODO)
+    - frontend/index.html contains `data-domains="flawchess.com"`
+    - frontend/index.html contains `defer` attribute on the script tag
+    - The script tag is inside the `<head>` section
+    - `npm run build` in frontend/ succeeds without errors
+  </acceptance_criteria>
+  <done>Umami tracking script embedded in frontend with production website ID and domain restriction</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Verify analytics pipeline end-to-end</name>
+  <files>n/a (production verification only)</files>
+  <action>
+Deploy the updated frontend with the tracking script and verify the full analytics pipeline works end-to-end. All verification is on production.
+
+Redeploy: `ssh flawchess "cd /opt/flawchess && git pull origin main && docker compose up -d --build caddy"`
+  </action>
+  <verify>Manual verification of Umami dashboard showing live pageview data from flawchess.com</verify>
+  <done>Umami dashboard shows pageviews, top pages, and referrer sources from live traffic</done>
+  <how-to-verify>
+After deploying the updated frontend (with the tracking script):
+
+1. **Redeploy frontend**: `ssh flawchess "cd /opt/flawchess && git pull origin main && docker compose up -d --build caddy"`
+
+2. **Check RAM usage**: `ssh flawchess "cd /opt/flawchess && docker stats --no-stream"` — verify the `umami` container uses less than 300 MB RAM (ANLY-05).
+
+3. **Browse the site**: Visit https://flawchess.com and navigate to 3-4 different pages (e.g., home, openings, dashboard, login).
+
+4. **Check Umami dashboard**: Visit https://analytics.flawchess.com and log in.
+   - ANLY-01: Page visit counts should appear with a time-series trend chart
+   - ANLY-02: "Pages" section should show the routes you visited, ranked by visit count
+   - ANLY-03: "Referrers" section should show referrer sources (may be empty if visiting directly — that's OK for initial verification)
+
+5. **Verify no cookies**: Open browser DevTools on flawchess.com -> Application -> Cookies. There should be NO cookies set by the analytics script (ANLY-04). The only cookies should be from the FlawChess auth system.
+
+6. **Verify no dev tracking**: Open http://localhost:5173 (if dev server is running), navigate around, then check Umami dashboard — no localhost pageviews should appear (due to `data-domains="flawchess.com"`).
+  </how-to-verify>
+  <resume-signal>Type "approved" if analytics data appears correctly, or describe any issues.</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+1. `grep "analytics.flawchess.com/script.js" frontend/index.html` shows tracking script
+2. `grep "data-domains" frontend/index.html` shows production-only restriction
+3. Umami dashboard at analytics.flawchess.com shows live pageview data
+4. No cookie consent banner needed (Umami is cookieless)
+5. `docker stats --no-stream` on production shows umami < 300 MB RAM
+</verification>
+
+<success_criteria>
+- Umami tracking script is live in the frontend with the correct website ID
+- Umami dashboard shows pageview counts and trends (ANLY-01)
+- Top pages are visible by visit count (ANLY-02)
+- Referrer sources section exists in dashboard (ANLY-03)
+- No cookies set by tracking script (ANLY-04)
+- Umami container uses < 300 MB RAM (ANLY-05)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/24-web-analytics/24-02-SUMMARY.md`
+</output>

--- a/.planning/phases/24-web-analytics/24-CONTEXT.md
+++ b/.planning/phases/24-web-analytics/24-CONTEXT.md
@@ -1,0 +1,89 @@
+# Phase 24: Web Analytics - Context
+
+**Gathered:** 2026-03-22
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Add privacy-friendly, low-resource web analytics to track page visits, top routes, and referrer sources. Site owner can view a dashboard showing usage trends. No cookie consent banner required.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Analytics tool
+- **D-01:** Umami (self-hosted), not Plausible CE (too resource-heavy — needs ClickHouse), not GoAccess (can't track SPA client-side route transitions), not Cloudflare Web Analytics (ad-blocker blind spot for developer audience, no data ownership), not Plausible Cloud (too expensive at ~$9/mo)
+
+### Database hosting
+- **D-02:** Shared PostgreSQL instance — Umami gets its own database (e.g., `umami`) within the existing `db` container. No separate PostgreSQL container. Lower RAM footprint than running two PostgreSQL processes.
+
+### Dashboard access
+- **D-03:** Subdomain at `analytics.flawchess.com` — Caddy handles auto-TLS. Clean URL, no subpath rewriting issues.
+- **D-04:** Dashboard is private (login required). Can be made public later if desired.
+
+### Authentication
+- **D-05:** Umami's built-in user/password system. Default admin account on first run.
+
+### Claude's Discretion
+- Umami version and Docker image selection
+- Caddy reverse proxy config details for the subdomain
+- Data retention configuration
+- Environment variable naming conventions
+- Umami tracking script integration in the React frontend
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- Server is resource-constrained (Hetzner CX32: 2 vCPUs, 3.7 GB RAM + 2 GB swap) — RAM overhead from Umami must stay minimal
+- Traffic is low (niche chess analysis site) — DB growth from pageview rows is negligible compared to existing `game_positions` table
+- If VPS gets tight on RAM, Umami could be migrated to Umami Cloud free tier (10k events/month) as a fallback
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+No external specs — requirements are fully captured in decisions above and REQUIREMENTS.md (ANLY-01 through ANLY-05).
+
+### Deployment
+- `docker-compose.yml` — Production Docker stack (PostgreSQL + backend + Caddy)
+- `deploy/Caddyfile` — Caddy reverse proxy config (add analytics subdomain here)
+- `frontend/Dockerfile` — Frontend build + Caddy runtime image
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- Existing PostgreSQL container (`db` service) — Umami connects to it with a separate database
+- Caddy reverse proxy — add `analytics.flawchess.com` block for Umami
+
+### Established Patterns
+- Docker Compose services pattern — add Umami as a new service alongside `db`, `backend`, `caddy`
+- Environment variables via `.env` file — Umami config follows same pattern
+
+### Integration Points
+- `docker-compose.yml` — new `umami` service definition
+- `deploy/Caddyfile` — new server block for `analytics.flawchess.com`
+- `frontend/index.html` or React root — Umami tracking `<script>` tag
+- Production `.env` at `/opt/flawchess/.env` — Umami database credentials
+
+</code_context>
+
+<deferred>
+## Deferred Ideas
+
+- Update privacy policy page (`/privacy`) to mention analytics data collection — should be done after analytics is live
+- Public analytics dashboard — revisit later if desired
+
+</deferred>
+
+---
+
+*Phase: 24-web-analytics*
+*Context gathered: 2026-03-22*

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -2,6 +2,10 @@ flawchess.org, www.flawchess.org {
     redir https://flawchess.com{uri} permanent
 }
 
+analytics.flawchess.com {
+    reverse_proxy umami:3000
+}
+
 flawchess.com {
     encode gzip
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,19 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    environment:
+      DATABASE_URL: postgresql://${UMAMI_DB_USER}:${UMAMI_DB_PASSWORD}@db:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+      NODE_OPTIONS: "--max-old-space-size=256"
+    expose:
+      - "3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
   caddy:
     build:
       context: .
@@ -42,6 +55,7 @@ services:
       - caddy_config:/config
     depends_on:
       - backend
+      - umami
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- Adds Umami analytics container to docker-compose.yml, sharing the existing PostgreSQL database (no separate DB container)
- Configures Caddy to reverse-proxy `analytics.flawchess.com` to Umami with auto-TLS
- Documents required env vars (`UMAMI_DB_USER`, `UMAMI_DB_PASSWORD`, `UMAMI_APP_SECRET`) in `.env.example`
- Node.js heap capped at 256 MB to protect the resource-constrained VPS

**Note:** This is plan 24-01 of Phase 24 (Web Analytics). Plan 24-02 (frontend tracking script) will follow after Umami is deployed and a website ID is obtained.

## Test plan
- [ ] Create DNS A record for `analytics.flawchess.com`
- [ ] Create `umami` database and user on production PostgreSQL
- [ ] Add env vars to production `.env`
- [ ] Deploy with `docker compose up -d --build`
- [ ] Verify Umami login page at `https://analytics.flawchess.com`
- [ ] Change default admin password

🤖 Generated with [Claude Code](https://claude.com/claude-code)