### PR TITLE
fix: detect conflicting local PostgreSQL before starting dev database

### DIFF
--- a/bin/run_local.sh
+++ b/bin/run_local.sh
@@ -8,6 +8,15 @@ pkill -f "uvicorn app.main:app" 2>/dev/null || true
 pkill -f "vite" 2>/dev/null || true
 sleep 1
 
+# Fail fast if a local postgres process is already holding port 5432.
+# Docker's port-forward shows up as "com.docke", not "postgres", so this
+# correctly distinguishes a conflicting system Postgres from Docker itself.
+if lsof -ti :5432 2>/dev/null | xargs -I{} ps -p {} -o comm= 2>/dev/null | grep -qi "postgres"; then
+  echo "Error: a local PostgreSQL process is already listening on port 5432."
+  echo "Stop your local PostgreSQL service before running this script."
+  exit 1
+fi
+
 # Ensure dev database is running
 echo "Starting dev database..."
 docker compose -f docker-compose.dev.yml -p flawchess-dev up -d


### PR DESCRIPTION
## Summary

- Adds a pre-flight check to `bin/run_local.sh` that detects if a local PostgreSQL process is already listening on port 5432
- Exits immediately with a clear error message instead of silently running migrations against the wrong database

## Why

Docker's port-forward shows up as `com.docke`, not `postgres`, so the check correctly distinguishes a conflicting system Postgres from Docker itself. Without this, a locally-running Postgres causes `alembic upgrade head` to fail with a cryptic `role "flawchess" does not exist` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)