### PR TITLE
fix: retry lichess stream drops and report reimport failures

### DIFF
--- a/app/services/lichess_client.py
+++ b/app/services/lichess_client.py
@@ -4,7 +4,9 @@ Fetches games for a user via NDJSON streaming and yields normalized game dicts.
 Supports incremental sync via the ``since`` millisecond timestamp parameter.
 """
 
+import asyncio
 import json
+import logging
 from collections.abc import AsyncIterator, Callable
 
 import httpx
@@ -12,10 +14,17 @@ import httpx
 from app.core.rate_limiters import get_lichess_semaphore
 from app.services.normalization import normalize_lichess_game
 
+logger = logging.getLogger(__name__)
+
 LICHESS_API_URL = "https://lichess.org/api/games/user"
 
 # Request standard time-control variants only (excludes correspondence/unlimited)
 _PERF_TYPES = "ultraBullet,bullet,blitz,rapid,classical"
+
+# Retry config for transient stream errors (e.g. "peer closed connection").
+# Lichess NDJSON streams for large exports (10k+ games) can drop mid-transfer.
+_MAX_RETRIES = 3
+_RETRY_BACKOFF_BASE_SECONDS = 5
 
 
 async def fetch_lichess_games(
@@ -28,7 +37,9 @@ async def fetch_lichess_games(
     """Async generator that yields normalized game dicts for a lichess user.
 
     Streams NDJSON from the lichess API line-by-line using httpx streaming,
-    so large exports never need to be buffered in memory.
+    so large exports never need to be buffered in memory. Retries on transient
+    connection drops — already-imported games are deduplicated downstream by
+    bulk_insert_games.
 
     Args:
         client: Shared httpx.AsyncClient instance.
@@ -57,28 +68,57 @@ async def fetch_lichess_games(
     url = f"{LICHESS_API_URL}/{username}"
     headers = {"Accept": "application/x-ndjson"}
 
-    # Semaphore held for entire stream duration. Lichess streams in one HTTP
-    # connection per job, so the semaphore limits concurrent connections, not
-    # individual requests.
-    async with get_lichess_semaphore():
-        async with client.stream(
-            "GET", url, params=params, headers=headers, timeout=300.0
-        ) as response:
-            if response.status_code == 404:
-                raise ValueError(f"lichess user '{username}' not found")
+    last_attempt_error: Exception | None = None
 
-            async for line in response.aiter_lines():
-                if not line.strip():
-                    continue
+    for attempt in range(_MAX_RETRIES + 1):
+        if attempt > 0:
+            backoff = _RETRY_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+            logger.warning(
+                "Lichess stream for %s dropped (attempt %d/%d), retrying in %ds: %s",
+                username,
+                attempt,
+                _MAX_RETRIES,
+                backoff,
+                last_attempt_error,
+            )
+            await asyncio.sleep(backoff)
 
-                try:
-                    game = json.loads(line)
-                except json.JSONDecodeError:
-                    # Skip malformed lines without aborting the stream
-                    continue
+        try:
+            # Semaphore held for entire stream duration. Lichess streams in one HTTP
+            # connection per job, so the semaphore limits concurrent connections, not
+            # individual requests.
+            async with get_lichess_semaphore():
+                async with client.stream(
+                    "GET", url, params=params, headers=headers, timeout=300.0
+                ) as response:
+                    if response.status_code == 404:
+                        raise ValueError(f"lichess user '{username}' not found")
 
-                normalized = normalize_lichess_game(game, username, user_id)
-                if normalized is not None:
-                    yield normalized
-                    if on_game_fetched is not None:
-                        on_game_fetched()
+                    async for line in response.aiter_lines():
+                        if not line.strip():
+                            continue
+
+                        try:
+                            game = json.loads(line)
+                        except json.JSONDecodeError:
+                            # Skip malformed lines without aborting the stream
+                            continue
+
+                        normalized = normalize_lichess_game(game, username, user_id)
+                        if normalized is not None:
+                            yield normalized
+                            if on_game_fetched is not None:
+                                on_game_fetched()
+
+            # Stream completed successfully — no retry needed
+            return
+
+        except (httpx.RemoteProtocolError, httpx.ReadError) as exc:
+            # Transient stream errors (e.g. "peer closed connection without
+            # sending complete message body"). Safe to retry because
+            # bulk_insert_games deduplicates already-imported games.
+            last_attempt_error = exc
+            continue
+
+    # All retries exhausted — re-raise the last error
+    raise last_attempt_error  # type: ignore[misc]

--- a/scripts/reimport_games.py
+++ b/scripts/reimport_games.py
@@ -145,6 +145,7 @@ async def reimport_user(session, user_id: int) -> tuple[bool, int]:
 
     # Re-import from each platform
     total_imported = 0
+    any_platform_failed = False
     for platform, username in platform_jobs:
         _log(f"  Re-importing from {platform} ({username})...")
         try:
@@ -160,12 +161,14 @@ async def reimport_user(session, user_id: int) -> tuple[bool, int]:
                         f"  Done: {job_state.games_imported} games imported from {platform}."
                     )
                 else:
+                    any_platform_failed = True
                     error_msg = job_state.error or "Unknown error"
-                    _log(f"  WARNING: Import from {platform} failed: {error_msg}")
+                    _log(f"  FAILED: Import from {platform} failed: {error_msg}")
         except Exception as e:
-            _log(f"  WARNING: Re-import from {platform} failed with exception: {e}")
+            any_platform_failed = True
+            _log(f"  FAILED: Re-import from {platform} failed with exception: {e}")
 
-    return True, total_imported
+    return not any_platform_failed, total_imported
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- Add retry with exponential backoff (3 attempts, 5s/10s/20s) to lichess NDJSON streaming for transient `RemoteProtocolError`/`ReadError` — large exports (10k+ games) can drop mid-transfer
- Fix `reimport_games.py` falsely reporting failed users as successful — now tracks per-platform failures and returns `success=False` when any import fails

## Context
User 4 (mywebcompanion, 9994 games) had all games deleted then the lichess stream dropped, leaving them with 0 games. The script summary reported 7/7 users successful.

## Test plan
- [x] All 379 existing tests pass
- [ ] Verify retry works by running reimport for a large lichess account
- [ ] Verify failure is correctly reported in summary when an import fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)