### PR TITLE
feat: add Umami tracking script to frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,14 @@
     <meta name="twitter:title" content="FlawChess — Chess Opening Analysis" />
     <meta name="twitter:description" content="Analyze your chess openings by position, not just name. Import games from chess.com and lichess to discover where you really lose." />
     <meta name="twitter:image" content="https://flawchess.com/og-image.jpg" />
+
+    <!-- Umami analytics (privacy-friendly, no cookies) -->
+    <script
+      defer
+      src="https://analytics.flawchess.com/script.js"
+      data-website-id="0ca19960-2398-4caf-b321-8039708fa7ef"
+      data-domains="flawchess.com"
+    ></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Embeds Umami analytics tracking script in `frontend/index.html`
- `data-domains="flawchess.com"` restricts tracking to production only (no localhost tracking)
- `defer` attribute ensures no render blocking
- SPA route changes tracked automatically via History API (no React code changes needed)

Follows PR #10 which deployed the Umami infrastructure.

## Test plan
- [ ] Deploy and browse flawchess.com — verify pageviews appear in Umami dashboard
- [ ] Check top pages and referrer sources in dashboard
- [ ] Verify no analytics cookies in browser DevTools
- [ ] Verify `docker stats` shows umami < 300 MB RAM
- [ ] Verify localhost dev server does NOT send pageviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)