### PR TITLE
Phase 34: Theme improvements

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -65,15 +65,16 @@ Users can determine their success rate for any opening position they specify, fi
 - Offline API data caching — chess data is user-specific + authenticated; caching risks stale analysis
 - Swipe-to-navigate between tabs — conflicts with chessboard touch gestures
 
-## Current Milestone: v1.5 Game Statistics & Endgame Analysis
+## Current Milestone: v1.6 UI Polish & Improvements
 
-**Goal:** Enrich imported games with per-position metadata (game phase, material, endgame classification) and surface endgame performance analytics through a new Endgames tab.
+**Goal:** Improve visual consistency, theming, and layout polish across the application.
 
 **Target features:**
-- Position metadata at import: game phase, material signature, material imbalance, endgame class
-- Import existing engine analysis from chess.com/lichess APIs when available
-- Endgame analytics tab with filters and W/D/L statistics per endgame category
-- Material-based conversion & recovery statistics by game phase
+- Centralized theme configuration via theme.ts (containers, spacing, colors)
+- Visually distinct containers with charcoal backgrounds and CSS-only noise texture
+- Better filter button spacing in sidebar (horizontal, full-width layout)
+- Consistent chart styling across all WDL/Recharts visualizations (unified corners, rendering)
+- Improved active subtab highlighting
 
 ## Current State
 
@@ -123,4 +124,4 @@ v1.3 shipped 2026-03-22. FlawChess is live at flawchess.com with automated CI/CD
 | Backend expose-only (no ports) | Caddy is sole internet-facing entry point | ✓ Good |
 
 ---
-*Last updated: 2026-03-26 after Phase 31 completion*
+*Last updated: 2026-03-28 after milestone v1.6 start*

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -78,7 +78,7 @@ Users can determine their success rate for any opening position they specify, fi
 
 ## Current State
 
-v1.3 shipped 2026-03-22. FlawChess is live at flawchess.com with automated CI/CD and Sentry monitoring. v1.4 (Web Analytics, Password Reset) in progress. Phase 31 complete — endgame analytics redesigned from per-game single-transition-point to per-position classification. endgame_class SmallInteger column on game_positions enables multi-class-per-game counting with 6-ply minimum threshold.
+v1.5 shipped 2026-03-28. Phase 34 (Theme Improvements) complete — centralized theme CSS variables, charcoal-texture containers with noise overlay across all pages, brand subtab highlighting, consistent button/toggle styling, GlobalStats sidebar layout. v1.6 UI Polish milestone in progress.
 
 ## Context
 
@@ -124,4 +124,4 @@ v1.3 shipped 2026-03-22. FlawChess is live at flawchess.com with automated CI/CD
 | Backend expose-only (no ports) | Caddy is sole internet-facing entry point | ✓ Good |
 
 ---
-*Last updated: 2026-03-28 after milestone v1.6 start*
+*Last updated: 2026-03-28 after Phase 34 completion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -9,10 +9,10 @@ Requirements for v1.6 — UI Polish & Improvements.
 
 ### Theme
 
-- [ ] **THEME-01**: User sees all visual constants (container colors, spacing, chart styles) centralized in theme.ts and CSS variables
+- [x] **THEME-01**: User sees all visual constants (container colors, spacing, chart styles) centralized in theme.ts and CSS variables
 - [x] **THEME-02**: User sees content containers with charcoal background and subtle SVG feTurbulence noise texture, visually distinct from page background
-- [ ] **THEME-03**: User sees filter buttons in sidebar spaced horizontally across full available width
-- [ ] **THEME-04**: User sees consistent WDL chart styling (unified corners and rendering) across all chart types (custom and Recharts-based)
+- [x] **THEME-03**: User sees filter buttons in sidebar spaced horizontally across full available width
+- [x] **THEME-04**: User sees consistent WDL chart styling (unified corners and rendering) across all chart types (custom and Recharts-based)
 - [x] **THEME-05**: User sees clear visual highlighting on the active subtab
 
 ## Future Requirements
@@ -43,10 +43,10 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| THEME-01 | Phase 34 | Pending |
+| THEME-01 | Phase 34 | Complete |
 | THEME-02 | Phase 34 | Complete |
-| THEME-03 | Phase 34 | Pending |
-| THEME-04 | Phase 34 | Pending |
+| THEME-03 | Phase 34 | Complete |
+| THEME-04 | Phase 34 | Complete |
 | THEME-05 | Phase 34 | Complete |
 
 **Coverage:**

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,60 +1,19 @@
 # Requirements: FlawChess
 
-**Defined:** 2026-03-23
-**Core Value:** Users can determine their success rate for any opening position they specify
+**Defined:** 2026-03-28
+**Core Value:** Users can determine their success rate for any opening position they specify, filtering by their own pieces only, regardless of how platforms categorize the opening.
 
-## v1.5 Requirements
+## v1.6 Requirements
 
-Requirements for v1.5 Game Statistics & Endgame Analysis milestone.
+Requirements for v1.6 — UI Polish & Improvements.
 
-### Position Metadata
+### Theme
 
-- [x] **PMETA-01**: System computes game phase (opening/middlegame/endgame) for every position during import using material-weight thresholds
-- [x] **PMETA-02**: System computes material signature in canonical form (stronger side first, e.g., KRP_KR) for every position during import
-- [x] **PMETA-03**: System computes material imbalance in centipawns for every position during import
-- [x] **PMETA-04**: System classifies endgame type (rook/minor piece/pawn/queen/mixed/pawnless) for positions in endgame phase
-- [x] **PMETA-05**: System backfills position metadata for all previously imported games without requiring user re-import
-
-### Engine Analysis Import
-
-- [ ] **ENGINE-01**: System imports per-move eval (centipawns/mate) from lichess PGN annotations for games with prior computer analysis
-- [ ] **ENGINE-02**: System imports game-level accuracy scores from chess.com for games where analysis exists
-- [ ] **ENGINE-03**: System gracefully handles missing analysis data (null fields, no errors) for unanalyzed games
-- [x] **LMETRIC-01**: System stores per-player analysis metrics (ACPL, inaccuracy count, mistake count, blunder count) as nullable SmallInteger columns on the games table
-- [x] **LMETRIC-02**: System imports lichess per-player analysis metrics (ACPL, inaccuracy, mistake, blunder counts) from the API response during game normalization
-
-### Endgame Analytics
-
-- [x] **ENDGM-01**: User can view W/D/L rates for each endgame category in a dedicated Endgames tab
-- [x] **ENDGM-02**: User can filter endgame statistics by time control (bullet/blitz/rapid/classical)
-- [x] **ENDGM-03**: User can filter endgame statistics by color played (white/black/both)
-- [x] **ENDGM-04**: User can see game count per endgame category to assess statistical significance
-
-### Conversion & Recovery Statistics
-
-- [x] **CONV-01**: User can see win rate when up material, broken down by game phase (placement TBD: Stats tab or Endgames tab)
-- [x] **CONV-02**: User can see draw/win rate when down material, broken down by game phase
-- [x] **CONV-03**: User can filter conversion/recovery stats by time control
-
-### Endgame Performance Charts
-
-- [ ] **PERF-01**: User can see side-by-side WDL comparison of endgame games vs non-endgame games
-- [ ] **PERF-02**: User can see a Relative Endgame Strength gauge (endgame win rate / overall win rate * 100)
-- [ ] **PERF-03**: User can see an Endgame Skill gauge (0.6 * conversion_pct + 0.4 * recovery_pct)
-- [ ] **PERF-04**: User can see conversion and recovery percentages side by side for each endgame type in a grouped bar chart
-- [ ] **PERF-05**: User can see rolling 50-game win rate timeline for endgame vs non-endgame games
-- [ ] **PERF-06**: User can see rolling 50-game win rate timeline broken down by endgame type
-- [ ] **PERF-07**: All endgame performance charts respect existing filters (time control, platform, recency, rated, opponent)
-
-## v1.4 Requirements (Prior Milestone)
-
-### Analytics
-
-- [ ] **ANLY-01**: Site owner can view page visit counts and trends over time
-- [ ] **ANLY-02**: Site owner can see top pages/routes by visit count
-- [ ] **ANLY-03**: Site owner can see visitor referrer sources
-- [x] **ANLY-04**: Analytics collection respects user privacy (no cookie consent banner required)
-- [x] **ANLY-05**: Analytics solution has minimal server resource footprint (RAM/CPU)
+- [ ] **THEME-01**: User sees all visual constants (container colors, spacing, chart styles) centralized in theme.ts and CSS variables
+- [ ] **THEME-02**: User sees content containers with charcoal background and subtle SVG feTurbulence noise texture, visually distinct from page background
+- [ ] **THEME-03**: User sees filter buttons in sidebar spaced horizontally across full available width
+- [ ] **THEME-04**: User sees consistent WDL chart styling (unified corners and rendering) across all chart types (custom and Recharts-based)
+- [ ] **THEME-05**: User sees clear visual highlighting on the active subtab
 
 ## Future Requirements
 
@@ -74,45 +33,22 @@ Requirements for v1.5 Game Statistics & Endgame Analysis milestone.
 
 | Feature | Reason |
 |---------|--------|
-| Local Stockfish analysis | Too CPU-intensive for Hetzner VPS; only import existing platform analysis |
-| Per-phase accuracy for chess.com | chess.com API only provides game-level accuracy, not per-phase |
-| Per-move quality classification (computing blunder/mistake/inaccuracy from engine evals) | Requires engine eval for every move; importing pre-computed game-level counts from lichess is in scope (Phase 28.1) |
-| Chessboard in Endgames tab | Endgame positions too diverse for meaningful board-based exploration |
+| Dark/light mode toggle | Not requested for v1.6; current dark theme is the only mode |
+| Fine borders on containers | Explicitly excluded — charcoal background with texture only |
+| Image-based background textures | Use lightweight SVG feTurbulence instead of asset files |
 
 ## Traceability
 
+Which phases cover which requirements. Updated during roadmap creation.
+
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| PMETA-01 | Phase 26 | Complete |
-| PMETA-02 | Phase 26 | Complete |
-| PMETA-03 | Phase 26 | Complete |
-| PMETA-04 | Phase 26 | Complete |
-| PMETA-05 | Phase 27 | Complete |
-| ENGINE-01 | Phase 29 | Pending |
-| ENGINE-02 | Phase 29 | Pending |
-| ENGINE-03 | Phase 29 | Pending |
-| ENDGM-01 | Phase 28 | Complete |
-| ENDGM-02 | Phase 28 | Complete |
-| ENDGM-03 | Phase 28 | Complete |
-| ENDGM-04 | Phase 28 | Complete |
-| CONV-01 | Phase 28 | Complete |
-| CONV-02 | Phase 28 | Complete |
-| CONV-03 | Phase 28 | Complete |
-| LMETRIC-01 | Phase 28.1 | Complete |
-| LMETRIC-02 | Phase 28.1 | Complete |
-| PERF-01 | Phase 32 | Pending |
-| PERF-02 | Phase 32 | Pending |
-| PERF-03 | Phase 32 | Pending |
-| PERF-04 | Phase 32 | Pending |
-| PERF-05 | Phase 32 | Pending |
-| PERF-06 | Phase 32 | Pending |
-| PERF-07 | Phase 32 | Pending |
 
 **Coverage:**
-- v1.5 requirements: 24 total
-- Mapped to phases: 24
-- Unmapped: 0
+- v1.6 requirements: 5 total
+- Mapped to phases: 0
+- Unmapped: 5 ⚠️
 
 ---
-*Requirements defined: 2026-03-23*
-*Last updated: 2026-03-26 after Phase 32 planning*
+*Requirements defined: 2026-03-28*
+*Last updated: 2026-03-28 after initial definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -43,12 +43,17 @@ Which phases cover which requirements. Updated during roadmap creation.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
+| THEME-01 | Phase 34 | Pending |
+| THEME-02 | Phase 34 | Pending |
+| THEME-03 | Phase 34 | Pending |
+| THEME-04 | Phase 34 | Pending |
+| THEME-05 | Phase 34 | Pending |
 
 **Coverage:**
 - v1.6 requirements: 5 total
-- Mapped to phases: 0
-- Unmapped: 5 ⚠️
+- Mapped to phases: 5
+- Unmapped: 0 ✓
 
 ---
 *Requirements defined: 2026-03-28*
-*Last updated: 2026-03-28 after initial definition*
+*Last updated: 2026-03-28 after roadmap creation*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -10,10 +10,10 @@ Requirements for v1.6 — UI Polish & Improvements.
 ### Theme
 
 - [ ] **THEME-01**: User sees all visual constants (container colors, spacing, chart styles) centralized in theme.ts and CSS variables
-- [ ] **THEME-02**: User sees content containers with charcoal background and subtle SVG feTurbulence noise texture, visually distinct from page background
+- [x] **THEME-02**: User sees content containers with charcoal background and subtle SVG feTurbulence noise texture, visually distinct from page background
 - [ ] **THEME-03**: User sees filter buttons in sidebar spaced horizontally across full available width
 - [ ] **THEME-04**: User sees consistent WDL chart styling (unified corners and rendering) across all chart types (custom and Recharts-based)
-- [ ] **THEME-05**: User sees clear visual highlighting on the active subtab
+- [x] **THEME-05**: User sees clear visual highlighting on the active subtab
 
 ## Future Requirements
 
@@ -44,10 +44,10 @@ Which phases cover which requirements. Updated during roadmap creation.
 | Requirement | Phase | Status |
 |-------------|-------|--------|
 | THEME-01 | Phase 34 | Pending |
-| THEME-02 | Phase 34 | Pending |
+| THEME-02 | Phase 34 | Complete |
 | THEME-03 | Phase 34 | Pending |
 | THEME-04 | Phase 34 | Pending |
-| THEME-05 | Phase 34 | Pending |
+| THEME-05 | Phase 34 | Complete |
 
 **Coverage:**
 - v1.6 requirements: 5 total

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -83,7 +83,7 @@
 
 ## v1.6 UI Polish & Improvements
 
-- [ ] **Phase 34: Theme Improvements** — Centralize theme constants, charcoal containers with noise texture, filter button layout, consistent WDL chart styling, active subtab highlighting
+- [x] **Phase 34: Theme Improvements** — Centralize theme constants, charcoal containers with noise texture, filter button layout, consistent WDL chart styling, active subtab highlighting (completed 2026-03-28)
 
 ## Phase Details
 
@@ -101,8 +101,8 @@
 **UI hint**: yes
 
 Plans:
-- [ ] 34-01-PLAN.md — Theme infrastructure: CSS variables, charcoal texture class, tabs brand variant, filter layout, WDL chart rounding
-- [ ] 34-02-PLAN.md — Apply charcoal containers to pages, collapsible styling, nav header polish, subtab highlighting, visual checkpoint
+- [x] 34-01-PLAN.md — Theme infrastructure: CSS variables, charcoal texture class, tabs brand variant, filter layout, WDL chart rounding
+- [x] 34-02-PLAN.md — Apply charcoal containers to pages, collapsible styling, nav header polish, subtab highlighting, visual checkpoint
 
 ## Progress
 
@@ -141,7 +141,7 @@ Plans:
 | 31. Endgame classification redesign | v1.5 | 2/2 | Complete | 2026-03-26 |
 | 32. Endgame Performance Charts | v1.5 | 3/3 | Complete | 2026-03-27 |
 | 33. Homepage, README & SEO Update | v1.5 | 3/3 | Complete | 2026-03-28 |
-| 34. Theme Improvements | v1.6 | 0/2 | Not started | - |
+| 34. Theme Improvements | v1.6 | 2/2 | Complete   | 2026-03-28 |
 
 ## Backlog
 
@@ -149,7 +149,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 0 plans
+**Plans:** 2/2 plans complete
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,6 +8,7 @@
 - ✅ **v1.3 Project Launch** — Phases 20-23 (shipped 2026-03-22)
 - ✅ **v1.4 Improvements** — Phase 24 (shipped 2026-03-22)
 - ✅ **v1.5 Game Statistics & Endgame Analysis** — Phases 26-33 (shipped 2026-03-28)
+- 🚧 **v1.6 UI Polish & Improvements** — Phase 34+ (in progress)
 
 ## Phases
 
@@ -80,6 +81,25 @@
 
 </details>
 
+## v1.6 UI Polish & Improvements
+
+- [ ] **Phase 34: Theme Improvements** — Centralize theme constants, charcoal containers with noise texture, filter button layout, consistent WDL chart styling, active subtab highlighting
+
+## Phase Details
+
+### Phase 34: Theme Improvements
+**Goal**: Users see a visually consistent, polished UI with centralized theme management across all pages
+**Depends on**: Nothing (first phase of v1.6)
+**Requirements**: THEME-01, THEME-02, THEME-03, THEME-04, THEME-05
+**Success Criteria** (what must be TRUE):
+  1. All theme-relevant constants (container colors, spacing, chart styles) are defined in theme.ts and CSS variables — no ad-hoc color values scattered across components
+  2. Content containers appear with a charcoal background and subtle noise texture, visually distinct from the page background
+  3. Filter buttons in the sidebar are laid out horizontally, spanning the full available width with even spacing
+  4. WDL charts (both custom bar and Recharts-based) share identical corner rounding and rendering style across all pages
+  5. The active subtab is clearly highlighted so the user always knows which sub-section they are viewing
+**Plans**: TBD
+**UI hint**: yes
+
 ## Progress
 
 | Phase | Milestone | Plans Complete | Status | Completed |
@@ -117,6 +137,7 @@
 | 31. Endgame classification redesign | v1.5 | 2/2 | Complete | 2026-03-26 |
 | 32. Endgame Performance Charts | v1.5 | 3/3 | Complete | 2026-03-27 |
 | 33. Homepage, README & SEO Update | v1.5 | 3/3 | Complete | 2026-03-28 |
+| 34. Theme Improvements | v1.6 | 0/? | Not started | - |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -141,7 +141,7 @@ Plans:
 | 31. Endgame classification redesign | v1.5 | 2/2 | Complete | 2026-03-26 |
 | 32. Endgame Performance Charts | v1.5 | 3/3 | Complete | 2026-03-27 |
 | 33. Homepage, README & SEO Update | v1.5 | 3/3 | Complete | 2026-03-28 |
-| 34. Theme Improvements | v1.6 | 2/2 | Complete   | 2026-03-28 |
+| 34. Theme Improvements | v1.6 | 2/2 | Complete    | 2026-03-28 |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -97,8 +97,12 @@
   3. Filter buttons in the sidebar are laid out horizontally, spanning the full available width with even spacing
   4. WDL charts (both custom bar and Recharts-based) share identical corner rounding and rendering style across all pages
   5. The active subtab is clearly highlighted so the user always knows which sub-section they are viewing
-**Plans**: TBD
+**Plans**: 2 plans
 **UI hint**: yes
+
+Plans:
+- [ ] 34-01-PLAN.md — Theme infrastructure: CSS variables, charcoal texture class, tabs brand variant, filter layout, WDL chart rounding
+- [ ] 34-02-PLAN.md — Apply charcoal containers to pages, collapsible styling, nav header polish, subtab highlighting, visual checkpoint
 
 ## Progress
 
@@ -137,7 +141,7 @@
 | 31. Endgame classification redesign | v1.5 | 2/2 | Complete | 2026-03-26 |
 | 32. Endgame Performance Charts | v1.5 | 3/3 | Complete | 2026-03-27 |
 | 33. Homepage, README & SEO Update | v1.5 | 3/3 | Complete | 2026-03-28 |
-| 34. Theme Improvements | v1.6 | 0/? | Not started | - |
+| 34. Theme Improvements | v1.6 | 0/2 | Not started | - |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ status: Active
 last_updated: "2026-03-28T00:00:00Z"
 last_activity: 2026-03-28
 progress:
-  total_phases: 0
+  total_phases: 1
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -16,10 +16,10 @@ progress:
 
 ## Current Position
 
-Phase: Not started (defining requirements)
+Phase: Phase 34 — Theme Improvements
 Plan: —
-Status: Defining requirements
-Last activity: 2026-03-28 — Milestone v1.6 started
+Status: Not started
+Last activity: 2026-03-28 — Roadmap created for v1.6
 
 ## Project Reference
 
@@ -31,6 +31,7 @@ Current focus: v1.6 UI Polish & Improvements
 
 | Phase | Goal | Status |
 |-------|------|--------|
+| 34. Theme Improvements | Users see a visually consistent, polished UI with centralized theme management | Not started |
 
 ## Key Context
 
@@ -92,6 +93,7 @@ Current focus: v1.6 UI Polish & Improvements
 - Phase 31 added: Endgame classification redesign — per-position instead of per-game
 - Phase 32 added: Endgame Performance Charts — endgame vs non-endgame WDL, strength gauge, rolling-window timelines
 - Phase 30 renumbered to Phase 33: Homepage, README & SEO Update (was skipped during v1.5 execution; phases 31 and 32 were inserted before it)
+- Phase 34 added: v1.6 Theme Improvements — centralized theme, charcoal containers, filter layout, WDL chart consistency, subtab highlighting
 
 ### Blockers/Concerns
 
@@ -136,4 +138,4 @@ Current focus: v1.6 UI Polish & Improvements
 | 260328-04a | Update SEO meta tags, README, and CLAUDE.md to match 5-feature homepage | 2026-03-27 | d039ba6 | [260328-04a-update-seo-readme-and-claude-md-based-on](./quick/260328-04a-update-seo-readme-and-claude-md-based-on/) |
 
 ---
-Last activity: 2026-03-28 - Milestone v1.5 complete. Phase 33 shipped, deployed to production.
+Last activity: 2026-03-28 - Roadmap created for v1.6. Phase 34 (Theme Improvements) defined.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,34 +1,36 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.5
-milestone_name: Game Statistics & Endgame Analysis
-status: Complete
+milestone: v1.6
+milestone_name: UI Polish & Improvements
+status: Active
 last_updated: "2026-03-28T00:00:00Z"
 last_activity: 2026-03-28
 progress:
-  total_phases: 11
-  completed_phases: 11
-  total_plans: 19
-  completed_plans: 19
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
 ---
 
 # Project State: FlawChess
 
 ## Current Position
 
-Milestone v1.5 complete. All phases shipped.
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-03-28 — Milestone v1.6 started
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-03-23)
+See: .planning/PROJECT.md (updated 2026-03-28)
 Core value: Users can determine their success rate for any opening position they specify
-Milestone v1.5 shipped: Game Statistics & Endgame Analysis
+Current focus: v1.6 UI Polish & Improvements
 
 ## Phase Progress
 
 | Phase | Goal | Status |
 |-------|------|--------|
-| 33. Homepage, README & SEO Update | Update homepage content, README, and SEO metadata | Complete |
 
 ## Key Context
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,24 +2,24 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: Active
-last_updated: "2026-03-28T00:00:00Z"
-last_activity: 2026-03-28
+status: executing
+last_updated: "2026-03-28T10:54:17.747Z"
+last_activity: 2026-03-28 -- Phase 34 execution started
 progress:
-  total_phases: 1
+  total_phases: 3
   completed_phases: 0
-  total_plans: 0
-  completed_plans: 0
+  total_plans: 2
+  completed_plans: 1
 ---
 
 # Project State: FlawChess
 
 ## Current Position
 
-Phase: Phase 34 — Theme Improvements
-Plan: —
-Status: Not started
-Last activity: 2026-03-28 — Roadmap created for v1.6
+Phase: 34 (theme-improvements) — EXECUTING
+Plan: 2 of 2
+Status: Executing Phase 34
+Last activity: 2026-03-28 -- Phase 34 execution started
 
 ## Project Reference
 
@@ -138,4 +138,4 @@ Current focus: v1.6 UI Polish & Improvements
 | 260328-04a | Update SEO meta tags, README, and CLAUDE.md to match 5-feature homepage | 2026-03-27 | d039ba6 | [260328-04a-update-seo-readme-and-claude-md-based-on](./quick/260328-04a-update-seo-readme-and-claude-md-based-on/) |
 
 ---
-Last activity: 2026-03-28 - Roadmap created for v1.6. Phase 34 (Theme Improvements) defined.
+Last activity: 2026-03-28 - Phase 34 Plan 01 complete. Theme infrastructure: CSS vars, charcoal-texture, tabs brand variant, filter grid layout, WDL chart rounding.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
 status: verifying
-last_updated: "2026-03-28T11:06:25.185Z"
+last_updated: "2026-03-28T12:52:56.747Z"
 last_activity: 2026-03-28
 progress:
   total_phases: 3
@@ -16,8 +16,8 @@ progress:
 
 ## Current Position
 
-Phase: 34 (theme-improvements) — EXECUTING
-Plan: 2 of 2
+Phase: 999.1
+Plan: Not started
 Status: Phase complete — ready for verification
 Last activity: 2026-03-28
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: executing
-last_updated: "2026-03-28T10:54:17.747Z"
-last_activity: 2026-03-28 -- Phase 34 execution started
+status: verifying
+last_updated: "2026-03-28T11:06:25.185Z"
+last_activity: 2026-03-28
 progress:
   total_phases: 3
-  completed_phases: 0
+  completed_phases: 1
   total_plans: 2
-  completed_plans: 1
+  completed_plans: 2
 ---
 
 # Project State: FlawChess
@@ -18,8 +18,8 @@ progress:
 
 Phase: 34 (theme-improvements) — EXECUTING
 Plan: 2 of 2
-Status: Executing Phase 34
-Last activity: 2026-03-28 -- Phase 34 execution started
+Status: Phase complete — ready for verification
+Last activity: 2026-03-28
 
 ## Project Reference
 
@@ -72,6 +72,8 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 33]: Title changed to 'Chess Analysis for Human Players' to reflect v1.5 scope
 - [Phase 33]: README broadened to include endgame analytics, Zobrist hash mention, and updated screenshot reference
 - [Phase 33]: orientation field removed from FEATURES type — all homepage sections now landscape with fixed 2fr/3fr grid ratio
+- [Phase 34-theme-improvements]: Nav active tab uses bg-white/10 (subtle lighter background) instead of border-b-2 underline per D-11
+- [Phase 34-theme-improvements]: charcoal-texture wraps each Collapsible block as a sibling div for correct rounded container rendering
 
 ### Critical v1.5 Constraints
 

--- a/.planning/phases/34-theme-improvements/34-01-PLAN.md
+++ b/.planning/phases/34-theme-improvements/34-01-PLAN.md
@@ -1,0 +1,296 @@
+---
+phase: 34-theme-improvements
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - frontend/src/index.css
+  - frontend/src/lib/theme.ts
+  - frontend/src/components/ui/tabs.tsx
+  - frontend/src/components/filters/FilterPanel.tsx
+  - frontend/src/components/charts/WDLBarChart.tsx
+autonomous: true
+requirements:
+  - THEME-01
+  - THEME-03
+  - THEME-04
+  - THEME-05
+
+must_haves:
+  truths:
+    - "Brand brown and charcoal CSS variables exist as Tailwind utilities (bg-brand-brown, bg-charcoal, etc.)"
+    - "PRIMARY_BUTTON_CLASS no longer contains hardcoded hex values"
+    - "A charcoal-texture CSS class exists with SVG feTurbulence noise overlay"
+    - "Filter buttons span the full sidebar width in equal-width columns"
+    - "Recharts WDL bars have rounded outer corners matching custom WDL bars"
+    - "Tabs component has a brand variant with brand brown active state"
+  artifacts:
+    - path: "frontend/src/index.css"
+      provides: "CSS variables for brand-brown, brand-brown-hover, charcoal, sidebar-bg; charcoal-texture class in @layer components"
+      contains: "--brand-brown"
+    - path: "frontend/src/lib/theme.ts"
+      provides: "Updated PRIMARY_BUTTON_CLASS using Tailwind utilities instead of hex brackets"
+      contains: "bg-brand-brown"
+    - path: "frontend/src/components/ui/tabs.tsx"
+      provides: "Brand variant for TabsList with brand brown active trigger styling"
+      contains: "brand"
+    - path: "frontend/src/components/filters/FilterPanel.tsx"
+      provides: "Grid-based full-width filter button layout"
+      contains: "grid grid-cols-4"
+    - path: "frontend/src/components/charts/WDLBarChart.tsx"
+      provides: "Rounded corners on outermost stacked WDL bars"
+      contains: "radius"
+  key_links:
+    - from: "frontend/src/index.css"
+      to: "frontend/src/lib/theme.ts"
+      via: "CSS variable --brand-brown referenced in PRIMARY_BUTTON_CLASS as bg-brand-brown Tailwind utility"
+      pattern: "bg-brand-brown"
+    - from: "frontend/src/index.css"
+      to: "frontend/src/components/ui/tabs.tsx"
+      via: "bg-charcoal Tailwind utility used in brand variant"
+      pattern: "bg-charcoal"
+---
+
+<objective>
+Set up the theme infrastructure and modify shared components for Phase 34.
+
+Purpose: Create CSS variable foundation, charcoal texture class, tabs brand variant, filter layout fix, and WDL chart rounding — all the shared building blocks that page-level changes in Plan 02 depend on.
+
+Output: Updated index.css with new CSS variables and charcoal-texture class, updated theme.ts with clean Tailwind utility references, updated tabs.tsx with brand variant, fixed FilterPanel.tsx layout, and rounded WDLBarChart.tsx corners.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-theme-improvements/34-CONTEXT.md
+@.planning/phases/34-theme-improvements/34-RESEARCH.md
+
+<interfaces>
+<!-- Key types and contracts the executor needs. -->
+
+From frontend/src/lib/theme.ts (current — to be updated):
+```typescript
+export const PRIMARY_BUTTON_CLASS = 'bg-[#8B5E3C] hover:bg-[#6B4226] text-white';
+// All other exports (WDL_WIN, WDL_DRAW, etc.) stay unchanged per D-17
+```
+
+From frontend/src/components/ui/tabs.tsx (current — to be extended):
+```typescript
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] ...",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+        // ADD: brand: "bg-charcoal gap-0"
+      },
+    },
+  }
+)
+// TabsTrigger active state patterns already use:
+// "group-data-[variant=default]/tabs-list:data-active:shadow-sm"
+// "group-data-[variant=line]/tabs-list:data-active:shadow-none"
+// ADD brand variant active state lines following same pattern
+```
+
+From frontend/src/index.css (current @theme inline block — to be extended):
+```css
+@theme inline {
+    --font-sans: 'Nunito Sans', sans-serif;
+    --color-sidebar-ring: var(--sidebar-ring);
+    /* ... existing entries ... */
+    /* ADD: --color-brand-brown, --color-brand-brown-hover, --color-charcoal */
+}
+```
+
+From frontend/src/components/ui/toggle-group.tsx (read-only reference):
+```typescript
+// Line 44: ToggleGroup has "w-fit" by default — must pass className="w-full" to override
+// Line 75: ToggleGroupItem has "shrink-0" — must pass className="flex-1" to grow
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: CSS variable foundation + charcoal texture class + theme.ts migration</name>
+  <files>frontend/src/index.css, frontend/src/lib/theme.ts</files>
+  <read_first>
+    - frontend/src/index.css (current CSS variables and @theme inline block)
+    - frontend/src/lib/theme.ts (current PRIMARY_BUTTON_CLASS with hardcoded hex)
+  </read_first>
+  <action>
+**In frontend/src/index.css:**
+
+1. Add new CSS custom properties to the `:root` block (per D-16):
+```css
+--brand-brown: #8B5E3C;
+--brand-brown-hover: #6B4226;
+--charcoal: #2A2520;
+--sidebar-bg: #171513;
+```
+
+2. Register them in the `@theme inline` block so Tailwind generates utility classes:
+```css
+--color-brand-brown: var(--brand-brown);
+--color-brand-brown-hover: var(--brand-brown-hover);
+--color-charcoal: var(--charcoal);
+--color-sidebar-bg: var(--sidebar-bg);
+```
+
+3. Add charcoal texture class in a new `@layer components` block (per D-01, D-02) AFTER the existing `@layer base` block:
+```css
+@layer components {
+  .charcoal-texture {
+    position: relative;
+    overflow: hidden;
+    background-color: var(--charcoal);
+  }
+  .charcoal-texture::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C%2Fsvg%3E");
+    background-repeat: repeat;
+    background-size: 200px;
+    opacity: 0.06;
+  }
+  /* Ensure children stack above the texture pseudo-element */
+  .charcoal-texture > * {
+    position: relative;
+    z-index: 1;
+  }
+}
+```
+
+**In frontend/src/lib/theme.ts:**
+
+4. Update `PRIMARY_BUTTON_CLASS` to use CSS variable-based Tailwind utilities (per D-16):
+```typescript
+export const PRIMARY_BUTTON_CLASS = 'bg-brand-brown hover:bg-brand-brown-hover text-white';
+```
+No other changes to theme.ts — WDL and gauge colors stay as JS constants per D-17.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npx tsc --noEmit 2>&1 | head -20 && npm run build 2>&1 | tail -5</automated>
+  </verify>
+  <acceptance_criteria>
+    - index.css contains `--brand-brown: #8B5E3C`
+    - index.css contains `--charcoal: #2A2520`
+    - index.css contains `--color-brand-brown: var(--brand-brown)`
+    - index.css contains `--color-charcoal: var(--charcoal)`
+    - index.css contains `.charcoal-texture` class definition
+    - index.css contains `feTurbulence` in the SVG data URI
+    - theme.ts contains `bg-brand-brown hover:bg-brand-brown-hover` (no `#8B5E3C` brackets)
+    - theme.ts does NOT contain `bg-[#` (no hardcoded hex brackets in PRIMARY_BUTTON_CLASS)
+    - `npm run build` succeeds
+  </acceptance_criteria>
+  <done>CSS variables registered, charcoal texture class created, PRIMARY_BUTTON_CLASS migrated to Tailwind utilities</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Tabs brand variant + filter button layout + WDL chart rounding</name>
+  <files>frontend/src/components/ui/tabs.tsx, frontend/src/components/filters/FilterPanel.tsx, frontend/src/components/charts/WDLBarChart.tsx</files>
+  <read_first>
+    - frontend/src/components/ui/tabs.tsx (current CVA variants and TabsTrigger className)
+    - frontend/src/components/filters/FilterPanel.tsx (current filter button layout)
+    - frontend/src/components/charts/WDLBarChart.tsx (current Bar radius props)
+    - frontend/src/components/ui/toggle-group.tsx (to confirm w-fit default and shrink-0 on items)
+  </read_first>
+  <action>
+**In frontend/src/components/ui/tabs.tsx (per D-09, D-10):**
+
+1. Add `brand` variant to `tabsListVariants` CVA:
+```typescript
+variants: {
+  variant: {
+    default: "bg-muted",
+    line: "gap-1 bg-transparent",
+    brand: "bg-charcoal gap-0",
+  },
+},
+```
+
+2. In `TabsTrigger`, add brand variant active state lines to the `cn(...)` call. Add a NEW string argument after the existing variant-specific lines:
+```typescript
+"group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent group-data-[variant=brand]/tabs-list:data-active:shadow-none",
+```
+
+**In frontend/src/components/filters/FilterPanel.tsx (per D-05, D-06):**
+
+3. Change Time Control button container from `flex flex-wrap gap-1` to `grid grid-cols-4 gap-1` — this makes 4 equal-width columns.
+
+4. Change Platform button container from `flex flex-wrap gap-1` to `grid grid-cols-2 gap-1` — this makes 2 equal-width columns.
+
+5. On each raw button element (both Time Control and Platform), remove `px-3` and `sm:px-2` padding classes. The grid handles width; just keep `rounded border h-11 sm:h-7 text-xs transition-colors` plus active/inactive state classes.
+
+6. On both `<ToggleGroup>` components (Rated and Opponent), add `className="w-full"`.
+
+7. On all `<ToggleGroupItem>` elements (6 total: 3 for Rated + 3 for Opponent), add `flex-1` to the existing className. Result: `className="min-h-11 sm:min-h-0 flex-1"`.
+
+**In frontend/src/components/charts/WDLBarChart.tsx (per D-07, D-08):**
+
+8. On the `win_pct` Bar component (first in stack, renders as bottom/leftmost in Recharts horizontal stacked bar), change `radius={[0, 0, 0, 0]}` to `radius={[4, 4, 0, 0]}`.
+   NOTE: In Recharts `layout="vertical"` stacked horizontal bars, the first declared Bar renders leftmost. For left-to-right stacking: leftmost bar needs `radius={[4, 4, 0, 0]}` (top-left, top-right corners = left edge in vertical layout). If visual verification shows this is wrong, swap — the goal is rounding on the outer edges only.
+
+9. On the `loss_pct` Bar component (last in stack, renders as rightmost), change `radius={[0, 0, 0, 0]}` to `radius={[0, 0, 4, 4]}`.
+
+10. Add a comment above the Bar components:
+```typescript
+{/* Radius on outermost bars only — Recharts 2.x doesn't support BarStack (3.x feature).
+    If a segment is 0%, its radius has no visual effect since Recharts skips zero-value bars. */}
+```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npx tsc --noEmit 2>&1 | head -20 && npm test 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - tabs.tsx contains `brand: "bg-charcoal gap-0"` in the variants object
+    - tabs.tsx contains `group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown`
+    - tabs.tsx contains `group-data-[variant=brand]/tabs-list:data-active:text-white`
+    - FilterPanel.tsx contains `grid grid-cols-4 gap-1` (Time Control container)
+    - FilterPanel.tsx contains `grid grid-cols-2 gap-1` (Platform container)
+    - FilterPanel.tsx ToggleGroup elements have `className="w-full"` (grep for `className="w-full"`)
+    - FilterPanel.tsx ToggleGroupItem elements have `flex-1` in className
+    - WDLBarChart.tsx win_pct Bar has `radius={[4, 4, 0, 0]}`
+    - WDLBarChart.tsx loss_pct Bar has `radius={[0, 0, 4, 4]}`
+    - `npm test` passes
+  </acceptance_criteria>
+  <done>Tabs brand variant available for use, filter buttons fill sidebar width, WDL chart bars have rounded outer corners</done>
+</task>
+
+</tasks>
+
+<verification>
+- `cd frontend && npm run build` succeeds with no TypeScript errors
+- `cd frontend && npm test` passes (all existing tests green)
+- `grep 'bg-brand-brown' frontend/src/lib/theme.ts` returns the updated PRIMARY_BUTTON_CLASS
+- `grep 'charcoal-texture' frontend/src/index.css` returns the CSS class
+- `grep 'brand.*bg-charcoal' frontend/src/components/ui/tabs.tsx` returns the brand variant
+- `grep 'grid grid-cols-4' frontend/src/components/filters/FilterPanel.tsx` returns the time control grid
+</verification>
+
+<success_criteria>
+- CSS variables (brand-brown, charcoal) registered in index.css and available as Tailwind utilities
+- PRIMARY_BUTTON_CLASS uses bg-brand-brown (no hardcoded hex)
+- charcoal-texture CSS class defined with feTurbulence noise overlay
+- Tabs brand variant ready for use on pages
+- Filter buttons span full width in grid layout
+- WDL bar chart has rounded outer corners
+- All existing tests pass, build succeeds
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/34-theme-improvements/34-01-SUMMARY.md`
+</output>

--- a/.planning/phases/34-theme-improvements/34-01-SUMMARY.md
+++ b/.planning/phases/34-theme-improvements/34-01-SUMMARY.md
@@ -1,0 +1,118 @@
+---
+phase: 34-theme-improvements
+plan: 01
+subsystem: ui
+tags: [tailwind, css-variables, react, typescript, recharts]
+
+# Dependency graph
+requires: []
+provides:
+  - CSS custom properties for brand-brown, brand-brown-hover, charcoal, sidebar-bg in :root
+  - Tailwind utility classes bg-brand-brown, bg-charcoal, etc. via @theme inline
+  - charcoal-texture CSS class with SVG feTurbulence noise overlay
+  - Tabs brand variant with brand-brown active state for use in Plan 02
+  - Filter buttons in equal-width grid layout spanning full sidebar width
+  - Rounded outer corners on WDL stacked bar chart
+  - PRIMARY_BUTTON_CLASS migrated to Tailwind utilities (no hardcoded hex)
+affects: [34-02-theme-improvements]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "CSS custom properties in :root, registered as Tailwind utilities in @theme inline"
+    - "charcoal-texture class with pseudo-element SVG noise overlay for textured backgrounds"
+    - "CVA variant pattern extended with brand variant for tabs"
+
+key-files:
+  created: []
+  modified:
+    - frontend/src/index.css
+    - frontend/src/lib/theme.ts
+    - frontend/src/components/ui/tabs.tsx
+    - frontend/src/components/filters/FilterPanel.tsx
+    - frontend/src/components/charts/WDLBarChart.tsx
+
+key-decisions:
+  - "CSS variables defined in :root and exposed via @theme inline block (not hardcoded in Tailwind config)"
+  - "charcoal-texture uses ::before pseudo-element for noise overlay so children don't need z-index workarounds — only direct children get z-index:1"
+  - "Filter buttons use CSS grid (grid-cols-4/grid-cols-2) not flex-wrap for guaranteed equal-width columns"
+  - "Recharts WDL bar radius on outermost bars only — Recharts 2.x lacks BarStack; zero-value bars have no visual effect"
+
+patterns-established:
+  - "Brand color constants: define in :root, register in @theme inline, reference as Tailwind utilities"
+  - "Tabs brand variant: bg-charcoal container with group-data-[variant=brand] active state selectors"
+
+requirements-completed: [THEME-01, THEME-03, THEME-04, THEME-05]
+
+# Metrics
+duration: 10min
+completed: 2026-03-28
+---
+
+# Phase 34 Plan 01: Theme Infrastructure Summary
+
+**CSS variable foundation with brand-brown/charcoal Tailwind utilities, charcoal-texture noise class, tabs brand variant, grid-based filter buttons, and rounded WDL chart bars**
+
+## Performance
+
+- **Duration:** ~10 min
+- **Started:** 2026-03-28T10:48:00Z
+- **Completed:** 2026-03-28T10:58:06Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+- Added `--brand-brown`, `--brand-brown-hover`, `--charcoal`, `--sidebar-bg` CSS custom properties and registered as Tailwind utilities so components can use `bg-brand-brown`, `bg-charcoal`, etc.
+- Created `.charcoal-texture` CSS class with SVG `feTurbulence` noise overlay via `::before` pseudo-element for textured dark backgrounds
+- Migrated `PRIMARY_BUTTON_CLASS` from hardcoded `bg-[#8B5E3C]` hex to `bg-brand-brown` Tailwind utility
+- Added `brand` variant to Tabs component with charcoal background and brand-brown active trigger state
+- Changed Time Control (4 buttons) and Platform (2 buttons) filter containers from `flex flex-wrap` to CSS grid for equal-width full-width layout
+- Added `w-full` and `flex-1` to Rated and Opponent ToggleGroup/ToggleGroupItem for consistent full-width distribution
+- Rounded outer corners of WDL stacked bar chart (`win_pct` radius `[4,4,0,0]`, `loss_pct` radius `[0,0,4,4]`)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: CSS variable foundation + charcoal texture + theme.ts migration** - `73fbc4c` (feat)
+2. **Task 2: Tabs brand variant + filter grid layout + WDL chart rounding** - `5d158dd` (feat)
+
+**Plan metadata:** (final docs commit — see below)
+
+## Files Created/Modified
+- `frontend/src/index.css` - Added brand-brown/charcoal CSS variables, @theme inline entries, charcoal-texture component class
+- `frontend/src/lib/theme.ts` - PRIMARY_BUTTON_CLASS migrated to Tailwind utilities
+- `frontend/src/components/ui/tabs.tsx` - Added brand variant to TabsList CVA and brand active state to TabsTrigger
+- `frontend/src/components/filters/FilterPanel.tsx` - Grid layout for Time Control/Platform buttons, w-full/flex-1 on ToggleGroups
+- `frontend/src/components/charts/WDLBarChart.tsx` - Rounded outer corners on win_pct and loss_pct bars
+
+## Decisions Made
+- CSS variables in `:root`, exposed via `@theme inline` — consistent with how existing shadcn variables work in the project
+- `charcoal-texture` uses `::before` pseudo-element so children don't need individual z-index; only direct children get `z-index: 1`
+- Grid layout for filter buttons over flex-wrap — guarantees equal-width columns regardless of label length
+- Recharts outer-bar-only rounding — Recharts 2.x doesn't support BarStack; zero-value bars silently have no visual effect
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- All theme infrastructure is in place for Plan 02 to use `charcoal-texture`, `bg-brand-brown`, and the `brand` tabs variant on page-level components
+- Build passes, all 38 tests green
+
+## Self-Check: PASSED
+
+All files present and commits verified:
+- `73fbc4c` feat(34-01): CSS variable foundation + charcoal texture + theme.ts migration
+- `5d158dd` feat(34-01): tabs brand variant, filter grid layout, WDL chart rounding
+
+---
+*Phase: 34-theme-improvements*
+*Completed: 2026-03-28*

--- a/.planning/phases/34-theme-improvements/34-02-PLAN.md
+++ b/.planning/phases/34-theme-improvements/34-02-PLAN.md
@@ -1,0 +1,259 @@
+---
+phase: 34-theme-improvements
+plan: 02
+type: execute
+wave: 2
+depends_on: ["34-01"]
+files_modified:
+  - frontend/src/App.tsx
+  - frontend/src/pages/Dashboard.tsx
+  - frontend/src/pages/Openings.tsx
+  - frontend/src/pages/Endgames.tsx
+  - frontend/src/pages/Import.tsx
+autonomous: false
+
+requirements:
+  - THEME-02
+  - THEME-05
+
+must_haves:
+  truths:
+    - "Content containers on Endgames, Dashboard, Openings, and Import pages have charcoal background with noise texture"
+    - "Collapsible sections on Dashboard, Openings, and Endgames are unified charcoal containers (header + content in one block)"
+    - "Active subtabs on Endgames and Openings pages use brand brown background with white text"
+    - "Desktop nav header has no bottom border and active tab has lighter background"
+    - "Logo and FlawChess text link to homepage on both desktop and mobile"
+  artifacts:
+    - path: "frontend/src/App.tsx"
+      provides: "Updated NavHeader with active tab highlight, no border, logo link; updated MobileHeader with no border, brand link"
+      contains: "bg-white/10"
+    - path: "frontend/src/pages/Dashboard.tsx"
+      provides: "Collapsible sections wrapped in charcoal-texture containers"
+      contains: "charcoal-texture"
+    - path: "frontend/src/pages/Openings.tsx"
+      provides: "Collapsible sections in charcoal-texture, subtabs using brand variant"
+      contains: "charcoal-texture"
+    - path: "frontend/src/pages/Endgames.tsx"
+      provides: "Content sections in charcoal-texture, subtabs using brand variant"
+      contains: "charcoal-texture"
+    - path: "frontend/src/pages/Import.tsx"
+      provides: "Import cards/containers with charcoal-texture"
+      contains: "charcoal-texture"
+  key_links:
+    - from: "frontend/src/pages/Endgames.tsx"
+      to: "frontend/src/components/ui/tabs.tsx"
+      via: "TabsList variant='brand' prop"
+      pattern: 'variant="brand"'
+    - from: "frontend/src/pages/Dashboard.tsx"
+      to: "frontend/src/index.css"
+      via: "charcoal-texture CSS class"
+      pattern: "charcoal-texture"
+---
+
+<objective>
+Apply theme infrastructure to all pages — charcoal containers, collapsible styling, nav header polish, and subtab highlighting.
+
+Purpose: With CSS variables, texture class, and tabs variant from Plan 01 in place, this plan applies them across all pages to achieve the visual consistency goals of Phase 34.
+
+Output: All target pages updated with charcoal containers, unified collapsible styling, nav header improvements, and brand subtab highlighting. Visual checkpoint confirms the result.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/34-theme-improvements/34-CONTEXT.md
+@.planning/phases/34-theme-improvements/34-RESEARCH.md
+@.planning/phases/34-theme-improvements/34-01-SUMMARY.md
+
+<interfaces>
+<!-- From Plan 01 — CSS classes and component variants available for use -->
+
+From frontend/src/index.css (created in Plan 01):
+```css
+/* CSS variables available as Tailwind utilities: */
+/* bg-brand-brown, hover:bg-brand-brown-hover, text-brand-brown */
+/* bg-charcoal, text-charcoal */
+/* bg-sidebar-bg */
+
+/* CSS class for charcoal container with noise texture: */
+/* .charcoal-texture — sets position:relative, overflow:hidden, bg charcoal, ::before noise overlay */
+/* Children get position:relative, z-index:1 automatically via .charcoal-texture > * rule */
+```
+
+From frontend/src/components/ui/tabs.tsx (updated in Plan 01):
+```typescript
+// TabsList now accepts variant="brand" — renders bg-charcoal tab bar
+// TabsTrigger with brand variant: active state = bg-brand-brown + text-white
+// Usage: <TabsList variant="brand" className="w-full">
+```
+
+From frontend/src/App.tsx (current NavHeader — lines 75-112):
+```typescript
+// NavHeader: <header className="hidden sm:block border-b border-border bg-background px-6 overflow-hidden">
+// Active tab: 'border-b-2 border-primary rounded-none font-medium'
+// Inactive tab: 'rounded-none text-muted-foreground'
+// Logo img + "FlawChess" span are NOT links currently
+```
+
+From frontend/src/App.tsx (current MobileHeader — lines 116-142):
+```typescript
+// MobileHeader: <header className="... border-b border-border bg-background overflow-hidden">
+// Brand span with logo img — NOT a link currently
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Navigation header polish + charcoal containers on all pages</name>
+  <files>frontend/src/App.tsx, frontend/src/pages/Dashboard.tsx, frontend/src/pages/Openings.tsx, frontend/src/pages/Endgames.tsx, frontend/src/pages/Import.tsx</files>
+  <read_first>
+    - frontend/src/App.tsx (NavHeader and MobileHeader implementations)
+    - frontend/src/pages/Dashboard.tsx (collapsible sections and their current styling)
+    - frontend/src/pages/Openings.tsx (collapsible sections, sidebar, subtab usage)
+    - frontend/src/pages/Endgames.tsx (content sections, subtab usage)
+    - frontend/src/pages/Import.tsx (card/container elements)
+  </read_first>
+  <action>
+**Navigation header (App.tsx) per D-11, D-12, D-13:**
+
+1. **NavHeader** — Remove `border-b border-border` from the `<header>` className (D-12). Keep `bg-background`.
+
+2. **NavHeader active tab** — Change active Button className from `'border-b-2 border-primary rounded-none font-medium'` to `'self-stretch rounded-none font-medium bg-white/10'`. This replaces the underline with a subtle full-height background highlight (D-11).
+
+3. **NavHeader logo link** — Wrap the `<img>` and `<span>FlawChess</span>` in a `<Link to="/">` with `className="flex items-center gap-1"` and `data-testid="nav-home"` (D-13). Remove the gap-1 from the parent div since the Link now provides it.
+
+4. **MobileHeader** — Remove `border-b border-border` from the `<header>` className (D-12).
+
+5. **MobileHeader brand link** — Wrap the entire `<span data-testid="mobile-header-brand" ...>` content in a `<Link to="/" data-testid="nav-home-mobile">`. Move the existing className from the span to the Link. Import `Link` is already imported in App.tsx.
+
+**Charcoal containers on Dashboard.tsx (per D-03, D-14, D-15):**
+
+6. Wrap each `<Collapsible>` block in a `<div className="charcoal-texture rounded-md p-2">`. There are 3 collapsible sections (Position filter, Position bookmarks, More filters).
+
+7. Remove any existing background classes from the `CollapsibleTrigger` Button elements (e.g., remove `bg-muted/50` if present). The trigger buttons should use `variant="ghost"` with no additional background — the charcoal container provides the background.
+
+**Charcoal containers on Openings.tsx (per D-03, D-14, D-15, D-09, D-10):**
+
+8. Wrap each `<Collapsible>` block in a `<div className="charcoal-texture rounded-md p-2">`.
+
+9. Remove background classes from CollapsibleTrigger buttons.
+
+10. Find the `<TabsList>` component and change it to use `variant="brand"` and ensure `className="w-full"`. This activates the brand brown active subtab (D-09, D-10).
+
+**Charcoal containers on Endgames.tsx (per D-03, D-09, D-10):**
+
+11. Apply `charcoal-texture rounded-md` to endgame statistics sections and the endgame concept accordion container per D-03.
+
+12. Find the `<TabsList>` and change to `variant="brand"` with `className="w-full"` (D-09, D-10).
+
+**Charcoal containers on Import.tsx (per D-03):**
+
+13. Apply `charcoal-texture rounded-md p-4` to import page card/container elements. Identify the main content cards and add the class. Remove any existing card-like background classes they replace.
+
+**IMPORTANT per D-04:** The sidebar filter panel does NOT get charcoal treatment. Only content sections. The sidebar uses flat `bg-sidebar-bg` (#171513) background — verify the sidebar panels on Openings and Endgames pages do NOT receive charcoal-texture.
+
+**Mobile considerations:** Per CLAUDE.md, check for duplicate desktop/mobile markup in each page. Collapsibles used in mobile layouts should also get charcoal-texture wrapping. The FilterPanel component itself is shared (no separate mobile variant needed).
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build 2>&1 | tail -5 && npm test 2>&1 | tail -10</automated>
+  </verify>
+  <acceptance_criteria>
+    - App.tsx NavHeader `<header>` does NOT contain `border-b border-border`
+    - App.tsx NavHeader active tab className contains `bg-white/10`
+    - App.tsx NavHeader contains `<Link to="/"` wrapping logo/brand (grep for `to="/" data-testid="nav-home"`)
+    - App.tsx MobileHeader `<header>` does NOT contain `border-b border-border`
+    - App.tsx MobileHeader contains `<Link to="/"` wrapping brand
+    - Dashboard.tsx contains `charcoal-texture` (at least 3 instances for 3 collapsibles)
+    - Openings.tsx contains `charcoal-texture` (collapsible wrappers)
+    - Openings.tsx contains `variant="brand"` on TabsList
+    - Endgames.tsx contains `charcoal-texture`
+    - Endgames.tsx contains `variant="brand"` on TabsList
+    - Import.tsx contains `charcoal-texture`
+    - `npm run build` succeeds
+    - `npm test` passes
+  </acceptance_criteria>
+  <done>All pages updated with charcoal containers, nav header polished, brand subtabs active, build and tests pass</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Visual verification of all theme changes</name>
+  <what-built>
+Complete theme overhaul across the application:
+- CSS variables for brand brown and charcoal registered as Tailwind utilities
+- Charcoal containers with subtle noise texture on Dashboard, Openings, Endgames, Import pages
+- Unified collapsible sections (header + content in one charcoal block)
+- Filter buttons spanning full sidebar width in grid layout
+- Rounded corners on Recharts WDL bar chart
+- Brand brown active subtab highlighting on Openings and Endgames
+- Nav header: no border, lighter active tab background, logo links to homepage
+  </what-built>
+  <how-to-verify>
+Run `cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run dev` and check each page:
+
+1. **Dashboard page** (`/openings` then navigate to dashboard collapsibles):
+   - Collapsible sections have charcoal background with subtle noise texture
+   - Expanding a collapsible shows content inside the same charcoal container
+   - Filter buttons (Time Control) fill sidebar width in 4 equal columns
+   - Platform buttons fill width in 2 equal columns
+   - ToggleGroup items (Rated, Opponent) fill width equally
+
+2. **Openings page** (`/openings`):
+   - Sidebar collapsibles wrapped in charcoal containers
+   - Active subtab has brand brown (#8B5E3C) background with white text
+   - Subtab bar itself has charcoal background
+   - WDL bar chart (if visible via saved bookmarks) has rounded outer corners
+
+3. **Endgames page** (`/endgames`):
+   - Content sections have charcoal background with noise texture
+   - Active subtab has brand brown background with white text
+   - Endgame concept accordion has charcoal background
+
+4. **Import page** (`/import`):
+   - Import cards/containers have charcoal background with noise texture
+
+5. **Navigation header** (desktop):
+   - No white border at bottom of header
+   - Active tab has subtle lighter background (not underline)
+   - Logo and "FlawChess" text link to homepage (click to verify)
+
+6. **Mobile view** (resize browser to <640px or use dev tools):
+   - No border at top of mobile header
+   - Brand name links to homepage
+   - Bottom nav still works
+   - Charcoal containers look correct on narrow screens
+   - Filter panel in mobile collapsible has full-width buttons
+
+7. **Button colors**: Verify primary buttons (e.g., on Import page) still show brown color correctly (the hex-to-CSS-variable migration didn't break styling)
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe specific issues to fix</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- `cd frontend && npm run build` — zero errors
+- `cd frontend && npm test` — all tests pass
+- Visual inspection confirms charcoal containers, filter layout, tab highlighting, nav changes
+- No regressions in existing functionality
+</verification>
+
+<success_criteria>
+- All 5 target pages show charcoal containers where specified (D-03)
+- Sidebar does NOT have charcoal (D-04)
+- Collapsibles are unified containers (D-15)
+- Subtabs use brand brown active state (D-09)
+- Nav header has no border (D-12), active highlight (D-11), logo link (D-13)
+- User approves visual appearance
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/34-theme-improvements/34-02-SUMMARY.md`
+</output>

--- a/.planning/phases/34-theme-improvements/34-02-SUMMARY.md
+++ b/.planning/phases/34-theme-improvements/34-02-SUMMARY.md
@@ -2,26 +2,26 @@
 phase: 34-theme-improvements
 plan: 02
 subsystem: ui
-tags: [tailwind, css-variables, react, typescript, navigation, theme]
+tags: [tailwind, css, react, charcoal-texture, theme, navigation]
 
-# Dependency graph
 requires:
-  - 34-01 (CSS vars, charcoal-texture class, tabs brand variant)
+  - phase: 34-01
+    provides: CSS variables, charcoal-texture class, tabs brand variant, filter grid layout
 provides:
-  - Charcoal containers with noise texture on Dashboard, Openings, Endgames, Import pages
-  - Collapsible sections unified as charcoal containers (header + content in one block)
-  - Brand brown active subtab highlighting on Openings and Endgames (variant="brand")
-  - Nav header without bottom border, active tab with bg-white/10 highlight
-  - Logo and FlawChess text link to homepage (desktop and mobile)
-affects: []
+  - Charcoal containers on all pages (Dashboard, Openings, Endgames, Import, GlobalStats)
+  - Brand brown (#6C4328) active subtab highlighting
+  - Nav header polish (no border, full-height active tab, logo link)
+  - Game cards with charcoal texture
+  - GlobalStats sidebar layout with filtered FilterPanel
+  - Consistent button/toggle styling (#171717 inactive, #262626 hover, primary active)
+affects: [all-pages, navigation, game-cards, filter-panel]
 
-# Tech tracking
 tech-stack:
   added: []
   patterns:
-    - "charcoal-texture applied as wrapper div around Collapsible blocks for unified dark container look"
-    - "variant='brand' on TabsList activates brand-brown active subtab from Plan 01 infrastructure"
-    - "bg-white/10 for active nav tab — subtle full-height background instead of underline"
+    - "charcoal-texture CSS class on content containers, game cards, board controls, tab bars"
+    - "Collapsible pattern: charcoal-texture wrapper, ghost trigger with hover:bg-charcoal-hover!, border separator"
+    - "FilterPanel visibleFilters prop for page-specific filter subsets"
 
 key-files:
   created: []
@@ -31,116 +31,97 @@ key-files:
     - frontend/src/pages/Openings.tsx
     - frontend/src/pages/Endgames.tsx
     - frontend/src/pages/Import.tsx
+    - frontend/src/pages/GlobalStats.tsx
+    - frontend/src/components/results/GameCard.tsx
+    - frontend/src/components/board/BoardControls.tsx
+    - frontend/src/components/ui/tabs.tsx
+    - frontend/src/components/ui/toggle.tsx
+    - frontend/src/components/filters/FilterPanel.tsx
+    - frontend/src/index.css
 
 key-decisions:
-  - "Nav active tab uses bg-white/10 (subtle lighter background) instead of border-b-2 underline per D-11"
-  - "Mobile brand wrapped in Link component (not span) to enable homepage navigation per D-13"
-  - "charcoal-texture wraps each Collapsible block as a sibling div (not the Collapsible itself) for correct rounded container rendering"
-  - "Import platform cards: border removed, replaced with charcoal-texture providing visual distinction"
-  - "Endgames chart sections individually wrapped in charcoal-texture to avoid nesting issues with chart components"
+  - "Charcoal darkened to #161412 for better contrast against dark mode background"
+  - "Subtab active color #6C4328 (darker brown) with !important to override default Tailwind active styles"
+  - "Toggle active state uses bg-primary/text-primary-foreground matching raw filter buttons"
+  - "Inactive buttons/toggles use #171717 bg, #262626 hover — no transparent backgrounds"
+  - "GlobalStats filters reduced to Platform + Recency via visibleFilters prop"
+  - "Board controls and subtab bar use charcoal-texture class (not just bg-charcoal) for noise effect"
+  - "Nav active tab uses items-stretch layout for full header height coverage"
+
+patterns-established:
+  - "charcoal-texture class on all content containers, game cards, board controls, tab bars"
+  - "Collapsible: charcoal-texture rounded-md wrapper, ghost trigger hover:bg-charcoal-hover!, border-t border-border/20 separator"
+  - "FilterPanel visibleFilters prop for page-specific filter subsets"
 
 requirements-completed: [THEME-02, THEME-05]
 
-# Metrics
-duration: 5min
+duration: 45min
 completed: 2026-03-28
 ---
 
-# Phase 34 Plan 02: Theme Application Summary
+# Plan 02: Page-Level Theme Application Summary
 
-**Charcoal containers on all pages, brand subtab highlighting, nav header polish — visual consistency across Dashboard, Openings, Endgames, and Import**
+**Charcoal containers, brand subtabs, nav polish, game card styling applied across all pages with iterative visual verification refinements**
 
 ## Performance
 
-- **Duration:** ~5 min
-- **Started:** 2026-03-28T11:01:28Z
-- **Completed:** 2026-03-28T11:06:30Z
-- **Tasks:** 1 of 2 (Task 2 is human-verify checkpoint)
-- **Files modified:** 5
+- **Duration:** ~45 min (including 6 rounds of visual verification)
+- **Tasks:** 2/2 (auto task + visual checkpoint approved)
+- **Files modified:** 12
 
 ## Accomplishments
-
-### Task 1: Navigation header polish + charcoal containers on all pages (committed `47dd209`)
-
-**App.tsx (NavHeader + MobileHeader):**
-- Removed `border-b border-border` from both NavHeader and MobileHeader `<header>` elements (D-12)
-- Changed active tab className from `border-b-2 border-primary rounded-none font-medium` to `self-stretch rounded-none font-medium bg-white/10` (D-11)
-- Wrapped logo img + "FlawChess" span in `<Link to="/" data-testid="nav-home">` on desktop (D-13)
-- Replaced `<span data-testid="mobile-header-brand">` with `<Link to="/" data-testid="nav-home-mobile">` on mobile (D-13)
-
-**Dashboard.tsx:**
-- Wrapped all 3 Collapsibles (Position filter, Position bookmarks, More filters) in `<div className="charcoal-texture rounded-md p-2">` (D-03, D-14, D-15)
-
-**Openings.tsx:**
-- Wrapped desktop Position bookmarks Collapsible in charcoal-texture container; removed `bg-muted/50 hover:bg-muted! border border-border/40` from trigger button
-- Wrapped desktop More filters Collapsible in charcoal-texture container; removed `bg-muted/50` styling from trigger
-- Wrapped mobile More filters and Position bookmarks Collapsibles in charcoal-texture containers; updated trigger button classes
-- Added `variant="brand"` to both desktop and mobile `<TabsList>` (D-09, D-10)
-
-**Endgames.tsx:**
-- Added `variant="brand"` to both desktop and mobile `<TabsList>` (D-09, D-10)
-- Changed Accordion AccordionItem from `border rounded-md border-border px-4` to `charcoal-texture rounded-md px-4`
-- Wrapped each chart section (EndgamePerformanceSection, EndgameConvRecovTimelineChart, EndgameWDLChart, EndgameConvRecovChart, EndgameTimelineChart) in `<div className="charcoal-texture rounded-md">` (D-03)
-
-**Import.tsx:**
-- Changed both platform card divs (chess.com and lichess) from `rounded-md border px-3 py-2` to `charcoal-texture space-y-2 rounded-md px-3 py-2` (D-03)
+- All pages use charcoal-texture containers for content sections, charts, and cards
+- Nav header: no border, full-height active tab highlight (items-stretch), logo links to homepage
+- Brand brown (#6C4328) active subtabs on Openings and Endgames
+- Game cards use charcoal-texture background with subtle border
+- Board controls bar and subtab bar have charcoal texture noise effect
+- GlobalStats restructured to sidebar layout with Platform + Recency filters only
+- Consistent button/toggle styling: #171717 inactive, #262626 hover, primary active
+- Recency filter moved to top of FilterPanel
+- WDL bars and MoveExplorer in charcoal containers on Openings
 
 ## Task Commits
 
-1. **Task 1: Nav header polish + charcoal containers on all pages** - `47dd209` (feat)
+1. **Task 1: Nav header + charcoal containers** - `47dd209` (feat)
+2. **Visual fixes round 1** - `3b62f07` (fix)
+3. **Visual fixes round 2** - `607c2cb` (fix)
+4. **Visual fixes round 3** - `4779b05` (fix)
+5. **Game cards charcoal** - `06a7987` (fix)
+6. **MoveExplorer charcoal** - `f3c7f39` (fix)
+7. **Filter button bg** - `bec9ee3` (fix)
+8. **WDL bar charcoal** - `1b209c7` (fix)
 
 ## Files Created/Modified
-
-- `frontend/src/App.tsx` - NavHeader border removed, active tab bg-white/10, logo+brand wrapped in Link; MobileHeader border removed, brand wrapped in Link
-- `frontend/src/pages/Dashboard.tsx` - All 3 Collapsibles wrapped in charcoal-texture containers
-- `frontend/src/pages/Openings.tsx` - Collapsibles in charcoal-texture (desktop+mobile), bg-muted/50 removed from triggers, TabsList variant="brand" (desktop+mobile)
-- `frontend/src/pages/Endgames.tsx` - TabsList variant="brand" (desktop+mobile), Accordion + chart sections in charcoal-texture
-- `frontend/src/pages/Import.tsx` - Platform cards use charcoal-texture (border removed)
+- `frontend/src/App.tsx` - Nav header full-height active tab, logo link
+- `frontend/src/pages/Dashboard.tsx` - Collapsibles in charcoal, Played as/Piece filter in charcoal
+- `frontend/src/pages/Openings.tsx` - Collapsibles, subtabs brand variant, WDL bars + MoveExplorer in charcoal
+- `frontend/src/pages/Endgames.tsx` - Chart sections with padding, filters in charcoal, brand subtabs
+- `frontend/src/pages/Import.tsx` - Platform cards charcoal
+- `frontend/src/pages/GlobalStats.tsx` - Sidebar layout, charts in charcoal, reduced filters
+- `frontend/src/components/results/GameCard.tsx` - charcoal-texture background
+- `frontend/src/components/board/BoardControls.tsx` - charcoal-texture bar
+- `frontend/src/components/ui/tabs.tsx` - Brand variant uses charcoal-texture, active color #6C4328
+- `frontend/src/components/ui/toggle.tsx` - Primary active state, #171717 inactive bg
+- `frontend/src/components/filters/FilterPanel.tsx` - visibleFilters prop, recency first, #171717 inactive bg
+- `frontend/src/index.css` - Charcoal #161412, brand-brown-active, charcoal-hover variables
 
 ## Decisions Made
-
-- Nav active tab uses `bg-white/10` (subtle lighter background) per D-11 — replaces `border-b-2` underline
-- Mobile header brand wrapped in `<Link>` component (not span) per D-13
-- Import platform cards: border removed in favor of charcoal-texture visual separation
-- Endgames: each chart section wrapped individually to allow conditional rendering to work correctly
+- Charcoal darkened twice through visual verification (#2A2520 → #1C1917 → #161412)
+- Switched from bg-charcoal to charcoal-texture class for noise effect on controls/tabs
+- Added !important to brand variant active styles to override Tailwind defaults
+- GlobalStats restructured from top-bar to sidebar layout matching Endgames
 
 ## Deviations from Plan
-
-None - plan executed exactly as written.
+Multiple iterative refinements through visual verification checkpoint — charcoal color, subtab color, toggle styling, filter layout, and container coverage all adjusted based on user feedback.
 
 ## Issues Encountered
-
-None.
+- `bg-charcoal` only sets background color, not noise texture — resolved by using `charcoal-texture` CSS class
+- Brand variant active styles overridden by default Tailwind active styles — resolved with `!important`
 
 ## User Setup Required
-
-None.
-
-## Current Status
-
-Paused at **Task 2: Visual verification of all theme changes** (checkpoint:human-verify).
-
-Run `cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run dev` and visually verify:
-1. Dashboard collapsibles have charcoal background with noise texture
-2. Openings active subtab has brand brown (#8B5E3C) background with white text
-3. Endgames active subtab has brand brown background
-4. Import platform cards have charcoal background
-5. Nav header has no white border at bottom; active tab shows lighter background (not underline)
-6. Logo and "FlawChess" text link to homepage on desktop and mobile
-
-## Known Stubs
-
 None.
 
 ## Self-Check: PASSED
-
-Files verified:
-- `frontend/src/App.tsx` — exists, contains `bg-white/10`, `to="/" data-testid="nav-home"`, no `border-b border-border` in header
-- `frontend/src/pages/Dashboard.tsx` — exists, contains 3x `charcoal-texture`
-- `frontend/src/pages/Openings.tsx` — exists, contains 4x `charcoal-texture`, 2x `variant="brand"`
-- `frontend/src/pages/Endgames.tsx` — exists, contains 6x `charcoal-texture`, 2x `variant="brand"`
-- `frontend/src/pages/Import.tsx` — exists, contains 2x `charcoal-texture`
-- Commit `47dd209` verified in git log
 
 ---
 *Phase: 34-theme-improvements*

--- a/.planning/phases/34-theme-improvements/34-02-SUMMARY.md
+++ b/.planning/phases/34-theme-improvements/34-02-SUMMARY.md
@@ -1,0 +1,147 @@
+---
+phase: 34-theme-improvements
+plan: 02
+subsystem: ui
+tags: [tailwind, css-variables, react, typescript, navigation, theme]
+
+# Dependency graph
+requires:
+  - 34-01 (CSS vars, charcoal-texture class, tabs brand variant)
+provides:
+  - Charcoal containers with noise texture on Dashboard, Openings, Endgames, Import pages
+  - Collapsible sections unified as charcoal containers (header + content in one block)
+  - Brand brown active subtab highlighting on Openings and Endgames (variant="brand")
+  - Nav header without bottom border, active tab with bg-white/10 highlight
+  - Logo and FlawChess text link to homepage (desktop and mobile)
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "charcoal-texture applied as wrapper div around Collapsible blocks for unified dark container look"
+    - "variant='brand' on TabsList activates brand-brown active subtab from Plan 01 infrastructure"
+    - "bg-white/10 for active nav tab — subtle full-height background instead of underline"
+
+key-files:
+  created: []
+  modified:
+    - frontend/src/App.tsx
+    - frontend/src/pages/Dashboard.tsx
+    - frontend/src/pages/Openings.tsx
+    - frontend/src/pages/Endgames.tsx
+    - frontend/src/pages/Import.tsx
+
+key-decisions:
+  - "Nav active tab uses bg-white/10 (subtle lighter background) instead of border-b-2 underline per D-11"
+  - "Mobile brand wrapped in Link component (not span) to enable homepage navigation per D-13"
+  - "charcoal-texture wraps each Collapsible block as a sibling div (not the Collapsible itself) for correct rounded container rendering"
+  - "Import platform cards: border removed, replaced with charcoal-texture providing visual distinction"
+  - "Endgames chart sections individually wrapped in charcoal-texture to avoid nesting issues with chart components"
+
+requirements-completed: [THEME-02, THEME-05]
+
+# Metrics
+duration: 5min
+completed: 2026-03-28
+---
+
+# Phase 34 Plan 02: Theme Application Summary
+
+**Charcoal containers on all pages, brand subtab highlighting, nav header polish — visual consistency across Dashboard, Openings, Endgames, and Import**
+
+## Performance
+
+- **Duration:** ~5 min
+- **Started:** 2026-03-28T11:01:28Z
+- **Completed:** 2026-03-28T11:06:30Z
+- **Tasks:** 1 of 2 (Task 2 is human-verify checkpoint)
+- **Files modified:** 5
+
+## Accomplishments
+
+### Task 1: Navigation header polish + charcoal containers on all pages (committed `47dd209`)
+
+**App.tsx (NavHeader + MobileHeader):**
+- Removed `border-b border-border` from both NavHeader and MobileHeader `<header>` elements (D-12)
+- Changed active tab className from `border-b-2 border-primary rounded-none font-medium` to `self-stretch rounded-none font-medium bg-white/10` (D-11)
+- Wrapped logo img + "FlawChess" span in `<Link to="/" data-testid="nav-home">` on desktop (D-13)
+- Replaced `<span data-testid="mobile-header-brand">` with `<Link to="/" data-testid="nav-home-mobile">` on mobile (D-13)
+
+**Dashboard.tsx:**
+- Wrapped all 3 Collapsibles (Position filter, Position bookmarks, More filters) in `<div className="charcoal-texture rounded-md p-2">` (D-03, D-14, D-15)
+
+**Openings.tsx:**
+- Wrapped desktop Position bookmarks Collapsible in charcoal-texture container; removed `bg-muted/50 hover:bg-muted! border border-border/40` from trigger button
+- Wrapped desktop More filters Collapsible in charcoal-texture container; removed `bg-muted/50` styling from trigger
+- Wrapped mobile More filters and Position bookmarks Collapsibles in charcoal-texture containers; updated trigger button classes
+- Added `variant="brand"` to both desktop and mobile `<TabsList>` (D-09, D-10)
+
+**Endgames.tsx:**
+- Added `variant="brand"` to both desktop and mobile `<TabsList>` (D-09, D-10)
+- Changed Accordion AccordionItem from `border rounded-md border-border px-4` to `charcoal-texture rounded-md px-4`
+- Wrapped each chart section (EndgamePerformanceSection, EndgameConvRecovTimelineChart, EndgameWDLChart, EndgameConvRecovChart, EndgameTimelineChart) in `<div className="charcoal-texture rounded-md">` (D-03)
+
+**Import.tsx:**
+- Changed both platform card divs (chess.com and lichess) from `rounded-md border px-3 py-2` to `charcoal-texture space-y-2 rounded-md px-3 py-2` (D-03)
+
+## Task Commits
+
+1. **Task 1: Nav header polish + charcoal containers on all pages** - `47dd209` (feat)
+
+## Files Created/Modified
+
+- `frontend/src/App.tsx` - NavHeader border removed, active tab bg-white/10, logo+brand wrapped in Link; MobileHeader border removed, brand wrapped in Link
+- `frontend/src/pages/Dashboard.tsx` - All 3 Collapsibles wrapped in charcoal-texture containers
+- `frontend/src/pages/Openings.tsx` - Collapsibles in charcoal-texture (desktop+mobile), bg-muted/50 removed from triggers, TabsList variant="brand" (desktop+mobile)
+- `frontend/src/pages/Endgames.tsx` - TabsList variant="brand" (desktop+mobile), Accordion + chart sections in charcoal-texture
+- `frontend/src/pages/Import.tsx` - Platform cards use charcoal-texture (border removed)
+
+## Decisions Made
+
+- Nav active tab uses `bg-white/10` (subtle lighter background) per D-11 — replaces `border-b-2` underline
+- Mobile header brand wrapped in `<Link>` component (not span) per D-13
+- Import platform cards: border removed in favor of charcoal-texture visual separation
+- Endgames: each chart section wrapped individually to allow conditional rendering to work correctly
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None.
+
+## Current Status
+
+Paused at **Task 2: Visual verification of all theme changes** (checkpoint:human-verify).
+
+Run `cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run dev` and visually verify:
+1. Dashboard collapsibles have charcoal background with noise texture
+2. Openings active subtab has brand brown (#8B5E3C) background with white text
+3. Endgames active subtab has brand brown background
+4. Import platform cards have charcoal background
+5. Nav header has no white border at bottom; active tab shows lighter background (not underline)
+6. Logo and "FlawChess" text link to homepage on desktop and mobile
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+Files verified:
+- `frontend/src/App.tsx` — exists, contains `bg-white/10`, `to="/" data-testid="nav-home"`, no `border-b border-border` in header
+- `frontend/src/pages/Dashboard.tsx` — exists, contains 3x `charcoal-texture`
+- `frontend/src/pages/Openings.tsx` — exists, contains 4x `charcoal-texture`, 2x `variant="brand"`
+- `frontend/src/pages/Endgames.tsx` — exists, contains 6x `charcoal-texture`, 2x `variant="brand"`
+- `frontend/src/pages/Import.tsx` — exists, contains 2x `charcoal-texture`
+- Commit `47dd209` verified in git log
+
+---
+*Phase: 34-theme-improvements*
+*Completed: 2026-03-28*

--- a/.planning/phases/34-theme-improvements/34-CONTEXT.md
+++ b/.planning/phases/34-theme-improvements/34-CONTEXT.md
@@ -1,0 +1,120 @@
+# Phase 34: Theme Improvements - Context
+
+**Gathered:** 2026-03-28
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Centralize theme management and improve visual consistency across all pages. Covers: CSS variable migration for brand colors, charcoal container styling with noise texture, filter button spacing, WDL chart corner consistency, subtab highlighting, navigation header polish, and collapsible section styling.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Container Styling
+- **D-01:** Charcoal background with SVG feTurbulence noise texture applied to specific content sections — NOT full-page panels
+- **D-02:** Implementation via CSS variable + Tailwind utility class (e.g. `bg-charcoal`) — not a wrapper component
+- **D-03:** Charcoal containers apply to: endgame statistics sections, endgame concept accordion, game cards, bookmark cards, subtab navigation bar, import page cards/containers
+- **D-04:** Sidebar filter panel does NOT get a card container — uses flat background `#171513` (dark brown), distinct from main content background
+
+### Filter Button Layout
+- **D-05:** Filter buttons should be spaced horizontally across the full sidebar width — Claude's discretion on whether to use equal-width grid or flex-grow
+- **D-06:** Keep the two existing filter patterns separate (raw buttons for Time Control/Platform, ToggleGroup for Rated/Opponent) — just fix the spacing, don't unify
+
+### Chart Consistency
+- **D-07:** All WDL charts use rounded corners — apply rounded corners to Recharts `WDLBarChart` bars to match custom `WDLBar` and `EndgameWDLChart` components
+- **D-08:** Glass overlay stays on custom WDL bars only — do NOT add glass effect to Recharts bars. Just match corners and theme colors.
+
+### Subtab Highlighting
+- **D-09:** Active subtab gets brand brown (#8B5E3C) as background fill with white text — bold, clear active state
+- **D-10:** Subtab navigation bar itself uses charcoal background (per D-03)
+
+### Navigation Header
+- **D-11:** Active main navigation tab highlighted with a lighter background spanning the full header height
+- **D-12:** Remove the white border from the header
+- **D-13:** Logo and "FlawChess" text both link to the homepage
+
+### Collapsible Sections
+- **D-14:** All collapsible sections (Dashboard, Openings, Endgames) use charcoal background consistently — no more divergent styling between pages
+- **D-15:** The entire collapsible (header + expanded content) is one charcoal container with its own padding — not just the header getting charcoal
+
+### CSS Variable Migration (Folded Todo)
+- **D-16:** Migrate brand brown from `PRIMARY_BUTTON_CLASS` hardcoded hex in theme.ts to a CSS variable in index.css's `@theme inline` block — enables Tailwind utility usage (`bg-brand` etc.) without hardcoded brackets
+- **D-17:** WDL and gauge colors remain in theme.ts as JS constants (oklch values used in inline styles) — no need to migrate these to CSS variables
+
+### Claude's Discretion
+- Filter button layout approach (grid vs flex-grow) — pick what looks best given button counts per group
+- WDL bar height normalization (h-5 vs h-6) — unify if it improves consistency
+- Exact charcoal color value — pick something that works with the noise texture and contrasts with the `#171513` sidebar
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Theme system
+- `frontend/src/lib/theme.ts` — Current theme constants (WDL colors, gauge zones, board colors, PRIMARY_BUTTON_CLASS)
+- `frontend/src/index.css` — Tailwind v4 `@theme inline` block, shadcn CSS variables, dark mode setup
+
+### Components to modify
+- `frontend/src/components/filters/FilterPanel.tsx` — Filter button layout (two patterns: raw buttons + ToggleGroup)
+- `frontend/src/components/results/WDLBar.tsx` — Custom WDL bar (rounded, h-6, glass overlay)
+- `frontend/src/components/charts/EndgameWDLChart.tsx` — Custom endgame WDL rows (rounded, h-5, glass overlay)
+- `frontend/src/components/charts/WDLBarChart.tsx` — Recharts WDL bar chart (square corners, needs rounding)
+- `frontend/src/components/ui/tabs.tsx` — Subtab component (needs brand brown active state)
+
+### Pages with containers to update
+- `frontend/src/pages/OpeningsPage.tsx` — Sidebar + content layout, collapsibles
+- `frontend/src/pages/EndgamesPage.tsx` — Sidebar + content layout, collapsibles
+- `frontend/src/pages/DashboardPage.tsx` — Collapsible sections (currently plain ghost buttons)
+- `frontend/src/pages/ImportPage.tsx` — Import cards/containers
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `theme.ts`: Already centralizes WDL/gauge colors and board square colors — extend with container/brand CSS variables
+- shadcn `tabs.tsx`: Has `default` and `line` variants — can add `brand` variant or modify default
+- shadcn CSS variable system in `index.css`: Well-structured `@theme inline` block ready for new variables
+
+### Established Patterns
+- Tailwind v4 with `@theme inline` in `index.css` — no tailwind.config file
+- Dark mode via `.dark` class selector
+- oklch color space for WDL/gauge colors (inline styles)
+- shadcn component variants via `class-variance-authority` (cva)
+
+### Integration Points
+- `index.css @theme inline` block: Add brand brown, charcoal, sidebar background as CSS variables
+- `theme.ts`: Keep as JS export hub but reference CSS variables where possible
+- Navigation header: likely in `frontend/src/components/` layout components
+- Collapsible pattern: used across Dashboard, Openings, Endgames pages with inconsistent styling
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Charcoal texture: Use SVG feTurbulence for lightweight, repeatable grain — no image assets
+- Sidebar background: specifically `#171513` (dark brown)
+- Brand brown for active subtabs: `#8B5E3C` fill with white text
+- Collapsibles must feel like one unified container when expanded, not header-only styling
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope
+
+</deferred>
+
+---
+
+*Phase: 34-theme-improvements*
+*Context gathered: 2026-03-28*

--- a/.planning/phases/34-theme-improvements/34-DISCUSSION-LOG.md
+++ b/.planning/phases/34-theme-improvements/34-DISCUSSION-LOG.md
@@ -1,0 +1,149 @@
+# Phase 34: Theme Improvements - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-03-28
+**Phase:** 34-theme-improvements
+**Areas discussed:** Container styling, Filter button layout, Chart consistency, Subtab highlighting, Navigation header, Collapsible sections
+
+---
+
+## Container Styling
+
+### Where to apply charcoal containers?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Sidebar + main content | Both panels get charcoal containers | |
+| Main content only | Only main content area gets containers | |
+| Per-section cards | Individual sections get their own charcoal cards | |
+
+**User's choice:** Custom — charcoal card containers on specific sections: endgame statistics sections, concept accordion, game cards, bookmark cards, subtab navigation, import page cards. Sidebar uses flat `#171513` background instead.
+**Notes:** Sidebar doesn't get a card container, just a different background color.
+
+### Implementation approach?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| CSS variable + utility class | Define in @theme inline, use as Tailwind utility | ✓ |
+| Reusable component | Create a <CharcoalCard> wrapper | |
+| You decide | Claude picks | |
+
+**User's choice:** CSS variable + utility class
+
+### Sidebar container?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, charcoal sidebar | Charcoal background on sidebar | |
+| Keep sidebar as-is | Sidebar stays current | |
+
+**User's choice:** Custom — sidebar uses `#171513` (dark brown) flat background, no card container
+
+---
+
+## Filter Button Layout
+
+### Horizontal layout approach?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Equal-width grid | CSS grid with equal columns | |
+| Flex with grow | Flex-wrap with flex-grow | |
+| You decide | Claude picks best approach | ✓ |
+
+**User's choice:** You decide
+
+### Unify filter patterns?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, unify all | One consistent component pattern | |
+| Keep separate | Leave two patterns, fix spacing only | ✓ |
+| You decide | Claude judges effort | |
+
+**User's choice:** Keep separate — just fix spacing
+
+---
+
+## Chart Consistency
+
+### Corner style?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Rounded everywhere | Match custom WDL bar style | ✓ |
+| Square everywhere | Sharp corners on all WDL charts | |
+| You decide | Claude picks | |
+
+**User's choice:** Rounded everywhere
+
+### Glass overlay on Recharts?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, add glass overlay | Apply glass effect to Recharts bars | |
+| No, colors only | Just corners and colors | ✓ |
+| You decide | Claude judges feasibility | |
+
+**User's choice:** No, colors only
+
+---
+
+## Subtab Highlighting
+
+### Active tab style?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Brand brown accent | #8B5E3C background or border | ✓ |
+| Charcoal with highlight | Charcoal bg + colored border | |
+| You decide | Claude picks | |
+
+**User's choice:** Brand brown accent
+
+### Background or underline?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Background fill | Brand brown fill, white text | ✓ |
+| Bottom border accent | Thin brown line under tab | |
+| You decide | Claude picks | |
+
+**User's choice:** Background fill
+
+---
+
+## Navigation Header
+
+**User's choice:** (Provided directly, no options presented)
+- Active main nav tab: lighter background spanning full header height
+- Remove white border from header
+- Logo + "FlawChess" text both link to homepage
+
+---
+
+## Collapsible Sections
+
+### Header styling?
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Charcoal background | Match new container style, consistent everywhere | ✓ |
+| Muted with border | Standardize on bg-muted/50 + border pattern | |
+| You decide | Claude picks | |
+
+**User's choice:** Charcoal background — entire collapsible (header + content) is one charcoal container with own padding
+
+---
+
+## Claude's Discretion
+
+- Filter button layout approach (grid vs flex-grow)
+- WDL bar height normalization (h-5 vs h-6)
+- Exact charcoal color value
+
+## Deferred Ideas
+
+None

--- a/.planning/phases/34-theme-improvements/34-RESEARCH.md
+++ b/.planning/phases/34-theme-improvements/34-RESEARCH.md
@@ -1,0 +1,660 @@
+# Phase 34: Theme Improvements - Research
+
+**Researched:** 2026-03-28
+**Domain:** React/TypeScript frontend — Tailwind v4 CSS variables, SVG noise textures, Recharts bar styling, shadcn/Radix Tabs
+**Confidence:** HIGH
+
+## Summary
+
+This phase is entirely frontend UI work with no backend changes. All four technical research areas (SVG noise texture, Tailwind v4 CSS variables, Recharts stacked bar rounding, shadcn tabs active state) are well-understood from official docs and code inspection. The existing codebase is well-structured for these changes — `@theme inline` is already in place, `tabs.tsx` uses CVA variants, and `theme.ts` is the established JS export hub.
+
+One important constraint: the project uses Recharts 2.15.4. The `BarStack` component (which cleanly rounds only outer stack corners) is a Recharts 3.x feature and is NOT available. Rounding outer corners of stacked WDL bars in `WDLBarChart.tsx` requires a custom shape or Cell-based conditional radius workaround in 2.x.
+
+**Primary recommendation:** Add `--color-brand-brown` and `--color-charcoal` to the `@theme inline` block in `index.css`, implement noise texture as a CSS custom property with a `::before` pseudo-element pattern, and use a new `brand` variant in `tabs.tsx` for the active subtab style.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Container Styling**
+- D-01: Charcoal background with SVG feTurbulence noise texture applied to specific content sections — NOT full-page panels
+- D-02: Implementation via CSS variable + Tailwind utility class (e.g. `bg-charcoal`) — not a wrapper component
+- D-03: Charcoal containers apply to: endgame statistics sections, endgame concept accordion, game cards, bookmark cards, subtab navigation bar, import page cards/containers
+- D-04: Sidebar filter panel does NOT get a card container — uses flat background `#171513` (dark brown), distinct from main content background
+
+**Filter Button Layout**
+- D-05: Filter buttons should be spaced horizontally across the full sidebar width — Claude's discretion on whether to use equal-width grid or flex-grow
+- D-06: Keep the two existing filter patterns separate (raw buttons for Time Control/Platform, ToggleGroup for Rated/Opponent) — just fix the spacing, don't unify
+
+**Chart Consistency**
+- D-07: All WDL charts use rounded corners — apply rounded corners to Recharts `WDLBarChart` bars to match custom `WDLBar` and `EndgameWDLChart` components
+- D-08: Glass overlay stays on custom WDL bars only — do NOT add glass effect to Recharts bars. Just match corners and theme colors.
+
+**Subtab Highlighting**
+- D-09: Active subtab gets brand brown (#8B5E3C) as background fill with white text — bold, clear active state
+- D-10: Subtab navigation bar itself uses charcoal background (per D-03)
+
+**Navigation Header**
+- D-11: Active main navigation tab highlighted with a lighter background spanning the full header height
+- D-12: Remove the white border from the header
+- D-13: Logo and "FlawChess" text both link to the homepage
+
+**Collapsible Sections**
+- D-14: All collapsible sections (Dashboard, Openings, Endgames) use charcoal background consistently — no more divergent styling between pages
+- D-15: The entire collapsible (header + expanded content) is one charcoal container with its own padding — not just the header getting charcoal
+
+**CSS Variable Migration**
+- D-16: Migrate brand brown from `PRIMARY_BUTTON_CLASS` hardcoded hex in theme.ts to a CSS variable in index.css's `@theme inline` block — enables Tailwind utility usage (`bg-brand` etc.) without hardcoded brackets
+- D-17: WDL and gauge colors remain in theme.ts as JS constants (oklch values used in inline styles) — no need to migrate these to CSS variables
+
+### Claude's Discretion
+- Filter button layout approach (grid vs flex-grow) — pick what looks best given button counts per group
+- WDL bar height normalization (h-5 vs h-6) — unify if it improves consistency
+- Exact charcoal color value — pick something that works with the noise texture and contrasts with the `#171513` sidebar
+
+### Deferred Ideas (OUT OF SCOPE)
+None — discussion stayed within phase scope
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| THEME-01 | User sees all visual constants (container colors, spacing, chart styles) centralized in theme.ts and CSS variables | D-16/D-17: brand brown migrated to CSS variable; WDL/gauge stays in theme.ts JS constants |
+| THEME-02 | User sees content containers with charcoal background and subtle SVG feTurbulence noise texture | SVG data URI pattern + Tailwind utility class via `@theme inline` |
+| THEME-03 | User sees filter buttons in sidebar spaced horizontally across full available width | `flex-1` on raw buttons; `w-full` on ToggleGroup components |
+| THEME-04 | User sees consistent WDL chart styling (unified corners and rendering) across all chart types | Recharts 2.x Cell-based radius workaround for outer corners only |
+| THEME-05 | User sees clear visual highlighting on the active subtab | New `brand` variant in `tabs.tsx` using `data-active:bg-[--color-brand-brown]` |
+</phase_requirements>
+
+---
+
+## Standard Stack
+
+### Core (already installed — no new dependencies)
+| Library | Version | Purpose | Notes |
+|---------|---------|---------|-------|
+| Tailwind CSS | 4.2.x | Utility-first CSS — `@theme inline` for brand variables | Already configured in `index.css` |
+| class-variance-authority (cva) | already installed | Variant-based class composition for shadcn | Already used in `tabs.tsx` |
+| Recharts | 2.15.4 | Stacked bar charts in `WDLBarChart.tsx` | No upgrade needed — workaround for stacked radius |
+
+**No new packages required.** All changes are CSS, component modification, and Tailwind configuration only.
+
+---
+
+## Architecture Patterns
+
+### Pattern 1: Tailwind v4 CSS Variable Registration
+
+**What:** In Tailwind v4, the `@theme inline` block in `index.css` registers CSS variables as Tailwind utility classes. Variables prefixed with `--color-` become `bg-*`, `text-*`, `border-*` utilities.
+
+**`@theme inline` vs `@theme`:** Use `@theme inline` (already in use) when variables reference other CSS variables (i.e., `var(--something)` indirection). The `inline` keyword ensures the utility class emits `color: var(--color-brand-brown)` rather than double-indirecting. This matters for referencing `:root` / `.dark` theme vars.
+
+**How to add brand brown and charcoal:**
+
+Step 1 — Define CSS custom properties in `:root` (and optionally `.dark`):
+```css
+/* in :root block */
+--brand-brown: #8B5E3C;
+--brand-brown-hover: #6B4226;
+--charcoal: #2A2520;  /* to be chosen — must contrast with #171513 sidebar */
+```
+
+Step 2 — Register in `@theme inline` block:
+```css
+@theme inline {
+  /* existing entries ... */
+  --color-brand-brown: var(--brand-brown);
+  --color-brand-brown-hover: var(--brand-brown-hover);
+  --color-charcoal: var(--charcoal);
+}
+```
+
+This creates `bg-brand-brown`, `hover:bg-brand-brown-hover`, `text-brand-brown`, `bg-charcoal`, etc. as standard Tailwind utilities.
+
+**After migration**, `PRIMARY_BUTTON_CLASS` in `theme.ts` becomes:
+```typescript
+export const PRIMARY_BUTTON_CLASS = 'bg-brand-brown hover:bg-brand-brown-hover text-white';
+```
+No more hardcoded hex in brackets.
+
+**Confidence:** HIGH — verified against official Tailwind v4 docs and confirmed with the existing `index.css` pattern (e.g., `--color-sidebar: var(--sidebar)` already follows this exact pattern).
+
+---
+
+### Pattern 2: SVG feTurbulence Noise Texture
+
+**What:** A lightweight repeating noise texture using an SVG `feFurbulence` filter embedded as a CSS `background-image` data URI. Applied via a `::before` pseudo-element layered on top of a solid charcoal background color.
+
+**Why pseudo-element:** The texture must overlay the background without obscuring content. Using `::before` with `pointer-events: none` and `position: absolute` achieves this. The container must have `position: relative` and `overflow: hidden`.
+
+**SVG data URI pattern (verified from official MDN + ibelick.com):**
+```css
+.bg-charcoal-texture {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--charcoal);
+}
+.bg-charcoal-texture::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 200px;
+  opacity: 0.06;  /* subtle — adjust to taste */
+}
+```
+
+**Key SVG parameters:**
+- `type='fractalNoise'` — smooth cloud-like grain (not turbulence which creates ripple lines)
+- `baseFrequency='0.65'` — controls grain density; higher = finer grain
+- `numOctaves='3'` — detail level; 3 is a good balance
+- `stitchTiles='stitch'` — ensures the tile seams are invisible when repeating
+- `opacity: 0.06` — very subtle; charcoal is dark, strong noise would look dirty
+
+**Defining as a CSS utility class for Tailwind v4:**
+Since Tailwind v4 doesn't have a simple way to add pseudo-element utilities via `@theme`, this should be defined as a plain CSS class in `@layer components` in `index.css`:
+
+```css
+@layer components {
+  .charcoal-texture {
+    position: relative;
+    overflow: hidden;
+    background-color: var(--charcoal);
+  }
+  .charcoal-texture::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,...");
+    background-repeat: repeat;
+    background-size: 200px;
+    opacity: 0.06;
+  }
+}
+```
+
+Usage: `<div className="charcoal-texture rounded-md p-4">` with `bg-charcoal` as a composable fallback where the pseudo-element isn't needed.
+
+**Confidence:** HIGH — SVG feTurbulence is a well-documented browser feature (MDN); CSS data URI embedding is standard; pseudo-element overlay pattern is widely used.
+
+---
+
+### Pattern 3: Filter Button Full-Width Layout
+
+**What:** Time Control (4 buttons: Bullet, Blitz, Rapid, Classical) and Platform (2 buttons: Chess.com, Lichess) groups should span the full sidebar width.
+
+**Current state:** `FilterPanel.tsx` uses `<div className="flex flex-wrap gap-1">` with unsized buttons. Buttons are content-width, leaving unused space.
+
+**Recommended approach (Claude's discretion — D-05):**
+
+For Time Control (4 buttons, equal labels): use `grid grid-cols-4` — each button gets exactly 25% width regardless of label length.
+```jsx
+<div className="grid grid-cols-4 gap-1">
+  {TIME_CONTROLS.map((tc) => (
+    <button key={tc} className={cn('rounded border h-11 sm:h-7 text-xs ...', ...)} />
+  ))}
+</div>
+```
+
+For Platform (2 buttons): use `grid grid-cols-2` — equal halves.
+
+For ToggleGroup components (Rated, Opponent): ToggleGroup has `w-fit` by default. Pass `className="w-full"` to the ToggleGroup and `className="flex-1"` to each ToggleGroupItem:
+```jsx
+<ToggleGroup className="w-full" ...>
+  <ToggleGroupItem className="flex-1" ...>All</ToggleGroupItem>
+  ...
+</ToggleGroup>
+```
+
+**Confidence:** HIGH — verified by reading the ToggleGroup source (`w-fit` default confirmed at line 44 of `toggle-group.tsx`).
+
+---
+
+### Pattern 4: Recharts Stacked Bar Corner Rounding (2.15.4)
+
+**What:** `WDLBarChart.tsx` renders three stacked `Bar` components (`win_pct`, `draw_pct`, `loss_pct`) with `stackId="wdl"`. Currently all have `radius={[0,0,0,0]}` (no rounding). Goal is outer corner rounding: bottom-left/bottom-right on the bottom bar, top-left/top-right on the top bar.
+
+**Key constraint:** `BarStack` component (the clean solution) was introduced in Recharts 3.x. The project uses 2.15.4 — BarStack does NOT exist.
+
+**Radius prop format in 2.x:** `radius?: number | [topLeft, topRight, bottomRight, bottomLeft]`
+
+**Problem with naive approach:** Applying `radius={[4,4,0,0]}` on the top bar AND `radius={[0,0,4,4]}` on the bottom bar works for rows where all three segments exist. But when `win_pct=0` or `loss_pct=0`, the "outermost" bar shifts. Applying radius to a bar that doesn't render causes no visual problem — Recharts skips zero-value bars — but a middle bar could end up as the actual outermost when flanking bars are zero.
+
+**For a WDL chart (win/draw/loss always has values unless total=0):** The `WDLBarChart` already filters out bookmarks with `total === 0` before rendering. Since we're dealing with meaningful percentages, all three bars will typically be present. However, draws at exactly 0% are possible (e.g., bulletins rarely draw).
+
+**Practical approach for 2.15.4:**
+
+Option A — Static outer-only radius (simple, good enough for typical WDL distributions):
+```jsx
+<Bar xAxisId="pct" dataKey="win_pct" stackId="wdl" fill="var(--color-win_pct)" radius={[4,4,0,0]} />
+<Bar xAxisId="pct" dataKey="draw_pct" stackId="wdl" fill="var(--color-draw_pct)" />
+<Bar xAxisId="pct" dataKey="loss_pct" stackId="wdl" fill="var(--color-loss_pct)" radius={[0,0,4,4]} />
+```
+Trade-off: if `win_pct=0`, the draw bar becomes the topmost but won't have radius. Acceptable for this use case since full zeroes are filtered out.
+
+Option B — Cell-based conditional radius per row (robust):
+```jsx
+<Bar dataKey="win_pct" ...>
+  {data.map((entry) => (
+    <Cell key={entry.label} radius={entry.win_pct > 0 && entry.loss_pct === 0 && entry.draw_pct === 0 ? [4,4,4,4] : entry.win_pct > 0 ? [4,4,0,0] : [0,0,0,0]} />
+  ))}
+</Bar>
+```
+Trade-off: verbose, but handles edge cases correctly.
+
+**Recommendation:** Start with Option A (static radius on top and bottom bars) since WDL values are always present in filtered data. Add a comment noting the limitation. This matches the rounding behavior of `WDLBar.tsx` (which uses `overflow-hidden rounded` on the container div — no per-segment control needed) and `EndgameWDLChart.tsx` (same container approach, `h-5 w-full overflow-hidden rounded`).
+
+**Insight on h-5 vs h-6 normalization (D-05, discretion):** `WDLBar.tsx` uses `h-6`, `EndgameWDLChart.tsx` uses `h-5`. Unifying to `h-6` would give the bars a bit more presence. Recharts bars have their height determined by the chart layout, not these CSS classes. The `h-5`/`h-6` inconsistency only affects the custom bar components.
+
+**Confidence:** MEDIUM — based on Recharts 2.x GitHub issues (#1888, #3887) and reading the installed type definitions. BarStack absence confirmed by direct filesystem check.
+
+---
+
+### Pattern 5: Charcoal Color Selection
+
+**Recommended charcoal value:** `#2A2520`
+
+- Sidebar (`#171513`): very dark brown-black
+- Background (`oklch(0.145 0 0)` in `.dark`): near-black neutral ≈ `#1a1a1a`
+- Charcoal at `#2A2520` sits between these — darker than standard card (`oklch(0.205 0 0)` ≈ `#2d2d2d`) but lighter than sidebar, with a warm brown undertone that complements the brand brown theme.
+
+If `#2A2520` lacks sufficient contrast from page background, try `#252018` (slightly warmer) or `#2C2822` (slightly lighter).
+
+**Confidence:** LOW (aesthetic judgment) — exact value is Claude's discretion per D-05 and should be validated visually.
+
+---
+
+### Pattern 6: shadcn Tabs Active State — Brand Variant
+
+**What:** Add a `brand` variant to `TabsList` and corresponding active state override in `TabsTrigger` so `data-active` sets brand brown background + white text.
+
+**Existing active state selector:** The current `tabs.tsx` uses `data-active:bg-background` for the `default` variant. The component uses custom `data-active` (not Radix's `data-state="active"`) — this is confirmed by reading the code.
+
+**Approach:** Add a `brand` variant to `tabsListVariants` and override the trigger's active state using group-based variant targeting:
+
+In `tabsListVariants` CVA:
+```typescript
+variants: {
+  variant: {
+    default: "bg-muted",
+    line: "gap-1 bg-transparent",
+    brand: "bg-charcoal gap-0",  // charcoal background for the tab bar
+  },
+}
+```
+
+In `TabsTrigger`, add a new line to the `cn(...)` call:
+```typescript
+"group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent",
+```
+
+This follows the exact same pattern already used in the component:
+```typescript
+"group-data-[variant=default]/tabs-list:data-active:shadow-sm"
+"group-data-[variant=line]/tabs-list:data-active:shadow-none"
+```
+
+Usage at call sites:
+```jsx
+<TabsList variant="brand" className="w-full">
+  <TabsTrigger value="statistics">Statistics</TabsTrigger>
+  <TabsTrigger value="games">Games</TabsTrigger>
+</TabsList>
+```
+
+**Confidence:** HIGH — pattern is directly confirmed by reading the existing `tabs.tsx` implementation. The group-based variant targeting is already established in the component.
+
+---
+
+### Pattern 7: Collapsible Unified Container
+
+**What:** Wrap the entire `<Collapsible>` (trigger + content) in a `<div className="charcoal-texture rounded-md">` container so the charcoal background applies to both header and expanded content as one unit.
+
+**Current state:** Collapsible triggers have `bg-muted/50` (Openings) or no background (Dashboard). Content is unstyled.
+
+**Target structure:**
+```jsx
+<div className="charcoal-texture rounded-md p-2">
+  <Collapsible open={open} onOpenChange={setOpen}>
+    <CollapsibleTrigger asChild>
+      <Button variant="ghost" size="sm" className="w-full justify-between text-sm font-medium">
+        Section title
+        {open ? <ChevronUp /> : <ChevronDown />}
+      </Button>
+    </CollapsibleTrigger>
+    <CollapsibleContent>
+      <div className="pt-2">
+        {/* content */}
+      </div>
+    </CollapsibleContent>
+  </Collapsible>
+</div>
+```
+
+The trigger button should use `variant="ghost"` without its own background — the container provides the charcoal. Remove `bg-muted/50`, `border border-border/40` from trigger buttons.
+
+**Confidence:** HIGH — straightforward structural change confirmed by reading page code.
+
+---
+
+### Pattern 8: Navigation Header Changes
+
+**Active tab highlight (D-11):**
+
+Current: `border-b-2 border-primary rounded-none font-medium` — only an underline indicator.
+Target: lighter background spanning full header height.
+
+The `NavHeader` header has `py-1` on the inner div, making the header height determined by the button content. To span full height, use `h-full self-stretch` on the Button plus a background:
+
+```jsx
+className={
+  isActive(to, location.pathname)
+    ? 'self-stretch rounded-none font-medium bg-white/10'  // subtle light tint
+    : 'self-stretch rounded-none text-muted-foreground'
+}
+```
+
+`bg-white/10` over a dark background creates a subtle highlight without being garish. The `border-b-2` underline can be removed (replaced by full-height highlight).
+
+**Remove header border (D-12):** Remove `border-b border-border` from the `<header>` element in `NavHeader()` and `MobileHeader()` in `App.tsx`.
+
+**Logo links to homepage (D-13):** In `NavHeader()`, wrap `<img>` + `<span>FlawChess</span>` in a `<Link to="/">`. Currently neither is a link in the nav header. In `MobileHeader()`, wrap the brand span in a `<Link to="/">`.
+
+**Confidence:** HIGH — confirmed by reading `App.tsx` NavHeader and MobileHeader implementations.
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Noise texture image | PNG/WebP asset file | SVG feTurbulence data URI | No extra HTTP request, scales infinitely, ~500 bytes |
+| Brand color variants | New component with hardcoded colors | CSS variable + `@theme inline` registration | Enables Tailwind utilities everywhere, single source of truth |
+| Tab active state logic | JS-based class toggling | CVA variant + `data-active` CSS selector | Already how the component works |
+| Stacked bar rounding | Custom SVG path renderer | `radius` prop on outermost Bar components | Recharts handles SVG path; only needs outer bars targeted |
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: Noise Texture Covering Content
+**What goes wrong:** Container has `position: static` (default) — the `::before` pseudo-element with `position: absolute` escapes the container.
+**Why it happens:** `position: absolute` is relative to the nearest positioned ancestor.
+**How to avoid:** The `.charcoal-texture` CSS class must include `position: relative`. The container also needs `overflow: hidden` to clip the texture at border-radius.
+**Warning signs:** Noise texture bleeds outside rounded corners, or content underneath adjacent elements gets covered.
+
+### Pitfall 2: Recharts Bar Radius Visual Artifacts in Stacked Mode
+**What goes wrong:** Applying `radius` to a middle bar (e.g., `draw_pct`) creates a gap between segments where the rounded corners pull away from adjacent bars.
+**Why it happens:** Recharts applies the radius to the individual SVG rectangle, not just the outer edges of the stack.
+**How to avoid:** Only apply radius to the first bar (bottom corners) and last bar (top corners). Leave middle bars with `radius={0}` or no radius prop.
+**Warning signs:** White/background-colored gaps visible between WDL segments in the chart.
+
+### Pitfall 3: Tailwind v4 @theme inline — Dark Mode Variables
+**What goes wrong:** Adding `--color-charcoal: #2A2520` directly to `@theme inline` hardcodes the value and bypasses dark mode switching.
+**Why it happens:** The project's existing pattern defines values in `:root` / `.dark` blocks and references them via `var()` in `@theme inline`. Bypassing this pattern breaks dark mode (though the app is dark-only, it's still good practice).
+**How to avoid:** Define the raw color values in `:root` (or `.dark`), then reference via `var(--charcoal)` in `@theme inline`. Follow the existing `--color-sidebar: var(--sidebar)` pattern exactly.
+
+### Pitfall 4: ToggleGroup Items Not Filling Width
+**What goes wrong:** Adding `className="w-full"` to `ToggleGroup` but items don't expand.
+**Why it happens:** ToggleGroupItem has `shrink-0` by default (see `toggle-group.tsx` line 75). Items need explicit `flex-1` to grow.
+**How to avoid:** Pass `className="flex-1"` on each `ToggleGroupItem`.
+
+### Pitfall 5: Mobile-only vs Desktop-only Sidebar — D-06 Filter Layout
+**What goes wrong:** Fixing the desktop sidebar filter layout but missing the mobile collapsible `FilterPanel` instance.
+**Why it happens:** `FilterPanel` is rendered twice per page — once in the desktop sidebar column, once in the mobile `<Collapsible>`. Both call the same component, so changes to `FilterPanel.tsx` propagate to both.
+**How to avoid:** Changes to `FilterPanel.tsx` automatically fix both layouts. No separate mobile/desktop handling needed.
+
+### Pitfall 6: Tabs Component data-active vs data-state
+**What goes wrong:** Using `data-[state=active]` Tailwind selector instead of `data-active`.
+**Why it happens:** Radix UI primitives normally expose `data-state="active"`, but the project's `tabs.tsx` is a customized shadcn build that uses `data-active` boolean attribute instead. Confirmed by reading the actual component source.
+**How to avoid:** Use `data-active:` prefix in Tailwind classes (already established in tabs.tsx). Do NOT use `data-[state=active]:`.
+
+---
+
+## Code Examples
+
+### Adding CSS Variables to index.css (THEME-01, D-16)
+
+```css
+/* Source: verified from existing index.css pattern */
+:root {
+    /* existing vars ... */
+
+    /* Brand colors */
+    --brand-brown: #8B5E3C;
+    --brand-brown-hover: #6B4226;
+
+    /* Container colors */
+    --charcoal: #2A2520;
+    --sidebar-bg: #171513;
+}
+
+@theme inline {
+    /* existing entries ... */
+
+    /* Brand and container utilities */
+    --color-brand-brown: var(--brand-brown);
+    --color-brand-brown-hover: var(--brand-brown-hover);
+    --color-charcoal: var(--charcoal);
+}
+```
+
+After this, `PRIMARY_BUTTON_CLASS` in `theme.ts` becomes:
+```typescript
+export const PRIMARY_BUTTON_CLASS = 'bg-brand-brown hover:bg-brand-brown-hover text-white';
+```
+
+### Noise Texture CSS Class (THEME-02)
+
+```css
+/* Source: ibelick.com pattern + MDN feTurbulence */
+/* Place in @layer components in index.css */
+@layer components {
+  .charcoal-texture {
+    position: relative;
+    overflow: hidden;
+    background-color: var(--charcoal);
+  }
+  .charcoal-texture::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C%2Fsvg%3E");
+    background-repeat: repeat;
+    background-size: 200px;
+    opacity: 0.06;
+  }
+}
+```
+
+Children of `.charcoal-texture` that should appear above the pseudo-element must have `position: relative; z-index: 1` if they stack incorrectly. In most cases, flow content sits above `::before` naturally.
+
+### Filter Buttons Full Width (THEME-03)
+
+Raw button groups — change `flex flex-wrap gap-1` to `grid`:
+```jsx
+/* Time Control: 4 equal columns */
+<div className="grid grid-cols-4 gap-1">
+  {TIME_CONTROLS.map((tc) => (
+    <button key={tc} className={cn('rounded border h-11 sm:h-7 text-xs transition-colors', ...)} />
+  ))}
+</div>
+
+/* Platform: 2 equal columns */
+<div className="grid grid-cols-2 gap-1">
+  {PLATFORMS.map((p) => (
+    <button ... />
+  ))}
+</div>
+```
+
+ToggleGroup components — add `className="w-full"` to ToggleGroup and `className="flex-1"` to each ToggleGroupItem:
+```jsx
+<ToggleGroup type="single" variant="outline" size="sm" className="w-full" ...>
+  <ToggleGroupItem value="all" className="flex-1" ...>All</ToggleGroupItem>
+  <ToggleGroupItem value="rated" className="flex-1" ...>Rated</ToggleGroupItem>
+  <ToggleGroupItem value="casual" className="flex-1" ...>Casual</ToggleGroupItem>
+</ToggleGroup>
+```
+
+### Recharts Stacked Bar Rounding (THEME-04)
+
+```jsx
+/* Source: Recharts 2.x Bar radius prop + GitHub issue #1888 */
+/* Apply radius only to outermost bars in the stack */
+<Bar xAxisId="pct" dataKey="win_pct" stackId="wdl" fill="var(--color-win_pct)"
+     radius={[4, 4, 0, 0]} />   {/* top-left, top-right, bottom-right, bottom-left */}
+<Bar xAxisId="pct" dataKey="draw_pct" stackId="wdl" fill="var(--color-draw_pct)" />
+<Bar xAxisId="pct" dataKey="loss_pct" stackId="wdl" fill="var(--color-loss_pct)"
+     radius={[0, 0, 4, 4]} />
+```
+
+Note: `radius={[4,4,0,0]}` on `win_pct` (topmost in Recharts stacking order — last rendered = topmost visual) and `radius={[0,0,4,4]}` on `loss_pct` (bottom). The stacking order in Recharts follows declaration order: `win_pct` is first declared so it renders at the bottom, `loss_pct` is last so it renders at the top. **Verify the actual visual stacking order** during implementation — adjust radius placement if needed.
+
+### Tabs Brand Variant (THEME-05)
+
+In `tabs.tsx`, add `brand` to CVA variants:
+```typescript
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg ...",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+        brand: "bg-charcoal gap-0",   // charcoal background for the tab bar
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
+)
+```
+
+In `TabsTrigger`, add brand active state styling:
+```typescript
+"group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown",
+"group-data-[variant=brand]/tabs-list:data-active:text-white",
+"group-data-[variant=brand]/tabs-list:data-active:border-transparent",
+"group-data-[variant=brand]/tabs-list:data-active:shadow-none",
+```
+
+Usage:
+```jsx
+<TabsList variant="brand" className="w-full" data-testid="endgames-tabs">
+  <TabsTrigger value="statistics" className="flex-1" ...>Statistics</TabsTrigger>
+  <TabsTrigger value="games" className="flex-1" ...>Games</TabsTrigger>
+</TabsList>
+```
+
+---
+
+## State of the Art
+
+| Old Approach | Current Approach | Notes |
+|--------------|------------------|-------|
+| Tailwind 3: `tailwind.config.js` theme extension | Tailwind v4: `@theme inline` in CSS | Project already on v4 |
+| Recharts BarStack for stacked rounding | Cell-based conditional radius (2.x) | BarStack requires Recharts 3.x |
+| Hardcoded hex in Tailwind brackets `bg-[#8B5E3C]` | CSS variable → `@theme inline` → `bg-brand-brown` | Enabled by D-16 |
+
+---
+
+## Environment Availability
+
+Step 2.6: SKIPPED — this phase is frontend-only code/CSS changes with no new external tool dependencies.
+
+---
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | Vitest 4.1.x |
+| Config file | `vite.config.ts` (vitest config embedded in vite config) |
+| Quick run command | `npm test` (from `frontend/`) |
+| Full suite command | `npm test` (from `frontend/`) |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| THEME-01 | Brand brown CSS variable defined in index.css and `PRIMARY_BUTTON_CLASS` uses `bg-brand-brown` | manual-only | — inspect `theme.ts` and `index.css` | N/A |
+| THEME-02 | Charcoal containers with noise texture visible on target pages | manual-only | — visual inspection required | N/A |
+| THEME-03 | Filter buttons span full sidebar width | manual-only | — visual inspection required | N/A |
+| THEME-04 | WDL bar chart corners rounded in `WDLBarChart.tsx` | manual-only | — visual inspection required | N/A |
+| THEME-05 | Active subtab has brand brown fill with white text | manual-only | — visual inspection required | N/A |
+
+All THEME requirements are purely visual and require manual browser inspection. The existing `arrowColor.test.ts` confirms Vitest is configured and working.
+
+### Sampling Rate
+- **Per task commit:** `npm test` — verify no existing tests regressed
+- **Per wave merge:** `npm test` + visual browser check of affected pages
+- **Phase gate:** All existing tests green + manual visual review of Openings, Endgames, Dashboard, Import pages
+
+### Wave 0 Gaps
+None — no new test files needed for this phase. All requirements are visual and manual-only. The existing test passes as a regression gate.
+
+---
+
+## Open Questions
+
+1. **Recharts stacking order: which bar is visually topmost?**
+   - What we know: In Recharts stacked horizontal bars, rendering order follows JSX declaration order, but the visual stacking (which value appears on which side) depends on the layout.
+   - What's unclear: For `layout="vertical"` stacked bars with `win_pct`, `draw_pct`, `loss_pct`, the first-declared bar may be leftmost (since WDL is horizontal here, effectively left = bottom, right = top). Needs visual verification during implementation.
+   - Recommendation: During implementation, temporarily set distinctive colors and confirm which bar is leftmost. Apply `radius={[0,0,4,4]}` to the leftmost (left edge = bottom-left/bottom-right corners visually) and `radius={[4,4,0,0]}` to the rightmost.
+
+2. **Charcoal opacity under noise texture — legibility of text/content**
+   - What we know: Charcoal at `#2A2520` with opacity 0.06 noise is the starting point.
+   - What's unclear: Whether content inside charcoal containers (e.g., bookmark card text, game card metadata) retains sufficient contrast.
+   - Recommendation: Start at opacity 0.06 and adjust. If content looks washed out, reduce to 0.04.
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- Tailwind CSS official docs (tailwindcss.com/docs/theme) — `@theme inline` CSS variable syntax verified
+- MDN Web Docs (developer.mozilla.org/SVG/Reference/Element/feTurbulence) — feTurbulence attributes
+- Project source code (`index.css`, `tabs.tsx`, `toggle-group.tsx`, `WDLBarChart.tsx`, `App.tsx`) — direct inspection
+
+### Secondary (MEDIUM confidence)
+- ibelick.com/blog/create-grainy-backgrounds-with-css — CSS data URI noise texture pattern (verified consistent with MDN)
+- Recharts GitHub issue #1888 (recharts/recharts) — stacked bar radius behavior in 2.x confirmed
+- Recharts GitHub issue #3887 — BarStack confirmed as 3.x-only feature
+
+### Tertiary (LOW confidence)
+- recharts.github.io/en-US/guide/roundedBars/ — references BarStack but this applies to 3.x only; confirmed mismatch with installed 2.15.4
+
+---
+
+## Project Constraints (from CLAUDE.md)
+
+| Directive | Impact on This Phase |
+|-----------|---------------------|
+| Theme constants in `theme.ts` — all theme-relevant color constants must be defined in `theme.ts` and imported from there | `PRIMARY_BUTTON_CLASS` update stays in `theme.ts` after migrating from hardcoded hex. WDL/gauge constants stay in `theme.ts` (D-17). |
+| Never hard-code color values with semantic meaning directly in components | Use `bg-brand-brown` utility, not `bg-[#8B5E3C]` in components |
+| `data-testid` on every interactive element | Any new/modified interactive elements need `data-testid`. The phase adds no new interactive elements — only visual styling changes. |
+| Mobile-friendly: apply changes to both desktop and mobile variants | `FilterPanel.tsx` is shared (single component used in both desktop sidebar and mobile collapsible) — one change covers both. Nav header has both `NavHeader` (desktop) and `MobileHeader` — both need border removal and logo link. |
+| Always check mobile variants | Dashboard collapsibles appear in mobile view too — verify charcoal texture looks correct on narrow screens. |
+| No dark/light mode toggle — dark theme is only mode | Only `.dark` block matters; `:root` light values exist in `index.css` but are never activated. Safe to define new variables in `:root` only since `.dark` overrides all background values anyway. |
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all libraries confirmed installed, no new dependencies
+- Architecture: HIGH — patterns verified by reading actual source files and official docs
+- Pitfalls: HIGH — specific to the actual code patterns observed in the codebase
+- Recharts radius workaround: MEDIUM — behavior confirmed via GitHub issues, visual validation still needed at implementation time
+
+**Research date:** 2026-03-28
+**Valid until:** 2026-09-01 (CSS/component patterns are stable; Tailwind v4 API unlikely to change significantly)

--- a/.planning/phases/34-theme-improvements/34-VALIDATION.md
+++ b/.planning/phases/34-theme-improvements/34-VALIDATION.md
@@ -1,0 +1,77 @@
+---
+phase: 34
+slug: theme-improvements
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-28
+---
+
+# Phase 34 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | vitest (frontend), pytest (backend — not needed for this phase) |
+| **Config file** | `frontend/vitest.config.ts` |
+| **Quick run command** | `cd frontend && npm test` |
+| **Full suite command** | `cd frontend && npm test && npm run build` |
+| **Estimated runtime** | ~15 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `cd frontend && npm test`
+- **After every plan wave:** Run `cd frontend && npm test && npm run build`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 15 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 34-01-01 | 01 | 1 | THEME-01 | build | `npm run build` | ✅ | ⬜ pending |
+| 34-01-02 | 01 | 1 | THEME-02 | visual | Manual inspection | N/A | ⬜ pending |
+| 34-02-01 | 02 | 1 | THEME-03 | visual | Manual inspection | N/A | ⬜ pending |
+| 34-02-02 | 02 | 1 | THEME-04 | build | `npm run build` | ✅ | ⬜ pending |
+| 34-02-03 | 02 | 1 | THEME-05 | visual | Manual inspection | N/A | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+Existing infrastructure covers all phase requirements. No new test framework or fixtures needed.
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Charcoal containers with noise texture visible | THEME-02 | Visual appearance, CSS aesthetics | Open Endgames tab, verify charcoal background with subtle grain on stat sections |
+| Filter buttons span full sidebar width | THEME-03 | Layout visual check | Open Openings page, verify filter buttons fill sidebar width evenly |
+| Active subtab has brand brown fill | THEME-05 | Visual color check | Navigate between Moves/Games/Statistics tabs, verify active tab has brown fill |
+| Navigation header active tab highlighting | D-11 | Visual appearance | Navigate between pages, verify active nav has lighter background |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 15s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/34-theme-improvements/34-VERIFICATION.md
+++ b/.planning/phases/34-theme-improvements/34-VERIFICATION.md
@@ -1,0 +1,168 @@
+---
+phase: 34-theme-improvements
+verified: 2026-03-28T12:49:42Z
+status: gaps_found
+score: 8/10 must-haves verified
+gaps:
+  - truth: "All theme-relevant constants are centralized in theme.ts and CSS variables — no ad-hoc color values scattered across components"
+    status: partial
+    reason: "Phase 34 introduced two new ad-hoc hex values (#171717 and #262626) in toggle.tsx and FilterPanel.tsx during visual iteration. These inactive-button background colors are not registered as CSS variables in index.css nor defined in theme.ts. The charcoal-hover CSS variable (#262220) already exists but is a different value. The REQUIREMENTS.md 'Pending' marker for THEME-01 reflects this: it was never checked off."
+    artifacts:
+      - path: "frontend/src/components/ui/toggle.tsx"
+        issue: "Line 13: bg-[#171717] hover:bg-[#262626] hardcoded — introduced in commit 4779b05 during phase 34 visual iteration"
+      - path: "frontend/src/components/filters/FilterPanel.tsx"
+        issue: "Lines 138, 164: bg-[#171717] hover:bg-[#262626] hardcoded — introduced in commit bec9ee3 during phase 34 visual iteration"
+    missing:
+      - "Add --inactive-bg: #171717 and --inactive-bg-hover: #262626 CSS variables to :root in index.css"
+      - "Register --color-inactive-bg and --color-inactive-bg-hover in @theme inline block"
+      - "Replace bg-[#171717] with bg-inactive-bg and bg-[#262626] with bg-inactive-bg-hover in toggle.tsx and FilterPanel.tsx"
+      - "Update REQUIREMENTS.md to check THEME-01, THEME-03, THEME-04 as Complete"
+  - truth: "REQUIREMENTS.md tracking reflects actual completion state"
+    status: failed
+    reason: "REQUIREMENTS.md shows THEME-01, THEME-03, THEME-04 as '[ ] Pending' and 'Pending' in the tracking table, but the phase has completed THEME-03 and THEME-04 fully, and THEME-01 partially. The summary frontmatter claims requirements-completed: [THEME-01, THEME-03, THEME-04, THEME-05] but REQUIREMENTS.md was never updated."
+    artifacts:
+      - path: ".planning/REQUIREMENTS.md"
+        issue: "Lines 12-16: THEME-01, THEME-03, THEME-04 still show [ ] / Pending status"
+    missing:
+      - "Update REQUIREMENTS.md: mark THEME-03 as [x] Complete (filter button layout fully implemented)"
+      - "Update REQUIREMENTS.md: mark THEME-04 as [x] Complete (Recharts corners added per D-07/D-08 scope)"
+      - "Update REQUIREMENTS.md: mark THEME-01 as [x] Complete after resolving the #171717/#262626 gap"
+      - "Update tracking table entries from 'Pending' to 'Complete' for THEME-03 and THEME-04"
+---
+
+# Phase 34: Theme Improvements Verification Report
+
+**Phase Goal:** Users see a visually consistent, polished UI with centralized theme management across all pages
+**Verified:** 2026-03-28T12:49:42Z
+**Status:** gaps_found
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (from ROADMAP Success Criteria)
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | All theme constants centralized — no ad-hoc hex colors scattered in components | PARTIAL | #171717 and #262626 hardcoded in toggle.tsx:13 and FilterPanel.tsx:138,164; introduced by this phase |
+| 2 | Content containers have charcoal background with SVG feTurbulence noise texture | VERIFIED | charcoal-texture class defined with feTurbulence in index.css; used on Dashboard (4x), Openings (9x), Endgames (8x), Import (2x) |
+| 3 | Filter buttons span full sidebar width with even spacing | VERIFIED | grid grid-cols-4 (Time Control), grid grid-cols-2 (Platform), w-full + flex-1 on ToggleGroups |
+| 4 | WDL charts (custom and Recharts) share identical corner rounding and theme colors on bars | VERIFIED | Custom WDLBar: overflow-hidden rounded container; Recharts WDLBarChart: radius={[4,4,0,0]}/{[0,0,4,4]}; both use WDL_WIN/WDL_DRAW/WDL_LOSS constants |
+| 5 | Active subtab is clearly highlighted | VERIFIED | TabsList variant="brand" in Openings (desktop line 529, mobile line 744) and Endgames (desktop line 270, mobile line 322); brand variant = charcoal-texture bar + bg-brand-brown-active! active state |
+| 6 | Desktop nav header has no bottom border and active tab has lighter background | VERIFIED | border-b border-border removed from App.tsx NavHeader; active tab uses 'font-medium bg-white/10 text-foreground' |
+| 7 | Logo and FlawChess text link to homepage on both desktop and mobile | VERIFIED | NavHeader: Link to="/" data-testid="nav-home" wraps img+span (line 83); MobileHeader: Link to="/" data-testid="nav-home-mobile" (line 131) |
+| 8 | Collapsible sections are unified charcoal containers (header + content in one block) | VERIFIED | Dashboard, Openings, Endgames all wrap Collapsible in charcoal-texture rounded-md div |
+| 9 | PRIMARY_BUTTON_CLASS uses CSS variable-based Tailwind utilities, not hardcoded hex | VERIFIED | theme.ts line 20: PRIMARY_BUTTON_CLASS = 'bg-brand-brown hover:bg-brand-brown-hover text-white' |
+| 10 | Brand brown and charcoal CSS variables registered as Tailwind utilities | VERIFIED | index.css: --brand-brown, --charcoal, --brand-brown-active, --charcoal-hover in :root; --color-brand-brown etc. in @theme inline |
+
+**Score:** 9/10 truths verified (Truth 1 is partial)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `frontend/src/index.css` | CSS variables for brand-brown, charcoal, sidebar-bg; charcoal-texture class | VERIFIED | --brand-brown: #8B5E3C, --charcoal: #161412, --sidebar-bg: #171513; .charcoal-texture with feTurbulence SVG data URI at line 149 |
+| `frontend/src/lib/theme.ts` | PRIMARY_BUTTON_CLASS using bg-brand-brown utility | VERIFIED | Line 20: bg-brand-brown hover:bg-brand-brown-hover; no bg-[# hex brackets |
+| `frontend/src/components/ui/tabs.tsx` | Brand variant with charcoal-texture bar and brand-brown active trigger | VERIFIED | Line 34: brand: "charcoal-texture gap-0"; line 71: brand active state with !important |
+| `frontend/src/components/filters/FilterPanel.tsx` | Grid-based full-width filter button layout | VERIFIED (with gap) | Lines 126/152: grid grid-cols-4/grid-cols-2; lines 188/211: className="w-full" on ToggleGroups; BUT lines 138/164 introduce bg-[#171717] hardcoded |
+| `frontend/src/components/charts/WDLBarChart.tsx` | Rounded corners on outermost stacked WDL bars | VERIFIED | Line 109: radius={[4,4,0,0]}; line 111: radius={[0,0,4,4]}; comment explaining approach |
+| `frontend/src/App.tsx` | Nav header: active tab bg-white/10, no border, logo link | VERIFIED | Line 80: no border-b; line 96: bg-white/10; lines 83/129-135: Link to="/" on both headers |
+| `frontend/src/pages/Dashboard.tsx` | Collapsibles in charcoal-texture containers | VERIFIED | Lines 297, 412, 439: three charcoal-texture rounded-md wrappers; additional nested charcoal-texture at 348 |
+| `frontend/src/pages/Openings.tsx` | Collapsibles in charcoal-texture; TabsList variant="brand" | VERIFIED | 9 charcoal-texture instances; variant="brand" at lines 529 (desktop) and 744 (mobile) |
+| `frontend/src/pages/Endgames.tsx` | Content sections in charcoal-texture; TabsList variant="brand" | VERIFIED | 8 charcoal-texture instances; variant="brand" at lines 270 (desktop) and 322 (mobile) |
+| `frontend/src/pages/Import.tsx` | Import cards with charcoal-texture | VERIFIED | Lines 183, 226: charcoal-texture rounded-md on platform import cards |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `frontend/src/index.css` | `frontend/src/lib/theme.ts` | bg-brand-brown in PRIMARY_BUTTON_CLASS references --color-brand-brown CSS variable | WIRED | theme.ts:20 uses bg-brand-brown; index.css:124 registers --color-brand-brown: var(--brand-brown) |
+| `frontend/src/index.css` | `frontend/src/components/ui/tabs.tsx` | bg-charcoal Tailwind utility in brand variant | WIRED | tabs.tsx:34 uses charcoal-texture class; index.css:149 defines .charcoal-texture with var(--charcoal) |
+| `frontend/src/pages/Endgames.tsx` | `frontend/src/components/ui/tabs.tsx` | TabsList variant="brand" | WIRED | Endgames.tsx:270 uses variant="brand"; Endgames.tsx:322 uses variant="brand" (mobile) |
+| `frontend/src/pages/Dashboard.tsx` | `frontend/src/index.css` | charcoal-texture CSS class | WIRED | Dashboard.tsx lines 297, 412, 439 all use charcoal-texture; class defined in index.css:149 |
+| `frontend/src/pages/Openings.tsx` | `frontend/src/components/ui/tabs.tsx` | TabsList variant="brand" | WIRED | Openings.tsx:529 desktop + 744 mobile both use variant="brand" |
+
+### Data-Flow Trace (Level 4)
+
+Not applicable — this phase is CSS/component styling only. No data fetching, state, or API connections were modified.
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Frontend build compiles without errors | `npm run build` | "built in 4.38s" | PASS |
+| All 38 frontend tests pass | `npm test` | "38 passed" | PASS |
+| PRIMARY_BUTTON_CLASS uses CSS utility (no hex) | `grep 'bg-brand-brown' frontend/src/lib/theme.ts` | Line 20 matches | PASS |
+| charcoal-texture class present with feTurbulence | `grep 'feTurbulence' frontend/src/index.css` | Line 160 matches | PASS |
+| Recharts WDL bar has rounded corners | `grep 'radius' frontend/src/components/charts/WDLBarChart.tsx` | Lines 109, 111 match | PASS |
+| Tabs brand variant defined | `grep 'brand.*charcoal-texture' frontend/src/components/ui/tabs.tsx` | Line 34 matches | PASS |
+| Nav header has no border | `grep 'border-b border-border' frontend/src/App.tsx` | No output (removed) | PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|----------|
+| THEME-01 | 34-01 | All visual constants centralized in theme.ts and CSS variables | PARTIAL | Brand brown migrated; charcoal registered as CSS var. BUT #171717/#262626 hardcoded in toggle.tsx + FilterPanel.tsx, introduced during phase 34 iteration. REQUIREMENTS.md still shows Pending. |
+| THEME-02 | 34-02 | Content containers with charcoal background and SVG feTurbulence noise texture | VERIFIED | charcoal-texture class implemented and applied across all 5 target pages. REQUIREMENTS.md correctly shows [x] Complete. |
+| THEME-03 | 34-01 | Filter buttons span full sidebar width | VERIFIED | grid-cols-4/grid-cols-2 layout, w-full ToggleGroups. REQUIREMENTS.md incorrectly shows Pending — needs update. |
+| THEME-04 | 34-01 | Consistent WDL chart corner rounding across all chart types | VERIFIED | Recharts radius props added per D-07/D-08 scope (corners only, not glass). Custom WDLBar uses overflow-hidden rounded container. REQUIREMENTS.md incorrectly shows Pending — needs update. |
+| THEME-05 | 34-01, 34-02 | Active subtab clearly highlighted | VERIFIED | TabsList variant="brand" on Openings and Endgames; active state = bg-brand-brown-active!. REQUIREMENTS.md correctly shows [x] Complete. |
+
+**Orphaned requirements from REQUIREMENTS.md:** None — all 5 THEME requirements are claimed by plans 34-01 and 34-02.
+
+**REQUIREMENTS.md documentation gap:** THEME-01, THEME-03, THEME-04 show as Pending in REQUIREMENTS.md but were completed (THEME-03, THEME-04 fully; THEME-01 partially). This is a tracking failure.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `frontend/src/components/ui/toggle.tsx` | 13 | `bg-[#171717] hover:bg-[#262626]` hardcoded hex in component | WARNING | Contradicts THEME-01 goal of centralized constants; introduced during phase 34 visual iteration |
+| `frontend/src/components/filters/FilterPanel.tsx` | 138, 164 | `bg-[#171717] hover:bg-[#262626]` hardcoded hex | WARNING | Same as above — matches toggle.tsx values but neither are in CSS variables |
+| `frontend/src/components/charts/WDLBarChart.tsx` | 98-100 | `text-green-600`, `text-gray-400`, `text-red-600` in tooltip | INFO | Pre-existing before phase 34; tooltip uses approximate Tailwind colors instead of WDL_WIN/WDL_LOSS theme constants. Not introduced by this phase. |
+| `.planning/REQUIREMENTS.md` | 12-16, 46-50 | THEME-01, THEME-03, THEME-04 still marked Pending | WARNING | Documentation tracking failure — phase declared these complete in summary frontmatter but REQUIREMENTS.md was not updated |
+
+**Anti-pattern assessment:** The #171717 and #262626 values in toggle.tsx and FilterPanel.tsx are rendered as interactive button backgrounds. They are non-trivial visual constants that should follow the same CSS-variable pattern established in this phase. No data-fetching stubs. No empty implementations.
+
+### Human Verification Required
+
+#### 1. Charcoal Texture Visual Quality
+
+**Test:** Open `npm run dev` and navigate to `/openings`. Inspect the sidebar collapsible sections and the main content area.
+**Expected:** Content containers have a distinctly darker charcoal background (#161412) with a subtle noise texture overlay. The sidebar itself (`#171513`) should look slightly different from the charcoal containers.
+**Why human:** SVG feTurbulence noise texture cannot be verified programmatically — it requires visual inspection to confirm the effect is visible and not too strong/subtle.
+
+#### 2. Active Subtab Brown Highlight
+
+**Test:** Navigate to `/openings` or `/endgames`, click between subtabs (e.g., Moves/Games/Openings on the Openings page).
+**Expected:** The active subtab shows a clear brand brown (#6C4328) background with white text. Inactive tabs show the charcoal background. Switching tabs updates the highlight.
+**Why human:** Requires browser interaction to confirm the !important override on brand variant active state actually displays correctly.
+
+#### 3. Filter Button Full-Width Layout
+
+**Test:** Open the Openings or Endgames page on desktop. Inspect the sidebar filter panel.
+**Expected:** Time Control buttons (4 columns) and Platform buttons (2 columns) span the full sidebar width with equal column widths. The Rated and Opponent toggle groups also fill the full width.
+**Why human:** Visual layout verification — grid width behavior depends on container size.
+
+#### 4. Mobile Responsive Behavior
+
+**Test:** Resize browser to <640px or use DevTools mobile emulation. Navigate between pages.
+**Expected:** Charcoal containers, filter buttons, and tab highlighting all work correctly on narrow screens. Logo links to homepage on mobile header.
+**Why human:** Responsive breakpoints require visual testing at multiple widths.
+
+### Gaps Summary
+
+Two gaps prevent marking this phase as fully complete:
+
+**Gap 1 (WARNING): Ad-hoc hex values introduced during visual iteration**
+During Phase 34's iterative visual verification, commits `4779b05` and `bec9ee3` introduced `bg-[#171717]` and `hover:bg-[#262626]` for inactive button backgrounds in `toggle.tsx` and `FilterPanel.tsx`. These values are not registered in `index.css` as CSS variables and are not in `theme.ts`. The existing `--charcoal-hover` variable is `#262220`, a different value. This directly contradicts THEME-01's success criterion of "no ad-hoc color values scattered across components."
+
+Fix: Add `--inactive-bg: #171717` and `--inactive-bg-hover: #262626` to `:root` in `index.css`, register them in `@theme inline`, and replace the hardcoded bracket syntax in both files.
+
+**Gap 2 (INFO): REQUIREMENTS.md tracking not updated**
+THEME-01, THEME-03, and THEME-04 remain marked as `[ ]` Pending in `REQUIREMENTS.md` and "Pending" in the tracking table, even though the phase summaries declare them complete. THEME-03 (filter layout) and THEME-04 (WDL chart rounding) are fully done and should be checked off. THEME-01 should be checked off after Gap 1 is resolved.
+
+This is a documentation gap only — the functional implementations are in place.
+
+---
+
+_Verified: 2026-03-28T12:49:42Z_
+_Verifier: Claude (gsd-verifier)_

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,36 +78,36 @@ function NavHeader() {
 
   return (
     <header className="hidden sm:block bg-background px-6 overflow-hidden">
-      <div className="mx-auto flex max-w-7xl items-center justify-between py-1">
+      <div className="mx-auto flex max-w-7xl items-stretch justify-between">
         <div className="flex items-center">
           <Link to="/" className="flex items-center gap-1 mr-3" data-testid="nav-home">
             <img src="/icons/logo-128.png" alt="" className="h-11 w-11 self-end -mb-1" aria-hidden="true" />
             <span className="text-lg tracking-tight text-foreground font-brand">FlawChess</span>
           </Link>
-          <nav aria-label="Main navigation">
+          <nav aria-label="Main navigation" className="flex items-stretch h-full">
             {NAV_ITEMS.map(({ to, label, Icon }) => (
-              <Button
+              <Link
                 key={to}
-                asChild
-                variant="ghost"
-                size="sm"
-                className={
+                to={to}
+                data-testid={`nav-${label.toLowerCase().replace(/\s+/g, '-')}`}
+                className={cn(
+                  'flex items-center gap-1.5 px-3 text-sm transition-colors',
                   isActive(to, location.pathname)
-                    ? 'self-stretch rounded-none font-medium bg-white/10'
-                    : 'rounded-none text-muted-foreground'
-                }
+                    ? 'font-medium bg-white/10 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
               >
-                <Link to={to} data-testid={`nav-${label.toLowerCase().replace(/\s+/g, '-')}`}>
-                  <Icon className="mr-1.5 h-4 w-4" aria-hidden="true" />
-                  {label}
-                </Link>
-              </Button>
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                {label}
+              </Link>
             ))}
           </nav>
         </div>
-        <Button variant="ghost" size="sm" onClick={logout} data-testid="nav-logout">
-          Logout
-        </Button>
+        <div className="flex items-center">
+          <Button variant="ghost" size="sm" onClick={logout} data-testid="nav-logout">
+            Logout
+          </Button>
+        </div>
       </div>
     </header>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,11 +77,13 @@ function NavHeader() {
   const { logout } = useAuth();
 
   return (
-    <header className="hidden sm:block border-b border-border bg-background px-6 overflow-hidden">
+    <header className="hidden sm:block bg-background px-6 overflow-hidden">
       <div className="mx-auto flex max-w-7xl items-center justify-between py-1">
-        <div className="flex items-center gap-1">
-          <img src="/icons/logo-128.png" alt="" className="h-11 w-11 self-end -mb-1" aria-hidden="true" />
-          <span className="mr-3 text-lg tracking-tight text-foreground font-brand">FlawChess</span>
+        <div className="flex items-center">
+          <Link to="/" className="flex items-center gap-1 mr-3" data-testid="nav-home">
+            <img src="/icons/logo-128.png" alt="" className="h-11 w-11 self-end -mb-1" aria-hidden="true" />
+            <span className="text-lg tracking-tight text-foreground font-brand">FlawChess</span>
+          </Link>
           <nav aria-label="Main navigation">
             {NAV_ITEMS.map(({ to, label, Icon }) => (
               <Button
@@ -91,7 +93,7 @@ function NavHeader() {
                 size="sm"
                 className={
                   isActive(to, location.pathname)
-                    ? 'border-b-2 border-primary rounded-none font-medium'
+                    ? 'self-stretch rounded-none font-medium bg-white/10'
                     : 'rounded-none text-muted-foreground'
                 }
               >
@@ -122,15 +124,16 @@ function MobileHeader() {
   return (
     <header
       data-testid="mobile-header"
-      className="block sm:hidden pt-safe flex items-center justify-between px-4 py-1 border-b border-border bg-background overflow-hidden"
+      className="block sm:hidden pt-safe flex items-center justify-between px-4 py-1 bg-background overflow-hidden"
     >
-      <span
-        data-testid="mobile-header-brand"
+      <Link
+        to="/"
+        data-testid="nav-home-mobile"
         className="flex items-center gap-1.5 text-xl tracking-tight text-foreground font-brand"
       >
         <img src="/icons/logo-128.png" alt="" className="h-11 w-11 self-end -mb-1" aria-hidden="true" />
         FlawChess
-      </span>
+      </Link>
       <span
         data-testid="mobile-header-page-title"
         className="text-sm text-muted-foreground"

--- a/frontend/src/components/board/BoardControls.tsx
+++ b/frontend/src/components/board/BoardControls.tsx
@@ -25,7 +25,7 @@ export function BoardControls({
   vertical = false,
 }: BoardControlsProps) {
   return (
-    <div className={`flex items-center justify-evenly rounded-lg bg-muted ${vertical ? 'flex-col' : ''}`}>
+    <div className={`flex items-center justify-evenly rounded-lg bg-charcoal ${vertical ? 'flex-col' : ''}`}>
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/src/components/board/BoardControls.tsx
+++ b/frontend/src/components/board/BoardControls.tsx
@@ -25,7 +25,7 @@ export function BoardControls({
   vertical = false,
 }: BoardControlsProps) {
   return (
-    <div className={`flex items-center justify-evenly rounded-lg bg-charcoal ${vertical ? 'flex-col' : ''}`}>
+    <div className={`flex items-center justify-evenly rounded-lg charcoal-texture ${vertical ? 'flex-col' : ''}`}>
       <Button
         variant="ghost"
         size="icon"

--- a/frontend/src/components/charts/WDLBarChart.tsx
+++ b/frontend/src/components/charts/WDLBarChart.tsx
@@ -104,9 +104,11 @@ export function WDLBarChart({ bookmarks, wdlStatsMap }: WDLBarChartProps) {
           }}
         />
         <ChartLegend content={<ChartLegendContent />} />
-        <Bar xAxisId="pct" dataKey="win_pct" stackId="wdl" fill="var(--color-win_pct)" radius={[0, 0, 0, 0]} />
+        {/* Radius on outermost bars only — Recharts 2.x doesn't support BarStack (3.x feature).
+            If a segment is 0%, its radius has no visual effect since Recharts skips zero-value bars. */}
+        <Bar xAxisId="pct" dataKey="win_pct" stackId="wdl" fill="var(--color-win_pct)" radius={[4, 4, 0, 0]} />
         <Bar xAxisId="pct" dataKey="draw_pct" stackId="wdl" fill="var(--color-draw_pct)" />
-        <Bar xAxisId="pct" dataKey="loss_pct" stackId="wdl" fill="var(--color-loss_pct)" radius={[0, 0, 0, 0]} />
+        <Bar xAxisId="pct" dataKey="loss_pct" stackId="wdl" fill="var(--color-loss_pct)" radius={[0, 0, 4, 4]} />
         <Bar
           xAxisId="count"
           dataKey="game_count"

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -96,6 +96,29 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
 
   return (
     <div className="space-y-3">
+      {/* Recency */}
+      {show('recency') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Recency</p>
+          <Select
+            value={filters.recency ?? 'all'}
+            onValueChange={(v) => update({ recency: v === 'all' ? null : (v as Recency) })}
+          >
+            <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0 w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All time</SelectItem>
+              <SelectItem value="week">Past week</SelectItem>
+              <SelectItem value="month">Past month</SelectItem>
+              <SelectItem value="3months">3 months</SelectItem>
+              <SelectItem value="6months">6 months</SelectItem>
+              <SelectItem value="year">1 year</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
       {/* Time controls */}
       {show('timeControl') && (
         <div>
@@ -191,29 +214,6 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
             <ToggleGroupItem value="bot" data-testid="filter-opponent-bot" className="min-h-11 sm:min-h-0 flex-1">Bot</ToggleGroupItem>
             <ToggleGroupItem value="both" data-testid="filter-opponent-both" className="min-h-11 sm:min-h-0 flex-1">Both</ToggleGroupItem>
           </ToggleGroup>
-        </div>
-      )}
-
-      {/* Recency */}
-      {show('recency') && (
-        <div>
-          <p className="mb-1 text-xs text-muted-foreground">Recency</p>
-          <Select
-            value={filters.recency ?? 'all'}
-            onValueChange={(v) => update({ recency: v === 'all' ? null : (v as Recency) })}
-          >
-            <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0 w-full">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All time</SelectItem>
-              <SelectItem value="week">Past week</SelectItem>
-              <SelectItem value="month">Past month</SelectItem>
-              <SelectItem value="3months">3 months</SelectItem>
-              <SelectItem value="6months">6 months</SelectItem>
-              <SelectItem value="year">1 year</SelectItem>
-            </SelectContent>
-          </Select>
         </div>
       )}
     </div>

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -135,7 +135,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isTimeControlActive(tc)
                     ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
+                    : 'border-border bg-[#171717] text-muted-foreground hover:bg-[#262626] hover:text-foreground',
                 )}
               >
                 {TIME_CONTROL_LABELS[tc]}
@@ -161,7 +161,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isPlatformActive(p)
                     ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
+                    : 'border-border bg-[#171717] text-muted-foreground hover:bg-[#262626] hover:text-foreground',
                 )}
               >
                 {PLATFORM_LABELS[p]}

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -135,7 +135,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isTimeControlActive(tc)
                     ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border bg-[#171717] text-muted-foreground hover:bg-[#262626] hover:text-foreground',
+                    : 'border-border bg-inactive-bg text-muted-foreground hover:bg-inactive-bg-hover hover:text-foreground',
                 )}
               >
                 {TIME_CONTROL_LABELS[tc]}
@@ -161,7 +161,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isPlatformActive(p)
                     ? 'border-primary bg-primary text-primary-foreground'
-                    : 'border-border bg-[#171717] text-muted-foreground hover:bg-[#262626] hover:text-foreground',
+                    : 'border-border bg-inactive-bg text-muted-foreground hover:bg-inactive-bg-hover hover:text-foreground',
                 )}
               >
                 {PLATFORM_LABELS[p]}

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -185,7 +185,7 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
           value={filters.recency ?? 'all'}
           onValueChange={(v) => update({ recency: v === 'all' ? null : (v as Recency) })}
         >
-          <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0">
+          <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0 w-full">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -91,7 +91,7 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
       {/* Time controls */}
       <div>
         <p className="mb-1 text-xs text-muted-foreground">Time control</p>
-        <div className="flex flex-wrap gap-1">
+        <div className="grid grid-cols-4 gap-1">
           {TIME_CONTROLS.map((tc) => (
             <button
               key={tc}
@@ -100,7 +100,7 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
               aria-label={`${TIME_CONTROL_LABELS[tc]} time control`}
               aria-pressed={isTimeControlActive(tc)}
               className={cn(
-                'rounded border px-3 h-11 sm:h-7 sm:px-2 text-xs transition-colors',
+                'rounded border h-11 sm:h-7 text-xs transition-colors',
                 isTimeControlActive(tc)
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
@@ -115,7 +115,7 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
       {/* Platform */}
       <div>
         <p className="mb-1 text-xs text-muted-foreground">Platform</p>
-        <div className="flex flex-wrap gap-1">
+        <div className="grid grid-cols-2 gap-1">
           {PLATFORMS.map((p) => (
             <button
               key={p}
@@ -124,7 +124,7 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
               aria-label={`${PLATFORM_LABELS[p]} platform`}
               aria-pressed={isPlatformActive(p)}
               className={cn(
-                'rounded border px-3 h-11 sm:h-7 sm:px-2 text-xs transition-colors',
+                'rounded border h-11 sm:h-7 text-xs transition-colors',
                 isPlatformActive(p)
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
@@ -149,10 +149,11 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
           variant="outline"
           size="sm"
           data-testid="filter-rated"
+          className="w-full"
         >
-          <ToggleGroupItem value="all" data-testid="filter-rated-all" className="min-h-11 sm:min-h-0">All</ToggleGroupItem>
-          <ToggleGroupItem value="rated" data-testid="filter-rated-rated" className="min-h-11 sm:min-h-0">Rated</ToggleGroupItem>
-          <ToggleGroupItem value="casual" data-testid="filter-rated-casual" className="min-h-11 sm:min-h-0">Casual</ToggleGroupItem>
+          <ToggleGroupItem value="all" data-testid="filter-rated-all" className="min-h-11 sm:min-h-0 flex-1">All</ToggleGroupItem>
+          <ToggleGroupItem value="rated" data-testid="filter-rated-rated" className="min-h-11 sm:min-h-0 flex-1">Rated</ToggleGroupItem>
+          <ToggleGroupItem value="casual" data-testid="filter-rated-casual" className="min-h-11 sm:min-h-0 flex-1">Casual</ToggleGroupItem>
         </ToggleGroup>
       </div>
 
@@ -169,10 +170,11 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
           variant="outline"
           size="sm"
           data-testid="filter-opponent"
+          className="w-full"
         >
-          <ToggleGroupItem value="human" data-testid="filter-opponent-human" className="min-h-11 sm:min-h-0">Human</ToggleGroupItem>
-          <ToggleGroupItem value="bot" data-testid="filter-opponent-bot" className="min-h-11 sm:min-h-0">Bot</ToggleGroupItem>
-          <ToggleGroupItem value="both" data-testid="filter-opponent-both" className="min-h-11 sm:min-h-0">Both</ToggleGroupItem>
+          <ToggleGroupItem value="human" data-testid="filter-opponent-human" className="min-h-11 sm:min-h-0 flex-1">Human</ToggleGroupItem>
+          <ToggleGroupItem value="bot" data-testid="filter-opponent-bot" className="min-h-11 sm:min-h-0 flex-1">Bot</ToggleGroupItem>
+          <ToggleGroupItem value="both" data-testid="filter-opponent-both" className="min-h-11 sm:min-h-0 flex-1">Both</ToggleGroupItem>
         </ToggleGroup>
       </div>
 

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -30,10 +30,16 @@ export const DEFAULT_FILTERS: FilterState = {
   color: 'white',
 };
 
+type FilterField = 'timeControl' | 'platform' | 'rated' | 'opponent' | 'recency';
+
 interface FilterPanelProps {
   filters: FilterState;
   onChange: (filters: FilterState) => void;
+  /** Which filter sections to show. Defaults to all. */
+  visibleFilters?: FilterField[];
 }
+
+const ALL_FILTERS: FilterField[] = ['timeControl', 'platform', 'rated', 'opponent', 'recency'];
 
 const TIME_CONTROLS: TimeControl[] = ['bullet', 'blitz', 'rapid', 'classical'];
 const TIME_CONTROL_LABELS: Record<TimeControl, string> = {
@@ -49,7 +55,7 @@ const PLATFORM_LABELS: Record<Platform, string> = {
   lichess: 'Lichess',
 };
 
-export function FilterPanel({ filters, onChange }: FilterPanelProps) {
+export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }: FilterPanelProps) {
   const update = (partial: Partial<FilterState>) => {
     onChange({ ...filters, ...partial });
   };
@@ -86,118 +92,130 @@ export function FilterPanel({ filters, onChange }: FilterPanelProps) {
     return filters.platforms.includes(p);
   };
 
+  const show = (field: FilterField) => visibleFilters.includes(field);
+
   return (
     <div className="space-y-3">
       {/* Time controls */}
-      <div>
-        <p className="mb-1 text-xs text-muted-foreground">Time control</p>
-        <div className="grid grid-cols-4 gap-1">
-          {TIME_CONTROLS.map((tc) => (
-            <button
-              key={tc}
-              onClick={() => toggleTimeControl(tc)}
-              data-testid={`filter-time-control-${tc}`}
-              aria-label={`${TIME_CONTROL_LABELS[tc]} time control`}
-              aria-pressed={isTimeControlActive(tc)}
-              className={cn(
-                'rounded border h-11 sm:h-7 text-xs transition-colors',
-                isTimeControlActive(tc)
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
-              )}
-            >
-              {TIME_CONTROL_LABELS[tc]}
-            </button>
-          ))}
+      {show('timeControl') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Time control</p>
+          <div className="grid grid-cols-4 gap-1">
+            {TIME_CONTROLS.map((tc) => (
+              <button
+                key={tc}
+                onClick={() => toggleTimeControl(tc)}
+                data-testid={`filter-time-control-${tc}`}
+                aria-label={`${TIME_CONTROL_LABELS[tc]} time control`}
+                aria-pressed={isTimeControlActive(tc)}
+                className={cn(
+                  'rounded border h-11 sm:h-7 text-xs transition-colors',
+                  isTimeControlActive(tc)
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
+                )}
+              >
+                {TIME_CONTROL_LABELS[tc]}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Platform */}
-      <div>
-        <p className="mb-1 text-xs text-muted-foreground">Platform</p>
-        <div className="grid grid-cols-2 gap-1">
-          {PLATFORMS.map((p) => (
-            <button
-              key={p}
-              onClick={() => togglePlatform(p)}
-              data-testid={`filter-platform-${p === 'chess.com' ? 'chess-com' : p}`}
-              aria-label={`${PLATFORM_LABELS[p]} platform`}
-              aria-pressed={isPlatformActive(p)}
-              className={cn(
-                'rounded border h-11 sm:h-7 text-xs transition-colors',
-                isPlatformActive(p)
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
-              )}
-            >
-              {PLATFORM_LABELS[p]}
-            </button>
-          ))}
+      {show('platform') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Platform</p>
+          <div className="grid grid-cols-2 gap-1">
+            {PLATFORMS.map((p) => (
+              <button
+                key={p}
+                onClick={() => togglePlatform(p)}
+                data-testid={`filter-platform-${p === 'chess.com' ? 'chess-com' : p}`}
+                aria-label={`${PLATFORM_LABELS[p]} platform`}
+                aria-pressed={isPlatformActive(p)}
+                className={cn(
+                  'rounded border h-11 sm:h-7 text-xs transition-colors',
+                  isPlatformActive(p)
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
+                )}
+              >
+                {PLATFORM_LABELS[p]}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Rated */}
-      <div>
-        <p className="mb-1 text-xs text-muted-foreground">Rated</p>
-        <ToggleGroup
-          type="single"
-          value={filters.rated === null ? 'all' : filters.rated ? 'rated' : 'casual'}
-          onValueChange={(v) => {
-            if (!v) return;
-            update({ rated: v === 'all' ? null : v === 'rated' });
-          }}
-          variant="outline"
-          size="sm"
-          data-testid="filter-rated"
-          className="w-full"
-        >
-          <ToggleGroupItem value="all" data-testid="filter-rated-all" className="min-h-11 sm:min-h-0 flex-1">All</ToggleGroupItem>
-          <ToggleGroupItem value="rated" data-testid="filter-rated-rated" className="min-h-11 sm:min-h-0 flex-1">Rated</ToggleGroupItem>
-          <ToggleGroupItem value="casual" data-testid="filter-rated-casual" className="min-h-11 sm:min-h-0 flex-1">Casual</ToggleGroupItem>
-        </ToggleGroup>
-      </div>
+      {show('rated') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Rated</p>
+          <ToggleGroup
+            type="single"
+            value={filters.rated === null ? 'all' : filters.rated ? 'rated' : 'casual'}
+            onValueChange={(v) => {
+              if (!v) return;
+              update({ rated: v === 'all' ? null : v === 'rated' });
+            }}
+            variant="outline"
+            size="sm"
+            data-testid="filter-rated"
+            className="w-full"
+          >
+            <ToggleGroupItem value="all" data-testid="filter-rated-all" className="min-h-11 sm:min-h-0 flex-1">All</ToggleGroupItem>
+            <ToggleGroupItem value="rated" data-testid="filter-rated-rated" className="min-h-11 sm:min-h-0 flex-1">Rated</ToggleGroupItem>
+            <ToggleGroupItem value="casual" data-testid="filter-rated-casual" className="min-h-11 sm:min-h-0 flex-1">Casual</ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      )}
 
       {/* Opponent */}
-      <div>
-        <p className="mb-1 text-xs text-muted-foreground">Opponent</p>
-        <ToggleGroup
-          type="single"
-          value={filters.opponentType}
-          onValueChange={(v) => {
-            if (!v) return;
-            update({ opponentType: v as OpponentType });
-          }}
-          variant="outline"
-          size="sm"
-          data-testid="filter-opponent"
-          className="w-full"
-        >
-          <ToggleGroupItem value="human" data-testid="filter-opponent-human" className="min-h-11 sm:min-h-0 flex-1">Human</ToggleGroupItem>
-          <ToggleGroupItem value="bot" data-testid="filter-opponent-bot" className="min-h-11 sm:min-h-0 flex-1">Bot</ToggleGroupItem>
-          <ToggleGroupItem value="both" data-testid="filter-opponent-both" className="min-h-11 sm:min-h-0 flex-1">Both</ToggleGroupItem>
-        </ToggleGroup>
-      </div>
+      {show('opponent') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Opponent</p>
+          <ToggleGroup
+            type="single"
+            value={filters.opponentType}
+            onValueChange={(v) => {
+              if (!v) return;
+              update({ opponentType: v as OpponentType });
+            }}
+            variant="outline"
+            size="sm"
+            data-testid="filter-opponent"
+            className="w-full"
+          >
+            <ToggleGroupItem value="human" data-testid="filter-opponent-human" className="min-h-11 sm:min-h-0 flex-1">Human</ToggleGroupItem>
+            <ToggleGroupItem value="bot" data-testid="filter-opponent-bot" className="min-h-11 sm:min-h-0 flex-1">Bot</ToggleGroupItem>
+            <ToggleGroupItem value="both" data-testid="filter-opponent-both" className="min-h-11 sm:min-h-0 flex-1">Both</ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      )}
 
       {/* Recency */}
-      <div>
-        <p className="mb-1 text-xs text-muted-foreground">Recency</p>
-        <Select
-          value={filters.recency ?? 'all'}
-          onValueChange={(v) => update({ recency: v === 'all' ? null : (v as Recency) })}
-        >
-          <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0 w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All time</SelectItem>
-            <SelectItem value="week">Past week</SelectItem>
-            <SelectItem value="month">Past month</SelectItem>
-            <SelectItem value="3months">3 months</SelectItem>
-            <SelectItem value="6months">6 months</SelectItem>
-            <SelectItem value="year">1 year</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      {show('recency') && (
+        <div>
+          <p className="mb-1 text-xs text-muted-foreground">Recency</p>
+          <Select
+            value={filters.recency ?? 'all'}
+            onValueChange={(v) => update({ recency: v === 'all' ? null : (v as Recency) })}
+          >
+            <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0 w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All time</SelectItem>
+              <SelectItem value="week">Past week</SelectItem>
+              <SelectItem value="month">Past month</SelectItem>
+              <SelectItem value="3months">3 months</SelectItem>
+              <SelectItem value="6months">6 months</SelectItem>
+              <SelectItem value="year">1 year</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/results/GameCard.tsx
+++ b/frontend/src/components/results/GameCard.tsx
@@ -84,7 +84,7 @@ export function GameCard({ game }: GameCardProps) {
     <div
       data-testid={`game-card-${game.game_id}`}
       className={cn(
-        'border-l-4 bg-card border border-border rounded px-4 py-3 flex gap-3 items-center',
+        'border-l-4 charcoal-texture border border-border/20 rounded px-4 py-3 flex gap-3 items-center',
         BORDER_CLASSES[game.user_result],
       )}
     >

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -68,7 +68,7 @@ function TabsTrigger({
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        "group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent group-data-[variant=brand]/tabs-list:data-active:shadow-none",
+        "group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown-active group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent group-data-[variant=brand]/tabs-list:data-active:shadow-none",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -31,6 +31,7 @@ const tabsListVariants = cva(
       variant: {
         default: "bg-muted",
         line: "gap-1 bg-transparent",
+        brand: "bg-charcoal gap-0",
       },
     },
     defaultVariants: {
@@ -67,6 +68,7 @@ function TabsTrigger({
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent group-data-[variant=brand]/tabs-list:data-active:shadow-none",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -68,7 +68,7 @@ function TabsTrigger({
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        "group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown-active group-data-[variant=brand]/tabs-list:data-active:text-white group-data-[variant=brand]/tabs-list:data-active:border-transparent group-data-[variant=brand]/tabs-list:data-active:shadow-none",
+        "group-data-[variant=brand]/tabs-list:data-active:bg-brand-brown-active! group-data-[variant=brand]/tabs-list:data-active:text-white! group-data-[variant=brand]/tabs-list:data-active:border-transparent! group-data-[variant=brand]/tabs-list:data-active:shadow-none!",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -31,7 +31,7 @@ const tabsListVariants = cva(
       variant: {
         default: "bg-muted",
         line: "gap-1 bg-transparent",
-        brand: "bg-charcoal gap-0",
+        brand: "charcoal-texture gap-0",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -10,7 +10,7 @@ const toggleVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border border-input bg-transparent hover:bg-muted text-muted-foreground",
+        outline: "border border-input bg-[#171717] hover:bg-[#262626] text-muted-foreground",
       },
       size: {
         default: "h-8 min-w-8 px-2",

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -10,7 +10,7 @@ const toggleVariants = cva(
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border border-input bg-[#171717] hover:bg-[#262626] text-muted-foreground",
+        outline: "border border-input bg-inactive-bg hover:bg-inactive-bg-hover text-muted-foreground",
       },
       size: {
         default: "h-8 min-w-8 px-2",

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -5,12 +5,12 @@ import { Toggle as TogglePrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border border-input bg-transparent hover:bg-muted",
+        outline: "border border-input bg-transparent hover:bg-muted text-muted-foreground",
       },
       size: {
         default: "h-8 min-w-8 px-2",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,8 +42,8 @@
     --brand-brown: #8B5E3C;
     --brand-brown-hover: #6B4226;
     --brand-brown-active: #6C4328;
-    --charcoal: #2A2520;
-    --charcoal-hover: #262626;
+    --charcoal: #1C1917;
+    --charcoal-hover: #262220;
     --sidebar-bg: #171513;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,6 +44,8 @@
     --brand-brown-active: #6C4328;
     --charcoal: #161412;
     --charcoal-hover: #262220;
+    --inactive-bg: #171717;
+    --inactive-bg-hover: #262626;
     --sidebar-bg: #171513;
 }
 
@@ -126,6 +128,8 @@
     --color-brand-brown-active: var(--brand-brown-active);
     --color-charcoal: var(--charcoal);
     --color-charcoal-hover: var(--charcoal-hover);
+    --color-inactive-bg: var(--inactive-bg);
+    --color-inactive-bg-hover: var(--inactive-bg-hover);
     --color-sidebar-bg: var(--sidebar-bg);
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,10 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+    --brand-brown: #8B5E3C;
+    --brand-brown-hover: #6B4226;
+    --charcoal: #2A2520;
+    --sidebar-bg: #171513;
 }
 
 .dark {
@@ -115,6 +119,10 @@
     --radius-2xl: calc(var(--radius) * 1.8);
     --radius-3xl: calc(var(--radius) * 2.2);
     --radius-4xl: calc(var(--radius) * 2.6);
+    --color-brand-brown: var(--brand-brown);
+    --color-brand-brown-hover: var(--brand-brown-hover);
+    --color-charcoal: var(--charcoal);
+    --color-sidebar-bg: var(--sidebar-bg);
 }
 
 @layer base {
@@ -131,6 +139,30 @@
   .font-brand {
     font-family: 'Fredoka', sans-serif;
     }
+}
+
+@layer components {
+  .charcoal-texture {
+    position: relative;
+    overflow: hidden;
+    background-color: var(--charcoal);
+  }
+  .charcoal-texture::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 600'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C%2Fsvg%3E");
+    background-repeat: repeat;
+    background-size: 200px;
+    opacity: 0.06;
+  }
+  /* Ensure children stack above the texture pseudo-element */
+  .charcoal-texture > * {
+    position: relative;
+    z-index: 1;
+  }
 }
 
 @keyframes progress-indeterminate {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,7 +41,9 @@
     --sidebar-ring: oklch(0.708 0 0);
     --brand-brown: #8B5E3C;
     --brand-brown-hover: #6B4226;
+    --brand-brown-active: #6C4328;
     --charcoal: #2A2520;
+    --charcoal-hover: #262626;
     --sidebar-bg: #171513;
 }
 
@@ -121,7 +123,9 @@
     --radius-4xl: calc(var(--radius) * 2.6);
     --color-brand-brown: var(--brand-brown);
     --color-brand-brown-hover: var(--brand-brown-hover);
+    --color-brand-brown-active: var(--brand-brown-active);
     --color-charcoal: var(--charcoal);
+    --color-charcoal-hover: var(--charcoal-hover);
     --color-sidebar-bg: var(--sidebar-bg);
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,7 +42,7 @@
     --brand-brown: #8B5E3C;
     --brand-brown-hover: #6B4226;
     --brand-brown-active: #6C4328;
-    --charcoal: #1C1917;
+    --charcoal: #161412;
     --charcoal-hover: #262220;
     --sidebar-bg: #171513;
 }

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -17,7 +17,7 @@ export const lightSquareStyle = { backgroundColor: BOARD_LIGHT_SQUARE } as const
  * because Tailwind scans source files at build time and can't resolve dynamic strings.
  * Update both the class string and the constants below when changing button colors.
  */
-export const PRIMARY_BUTTON_CLASS = 'bg-[#8B5E3C] hover:bg-[#6B4226] text-white';
+export const PRIMARY_BUTTON_CLASS = 'bg-brand-brown hover:bg-brand-brown-hover text-white';
 
 // WDL colors — used in all win/draw/loss visualizations
 // Richer base colors; the glass overlay softens them visually when applied

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -294,6 +294,7 @@ export function DashboardPage() {
   const leftColumn = (
     <div className="flex flex-col gap-2 min-w-0">
       {/* Section 1: Position filter */}
+      <div className="charcoal-texture rounded-md p-2">
       <Collapsible open={positionFilterOpen} onOpenChange={setPositionFilterOpen}>
         <CollapsibleTrigger asChild>
           <Button
@@ -402,8 +403,10 @@ export function DashboardPage() {
           </div>
         </CollapsibleContent>
       </Collapsible>
+      </div>
 
       {/* Section 2: Position bookmarks */}
+      <div className="charcoal-texture rounded-md p-2">
       <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
         <CollapsibleTrigger asChild>
           <Button
@@ -426,8 +429,10 @@ export function DashboardPage() {
           </div>
         </CollapsibleContent>
       </Collapsible>
+      </div>
 
       {/* Section 3: More filters */}
+      <div className="charcoal-texture rounded-md p-2">
       <Collapsible open={moreFiltersOpen} onOpenChange={setMoreFiltersOpen}>
         <CollapsibleTrigger asChild>
           <Button
@@ -446,6 +451,7 @@ export function DashboardPage() {
           </div>
         </CollapsibleContent>
       </Collapsible>
+      </div>
 
       {/* Always-visible action buttons */}
       <div className="flex gap-2 pt-1">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -294,13 +294,13 @@ export function DashboardPage() {
   const leftColumn = (
     <div className="flex flex-col gap-2 min-w-0">
       {/* Section 1: Position filter */}
-      <div className="charcoal-texture rounded-md p-2">
+      <div className="charcoal-texture rounded-md">
       <Collapsible open={positionFilterOpen} onOpenChange={setPositionFilterOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium"
+            className="w-full justify-between px-3 text-sm font-medium rounded-none hover:bg-charcoal-hover!"
             data-testid="section-position-filter"
           >
             Position filter
@@ -308,7 +308,8 @@ export function DashboardPage() {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex flex-col gap-3 pt-2">
+          <div className="border-t border-border/20" />
+          <div className="flex flex-col gap-3 p-2 pt-2">
             <ChessBoard
               position={chess.position}
               onPieceDrop={chess.makeMove}
@@ -344,47 +345,49 @@ export function DashboardPage() {
             />
 
             {/* Played as + Piece filter */}
-            <div className="flex flex-wrap gap-x-4 gap-y-3">
-              <div>
-                <p className="mb-1 text-xs text-muted-foreground">Played as</p>
-                <ToggleGroup
-                  type="single"
-                  value={filters.color}
-                  onValueChange={(v) => {
-                    if (!v) return;
-                    const color = v as Color;
-                    setFilters(prev => ({ ...prev, color }));
-                    setBoardFlipped(color === 'black');
-                  }}
-                  variant="outline"
-                  size="sm"
-                  data-testid="filter-played-as"
-                >
-                  <ToggleGroupItem value="white" data-testid="filter-played-as-white">
-                    <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white mr-1" />
-                    White
-                  </ToggleGroupItem>
-                  <ToggleGroupItem value="black" data-testid="filter-played-as-black">
-                    <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900 mr-1" />
-                    Black
-                  </ToggleGroupItem>
-                </ToggleGroup>
-              </div>
+            <div className="charcoal-texture rounded-md p-2">
+              <div className="flex flex-wrap gap-x-4 gap-y-3">
+                <div>
+                  <p className="mb-1 text-xs text-muted-foreground">Played as</p>
+                  <ToggleGroup
+                    type="single"
+                    value={filters.color}
+                    onValueChange={(v) => {
+                      if (!v) return;
+                      const color = v as Color;
+                      setFilters(prev => ({ ...prev, color }));
+                      setBoardFlipped(color === 'black');
+                    }}
+                    variant="outline"
+                    size="sm"
+                    data-testid="filter-played-as"
+                  >
+                    <ToggleGroupItem value="white" data-testid="filter-played-as-white">
+                      <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white mr-1" />
+                      White
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="black" data-testid="filter-played-as-black">
+                      <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900 mr-1" />
+                      Black
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
 
-              <div>
-                <p className="mb-1 text-xs text-muted-foreground">Piece filter</p>
-                <ToggleGroup
-                  type="single"
-                  value={filters.matchSide}
-                  onValueChange={(v) => v && setFilters(prev => ({ ...prev, matchSide: v as MatchSide }))}
-                  variant="outline"
-                  size="sm"
-                  data-testid="filter-piece-filter"
-                >
-                  <ToggleGroupItem value="mine" data-testid="filter-piece-filter-mine">Mine</ToggleGroupItem>
-                  <ToggleGroupItem value="opponent" data-testid="filter-piece-filter-opponent">Opponent</ToggleGroupItem>
-                  <ToggleGroupItem value="both" data-testid="filter-piece-filter-both">Both</ToggleGroupItem>
-                </ToggleGroup>
+                <div>
+                  <p className="mb-1 text-xs text-muted-foreground">Piece filter</p>
+                  <ToggleGroup
+                    type="single"
+                    value={filters.matchSide}
+                    onValueChange={(v) => v && setFilters(prev => ({ ...prev, matchSide: v as MatchSide }))}
+                    variant="outline"
+                    size="sm"
+                    data-testid="filter-piece-filter"
+                  >
+                    <ToggleGroupItem value="mine" data-testid="filter-piece-filter-mine">Mine</ToggleGroupItem>
+                    <ToggleGroupItem value="opponent" data-testid="filter-piece-filter-opponent">Opponent</ToggleGroupItem>
+                    <ToggleGroupItem value="both" data-testid="filter-piece-filter-both">Both</ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
               </div>
             </div>
 
@@ -406,13 +409,13 @@ export function DashboardPage() {
       </div>
 
       {/* Section 2: Position bookmarks */}
-      <div className="charcoal-texture rounded-md p-2">
+      <div className="charcoal-texture rounded-md">
       <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium"
+            className="w-full justify-between px-3 text-sm font-medium rounded-none hover:bg-charcoal-hover!"
             data-testid="section-position-bookmarks"
           >
             Position bookmarks
@@ -420,7 +423,8 @@ export function DashboardPage() {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="pt-2">
+          <div className="border-t border-border/20" />
+          <div className="p-2">
             <PositionBookmarkList
               bookmarks={bookmarks}
               onReorder={handleReorder}
@@ -432,13 +436,13 @@ export function DashboardPage() {
       </div>
 
       {/* Section 3: More filters */}
-      <div className="charcoal-texture rounded-md p-2">
+      <div className="charcoal-texture rounded-md">
       <Collapsible open={moreFiltersOpen} onOpenChange={setMoreFiltersOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium"
+            className="w-full justify-between px-3 text-sm font-medium rounded-none hover:bg-charcoal-hover!"
             data-testid="section-more-filters"
           >
             More filters
@@ -446,7 +450,8 @@ export function DashboardPage() {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="pt-2">
+          <div className="border-t border-border/20" />
+          <div className="p-2">
             <FilterPanel filters={filters} onChange={handleFiltersChange} />
           </div>
         </CollapsibleContent>

--- a/frontend/src/pages/Endgames.tsx
+++ b/frontend/src/pages/Endgames.tsx
@@ -98,7 +98,7 @@ export function EndgamesPage() {
           ({(statsData.endgame_games / statsData.total_games * 100).toFixed(1)}%) reached an endgame phase
         </p>
         <Accordion type="single" collapsible>
-          <AccordionItem value="concepts" className="border rounded-md border-border px-4" data-testid="endgame-concepts-trigger">
+          <AccordionItem value="concepts" className="charcoal-texture rounded-md px-4" data-testid="endgame-concepts-trigger">
             <AccordionTrigger className="text-muted-foreground hover:no-underline">
               Endgame statistics concepts
             </AccordionTrigger>
@@ -141,20 +141,30 @@ export function EndgamesPage() {
         <>
           {endgameSummary}
           {perfData && perfData.endgame_wdl.total > 0 && (
-            <EndgamePerformanceSection data={perfData} />
+            <div className="charcoal-texture rounded-md">
+              <EndgamePerformanceSection data={perfData} />
+            </div>
           )}
           {convRecovData && (convRecovData.conversion.length > 0 || convRecovData.recovery.length > 0) && (
-            <EndgameConvRecovTimelineChart data={convRecovData} />
+            <div className="charcoal-texture rounded-md">
+              <EndgameConvRecovTimelineChart data={convRecovData} />
+            </div>
           )}
-          <EndgameWDLChart
-            categories={statsData.categories}
-            onCategorySelect={handleCategorySelect}
-          />
+          <div className="charcoal-texture rounded-md">
+            <EndgameWDLChart
+              categories={statsData.categories}
+              onCategorySelect={handleCategorySelect}
+            />
+          </div>
           {statsData && statsData.categories.length > 0 && (
-            <EndgameConvRecovChart categories={statsData.categories} />
+            <div className="charcoal-texture rounded-md">
+              <EndgameConvRecovChart categories={statsData.categories} />
+            </div>
           )}
           {timelineData && timelineData.overall.length > 0 && (
-            <EndgameTimelineChart data={timelineData} />
+            <div className="charcoal-texture rounded-md">
+              <EndgameTimelineChart data={timelineData} />
+            </div>
           )}
         </>
       ) : statsData && statsData.categories.length === 0 ? (
@@ -255,7 +265,7 @@ export function EndgamesPage() {
           </div>
           <div className="min-w-0">
             <Tabs value={activeTab} onValueChange={(val) => navigate(`/endgames/${val}`)}>
-              <TabsList className="w-full" data-testid="endgames-tabs">
+              <TabsList variant="brand" className="w-full" data-testid="endgames-tabs">
                 <TabsTrigger value="statistics" data-testid="tab-statistics" className="flex-1">
                   <BarChart2Icon className="mr-1.5 h-4 w-4" />
                   Statistics
@@ -307,7 +317,7 @@ export function EndgamesPage() {
             </div>
 
             {/* Tabs: Statistics / Games */}
-            <TabsList className="w-full h-11!" data-testid="endgames-tabs-mobile">
+            <TabsList variant="brand" className="w-full h-11!" data-testid="endgames-tabs-mobile">
               <TabsTrigger value="statistics" className="flex-1" data-testid="tab-statistics-mobile">
                 <BarChart2Icon className="mr-1.5 h-4 w-4" />
                 Statistics

--- a/frontend/src/pages/Endgames.tsx
+++ b/frontend/src/pages/Endgames.tsx
@@ -141,28 +141,28 @@ export function EndgamesPage() {
         <>
           {endgameSummary}
           {perfData && perfData.endgame_wdl.total > 0 && (
-            <div className="charcoal-texture rounded-md">
+            <div className="charcoal-texture rounded-md p-4">
               <EndgamePerformanceSection data={perfData} />
             </div>
           )}
           {convRecovData && (convRecovData.conversion.length > 0 || convRecovData.recovery.length > 0) && (
-            <div className="charcoal-texture rounded-md">
+            <div className="charcoal-texture rounded-md p-4">
               <EndgameConvRecovTimelineChart data={convRecovData} />
             </div>
           )}
-          <div className="charcoal-texture rounded-md">
+          <div className="charcoal-texture rounded-md p-4">
             <EndgameWDLChart
               categories={statsData.categories}
               onCategorySelect={handleCategorySelect}
             />
           </div>
           {statsData && statsData.categories.length > 0 && (
-            <div className="charcoal-texture rounded-md">
+            <div className="charcoal-texture rounded-md p-4">
               <EndgameConvRecovChart categories={statsData.categories} />
             </div>
           )}
           {timelineData && timelineData.overall.length > 0 && (
-            <div className="charcoal-texture rounded-md">
+            <div className="charcoal-texture rounded-md p-4">
               <EndgameTimelineChart data={timelineData} />
             </div>
           )}
@@ -261,7 +261,9 @@ export function EndgamesPage() {
         {/* Desktop: two-column layout */}
         <div className="hidden md:grid md:grid-cols-[280px_1fr] md:gap-8">
           <div className="min-w-0">
-            <FilterPanel filters={filters} onChange={handleFilterChange} />
+            <div className="charcoal-texture rounded-md p-2">
+              <FilterPanel filters={filters} onChange={handleFilterChange} />
+            </div>
           </div>
           <div className="min-w-0">
             <Tabs value={activeTab} onValueChange={(val) => navigate(`/endgames/${val}`)}>

--- a/frontend/src/pages/GlobalStats.tsx
+++ b/frontend/src/pages/GlobalStats.tsx
@@ -1,130 +1,131 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { InfoPopover } from '@/components/ui/info-popover';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { FilterPanel, DEFAULT_FILTERS } from '@/components/filters/FilterPanel';
 import { useGlobalStats, useRatingHistory } from '@/hooks/useStats';
 import { GlobalStatsCharts } from '@/components/stats/GlobalStatsCharts';
 import { RatingChart } from '@/components/stats/RatingChart';
-import { cn } from '@/lib/utils';
-import type { Platform, Recency } from '@/types/api';
+import type { FilterState } from '@/components/filters/FilterPanel';
 
 export function GlobalStatsPage() {
-  const [recency, setRecency] = useState<Recency | null>(null);
-  const [selectedPlatforms, setSelectedPlatforms] = useState<Platform[] | null>(null);
+  const [filters, setFilters] = useState<FilterState>({
+    ...DEFAULT_FILTERS,
+    color: 'white',
+    matchSide: 'both',
+  });
+
+  // Derive recency and platforms from FilterState for the stats hooks
+  const recency = filters.recency;
+  const selectedPlatforms = filters.platforms;
 
   const { data: ratingData, isLoading: ratingLoading } = useRatingHistory(recency, selectedPlatforms);
   const { data: globalStats, isLoading: statsLoading } = useGlobalStats(recency, selectedPlatforms);
 
   const isLoading = ratingLoading || statsLoading;
 
-  return (
-    <div data-testid="global-stats-page" className="mx-auto max-w-4xl space-y-6 px-6 py-6">
-      {/* Sticky filters */}
-      <div className="sticky top-0 z-10 bg-background pb-2 -mx-6 px-6 pt-1">
-        <div className="flex flex-wrap items-end gap-4">
-        {/* Recency filter */}
-        <div>
-          <p className="mb-1 text-xs text-muted-foreground">Recency</p>
-          <Select
-            value={recency ?? 'all'}
-            onValueChange={(v) => setRecency(v === 'all' ? null : (v as Recency))}
-          >
-            <SelectTrigger size="sm" data-testid="filter-recency" className="min-h-11 sm:min-h-0">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All time</SelectItem>
-              <SelectItem value="week">Past week</SelectItem>
-              <SelectItem value="month">Past month</SelectItem>
-              <SelectItem value="3months">3 months</SelectItem>
-              <SelectItem value="6months">6 months</SelectItem>
-              <SelectItem value="year">1 year</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
+  // ── Mobile collapsible state ───────────────────────────────────────────────
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
-        {/* Platform filter */}
-        <div>
-          <p className="mb-1 text-xs text-muted-foreground">Platform</p>
-          <div className="flex gap-1">
-            {(['chess.com', 'lichess'] as Platform[]).map((p) => {
-              const isActive = selectedPlatforms === null || selectedPlatforms.includes(p);
-              return (
-                <button
-                  key={p}
-                  onClick={() => {
-                    setSelectedPlatforms((prev) => {
-                      if (prev === null) return [p === 'chess.com' ? 'lichess' : 'chess.com'] as Platform[];
-                      if (prev.length === 1 && prev[0] === p) return null; // re-select = show all
-                      if (prev.includes(p)) return prev.filter((x) => x !== p) as Platform[];
-                      return null; // both selected = all
-                    });
-                  }}
-                  data-testid={`filter-platform-${p === 'chess.com' ? 'chess-com' : p}`}
-                  aria-label={`${p} platform`}
-                  aria-pressed={isActive}
-                  className={cn(
-                    'rounded border px-3 h-11 sm:h-7 sm:px-2 text-xs transition-colors',
-                    isActive
-                      ? 'border-primary bg-primary text-primary-foreground'
-                      : 'border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground',
-                  )}
-                >
-                  {p === 'chess.com' ? 'Chess.com' : 'Lichess'}
-                </button>
-              );
-            })}
+  const handleFilterChange = useCallback((newFilters: FilterState) => {
+    setFilters(newFilters);
+  }, []);
+
+  const content = isLoading ? (
+    <div className="text-muted-foreground">Loading...</div>
+  ) : (
+    <div className="space-y-6">
+      {/* Chess.com Rating section */}
+      {(selectedPlatforms === null || selectedPlatforms.includes('chess.com')) && (
+        <div className="charcoal-texture rounded-md p-4">
+          <section data-testid="rating-section-chess-com" className="space-y-3">
+            <h2 className="text-lg font-medium">
+              <span className="inline-flex items-center gap-1">
+                Chess.com Rating
+                <InfoPopover ariaLabel="Chess.com rating info" testId="rating-chess-com-info" side="top">
+                  Your Chess.com rating over time by time control. Granularity adapts automatically: daily for shorter spans, weekly or monthly for longer ones.
+                </InfoPopover>
+              </span>
+            </h2>
+            <RatingChart data={ratingData?.chess_com ?? []} platform="Chess.com" />
+          </section>
+        </div>
+      )}
+
+      {/* Lichess Rating section */}
+      {(selectedPlatforms === null || selectedPlatforms.includes('lichess')) && (
+        <div className="charcoal-texture rounded-md p-4">
+          <section data-testid="rating-section-lichess" className="space-y-3">
+            <h2 className="text-lg font-medium">
+              <span className="inline-flex items-center gap-1">
+                Lichess Rating
+                <InfoPopover ariaLabel="Lichess rating info" testId="rating-lichess-info" side="top">
+                  Your Lichess rating over time by time control. Granularity adapts automatically: daily for shorter spans, weekly or monthly for longer ones. Lichess uses Glicko-2 ratings which start at 1500 and tend to run 200-400 points higher than Chess.com, so the two are not directly comparable.
+                </InfoPopover>
+              </span>
+            </h2>
+            <RatingChart data={ratingData?.lichess ?? []} platform="Lichess" />
+          </section>
+        </div>
+      )}
+
+      {/* WDL charts */}
+      <div className="charcoal-texture rounded-md p-4">
+        <GlobalStatsCharts
+          byTimeControl={globalStats?.by_time_control ?? []}
+          byColor={globalStats?.by_color ?? []}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div data-testid="global-stats-page" className="flex min-h-0 flex-1 flex-col bg-background">
+      <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-2 md:py-6 md:px-6">
+
+        {/* Desktop: two-column layout with sidebar */}
+        <div className="hidden md:grid md:grid-cols-[280px_1fr] md:gap-8">
+          <div className="min-w-0">
+            <div className="charcoal-texture rounded-md p-2">
+              <FilterPanel filters={filters} onChange={handleFilterChange} />
+            </div>
+          </div>
+          <div className="min-w-0">
+            {content}
           </div>
         </div>
+
+        {/* Mobile: single column */}
+        <div className="md:hidden flex flex-col gap-4 min-w-0">
+          {/* Mobile filters collapsible */}
+          <div className="sticky top-0 z-20 bg-background pb-2">
+            <div className="charcoal-texture rounded-md">
+              <Collapsible open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
+                <CollapsibleTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-between px-3 text-sm font-medium min-h-11 rounded-none hover:bg-charcoal-hover!"
+                    data-testid="section-filters-mobile"
+                  >
+                    Filters
+                    {mobileFiltersOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                  </Button>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="border-t border-border/20" />
+                  <div className="p-2">
+                    <FilterPanel filters={filters} onChange={handleFilterChange} />
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+          </div>
+
+          {content}
         </div>
-      </div>
-
-      {isLoading ? (
-        <div className="text-muted-foreground">Loading...</div>
-      ) : (
-        <>
-          {/* Chess.com Rating section */}
-          {(selectedPlatforms === null || selectedPlatforms.includes('chess.com')) && (
-            <section data-testid="rating-section-chess-com" className="space-y-3">
-              <h2 className="text-lg font-medium">
-                <span className="inline-flex items-center gap-1">
-                  Chess.com Rating
-                  <InfoPopover ariaLabel="Chess.com rating info" testId="rating-chess-com-info" side="top">
-                    Your Chess.com rating over time by time control. Granularity adapts automatically: daily for shorter spans, weekly or monthly for longer ones.
-                  </InfoPopover>
-                </span>
-              </h2>
-              <RatingChart data={ratingData?.chess_com ?? []} platform="Chess.com" />
-            </section>
-          )}
-
-          {/* Lichess Rating section */}
-          {(selectedPlatforms === null || selectedPlatforms.includes('lichess')) && (
-            <section data-testid="rating-section-lichess" className="space-y-3">
-              <h2 className="text-lg font-medium">
-                <span className="inline-flex items-center gap-1">
-                  Lichess Rating
-                  <InfoPopover ariaLabel="Lichess rating info" testId="rating-lichess-info" side="top">
-                    Your Lichess rating over time by time control. Granularity adapts automatically: daily for shorter spans, weekly or monthly for longer ones. Lichess uses Glicko-2 ratings which start at 1500 and tend to run 200-400 points higher than Chess.com, so the two are not directly comparable.
-                  </InfoPopover>
-                </span>
-              </h2>
-              <RatingChart data={ratingData?.lichess ?? []} platform="Lichess" />
-            </section>
-          )}
-
-          {/* WDL charts — always shown */}
-          <GlobalStatsCharts
-            byTimeControl={globalStats?.by_time_control ?? []}
-            byColor={globalStats?.by_color ?? []}
-          />
-        </>
-      )}
+      </main>
     </div>
   );
 }

--- a/frontend/src/pages/GlobalStats.tsx
+++ b/frontend/src/pages/GlobalStats.tsx
@@ -88,7 +88,7 @@ export function GlobalStatsPage() {
         <div className="hidden md:grid md:grid-cols-[280px_1fr] md:gap-8">
           <div className="min-w-0">
             <div className="charcoal-texture rounded-md p-2">
-              <FilterPanel filters={filters} onChange={handleFilterChange} />
+              <FilterPanel filters={filters} onChange={handleFilterChange} visibleFilters={['platform', 'recency']} />
             </div>
           </div>
           <div className="min-w-0">
@@ -116,7 +116,7 @@ export function GlobalStatsPage() {
                 <CollapsibleContent>
                   <div className="border-t border-border/20" />
                   <div className="p-2">
-                    <FilterPanel filters={filters} onChange={handleFilterChange} />
+                    <FilterPanel filters={filters} onChange={handleFilterChange} visibleFilters={['platform', 'recency']} />
                   </div>
                 </CollapsibleContent>
               </Collapsible>

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -180,7 +180,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
           {/* chess.com platform row */}
           <div
             data-testid="import-platform-chess-com"
-            className="space-y-2 rounded-md border px-3 py-2"
+            className="charcoal-texture space-y-2 rounded-md px-3 py-2"
           >
             <div className="flex items-center gap-3">
               <div className="flex-1 space-y-1">
@@ -223,7 +223,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
           {/* lichess platform row */}
           <div
             data-testid="import-platform-lichess"
-            className="space-y-2 rounded-md border px-3 py-2"
+            className="charcoal-texture space-y-2 rounded-md px-3 py-2"
           >
             <div className="flex items-center gap-3">
               <div className="flex-1 space-y-1">

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -430,14 +430,16 @@ export function OpeningsPage() {
       {nextMoves.data && nextMoves.data.position_stats.total > 0 && (
         <WDLBar stats={nextMoves.data.position_stats} />
       )}
-      <MoveExplorer
-        moves={nextMoves.data?.moves ?? []}
-        isLoading={nextMoves.isLoading}
-        isError={nextMoves.isError}
-        position={chess.position}
-        onMoveClick={(from, to) => chess.makeMove(from, to)}
-        onMoveHover={setHoveredMove}
-      />
+      <div className="charcoal-texture rounded-md p-4">
+        <MoveExplorer
+          moves={nextMoves.data?.moves ?? []}
+          isLoading={nextMoves.isLoading}
+          isError={nextMoves.isError}
+          position={chess.position}
+          onMoveClick={(from, to) => chess.makeMove(from, to)}
+          onMoveHover={setHoveredMove}
+        />
+      </div>
     </div>
   );
 

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -290,68 +290,68 @@ export function OpeningsPage() {
       <div className="border-t border-border/40" />
 
       {/* Played as + Piece filter */}
-      <div className="flex flex-wrap gap-x-4 gap-y-3">
-        <div>
-          <p className="mb-1 text-xs text-muted-foreground">Played as</p>
-          <ToggleGroup
-            type="single"
-            value={filters.color}
-            onValueChange={(v) => {
-              if (!v) return;
-              const color = v as Color;
-              setFilters(prev => ({ ...prev, color }));
-              setBoardFlipped(color === 'black');
-            }}
-            variant="outline"
-            size="sm"
-            data-testid="filter-played-as"
-          >
-            <ToggleGroupItem value="white" data-testid="filter-played-as-white">
-              <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white mr-1" />
-              White
-            </ToggleGroupItem>
-            <ToggleGroupItem value="black" data-testid="filter-played-as-black">
-              <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900 mr-1" />
-              Black
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </div>
-
-        <div className="ml-auto">
-          <div className="mb-1 flex items-center gap-1">
-            <p className="text-xs text-muted-foreground">Piece filter</p>
-            <InfoPopover ariaLabel="Piece filter info" testId="piece-filter-info" side="top">
-              Use the option "Mine" to find games with a specific formation (e.g. the London System) regardless of the opponent's moves. "Mine" matches only your pieces, "Opponent" only theirs, and "Both" requires an exact match of all pieces. The Moves tab always uses "Both".
-            </InfoPopover>
+      <div className="charcoal-texture rounded-md p-2">
+        <div className="flex flex-wrap gap-x-4 gap-y-3">
+          <div>
+            <p className="mb-1 text-xs text-muted-foreground">Played as</p>
+            <ToggleGroup
+              type="single"
+              value={filters.color}
+              onValueChange={(v) => {
+                if (!v) return;
+                const color = v as Color;
+                setFilters(prev => ({ ...prev, color }));
+                setBoardFlipped(color === 'black');
+              }}
+              variant="outline"
+              size="sm"
+              data-testid="filter-played-as"
+            >
+              <ToggleGroupItem value="white" data-testid="filter-played-as-white">
+                <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white mr-1" />
+                White
+              </ToggleGroupItem>
+              <ToggleGroupItem value="black" data-testid="filter-played-as-black">
+                <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900 mr-1" />
+                Black
+              </ToggleGroupItem>
+            </ToggleGroup>
           </div>
-          <ToggleGroup
-            type="single"
-            value={filters.matchSide}
-            onValueChange={(v) => {
-              if (!v) return;
-              setFilters(prev => ({ ...prev, matchSide: v as MatchSide }));
-            }}
-            variant="outline"
-            size="sm"
-            data-testid="filter-piece-filter"
-          >
-            <ToggleGroupItem value="mine" data-testid="filter-piece-filter-mine">Mine</ToggleGroupItem>
-            <ToggleGroupItem value="opponent" data-testid="filter-piece-filter-opponent">Opponent</ToggleGroupItem>
-            <ToggleGroupItem value="both" data-testid="filter-piece-filter-both">Both</ToggleGroupItem>
-          </ToggleGroup>
+
+          <div className="ml-auto">
+            <div className="mb-1 flex items-center gap-1">
+              <p className="text-xs text-muted-foreground">Piece filter</p>
+              <InfoPopover ariaLabel="Piece filter info" testId="piece-filter-info" side="top">
+                Use the option "Mine" to find games with a specific formation (e.g. the London System) regardless of the opponent's moves. "Mine" matches only your pieces, "Opponent" only theirs, and "Both" requires an exact match of all pieces. The Moves tab always uses "Both".
+              </InfoPopover>
+            </div>
+            <ToggleGroup
+              type="single"
+              value={filters.matchSide}
+              onValueChange={(v) => {
+                if (!v) return;
+                setFilters(prev => ({ ...prev, matchSide: v as MatchSide }));
+              }}
+              variant="outline"
+              size="sm"
+              data-testid="filter-piece-filter"
+            >
+              <ToggleGroupItem value="mine" data-testid="filter-piece-filter-mine">Mine</ToggleGroupItem>
+              <ToggleGroupItem value="opponent" data-testid="filter-piece-filter-opponent">Opponent</ToggleGroupItem>
+              <ToggleGroupItem value="both" data-testid="filter-piece-filter-both">Both</ToggleGroupItem>
+            </ToggleGroup>
+          </div>
         </div>
       </div>
 
-      <div className="border-t border-border/40" />
-
       {/* Position bookmarks collapsible */}
-      <div className="charcoal-texture rounded-md p-2">
+      <div className="charcoal-texture rounded-md">
       <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
+            className="w-full justify-between px-3 text-sm font-medium min-h-11 sm:min-h-0 rounded-none hover:bg-charcoal-hover!"
             data-testid="section-position-bookmarks"
           >
             <span className="flex items-center gap-1">
@@ -366,7 +366,8 @@ export function OpeningsPage() {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="pt-2">
+          <div className="border-t border-border/20" />
+          <div className="p-2">
             <div className="flex gap-2 mb-2">
               <Button
                 size="lg"
@@ -397,16 +398,14 @@ export function OpeningsPage() {
       </Collapsible>
       </div>
 
-      <div className="border-t border-border/40" />
-
       {/* More filters collapsible */}
-      <div className="charcoal-texture rounded-md p-2">
+      <div className="charcoal-texture rounded-md">
       <Collapsible open={moreFiltersOpen} onOpenChange={setMoreFiltersOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
+            className="w-full justify-between px-3 text-sm font-medium min-h-11 sm:min-h-0 rounded-none hover:bg-charcoal-hover!"
             data-testid="section-more-filters"
           >
             More filters
@@ -414,7 +413,8 @@ export function OpeningsPage() {
           </Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="pt-2">
+          <div className="border-t border-border/20" />
+          <div className="p-2">
             <FilterPanel filters={filters} onChange={handleFiltersChange} />
           </div>
         </CollapsibleContent>
@@ -657,13 +657,13 @@ export function OpeningsPage() {
           <div className="border-t border-border/40" />
 
           {/* More filters — collapsed by default on mobile */}
-          <div className="charcoal-texture rounded-md p-2">
+          <div className="charcoal-texture rounded-md">
           <Collapsible open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
             <CollapsibleTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
+                className="w-full justify-between px-3 text-sm font-medium min-h-11 sm:min-h-0 rounded-none hover:bg-charcoal-hover!"
                 data-testid="section-more-filters-mobile"
               >
                 More filters
@@ -671,7 +671,8 @@ export function OpeningsPage() {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div className="pt-2">
+              <div className="border-t border-border/20" />
+              <div className="p-2">
                 <FilterPanel filters={filters} onChange={handleFiltersChange} />
               </div>
             </CollapsibleContent>
@@ -679,13 +680,13 @@ export function OpeningsPage() {
           </div>
 
           {/* Position bookmarks — collapsed by default */}
-          <div className="charcoal-texture rounded-md p-2">
+          <div className="charcoal-texture rounded-md">
           <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
             <CollapsibleTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
+                className="w-full justify-between px-3 text-sm font-medium min-h-11 sm:min-h-0 rounded-none hover:bg-charcoal-hover!"
                 data-testid="section-position-bookmarks-mobile"
               >
                 <span className="flex items-center gap-1">
@@ -700,7 +701,8 @@ export function OpeningsPage() {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent>
-              <div className="pt-2">
+              <div className="border-t border-border/20" />
+              <div className="p-2">
                 <div className="flex gap-2 mb-2">
                   <Button
                     size="lg"
@@ -730,8 +732,6 @@ export function OpeningsPage() {
             </CollapsibleContent>
           </Collapsible>
           </div>
-
-          <div className="border-t border-border/40" />
 
           {/* Tabs: Moves / Games / Compare */}
           <Tabs value={activeTab} onValueChange={(val) => navigate(`/openings/${val}`)}>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -345,12 +345,13 @@ export function OpeningsPage() {
       <div className="border-t border-border/40" />
 
       {/* Position bookmarks collapsible */}
+      <div className="charcoal-texture rounded-md p-2">
       <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium bg-muted/50 hover:bg-muted! border border-border/40 rounded min-h-11 sm:min-h-0"
+            className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
             data-testid="section-position-bookmarks"
           >
             <span className="flex items-center gap-1">
@@ -394,16 +395,18 @@ export function OpeningsPage() {
           </div>
         </CollapsibleContent>
       </Collapsible>
+      </div>
 
       <div className="border-t border-border/40" />
 
       {/* More filters collapsible */}
+      <div className="charcoal-texture rounded-md p-2">
       <Collapsible open={moreFiltersOpen} onOpenChange={setMoreFiltersOpen}>
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
-            className="w-full justify-between px-2 text-sm font-medium bg-muted/50 hover:bg-muted! border border-border/40 rounded min-h-11 sm:min-h-0"
+            className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
             data-testid="section-more-filters"
           >
             More filters
@@ -416,6 +419,7 @@ export function OpeningsPage() {
           </div>
         </CollapsibleContent>
       </Collapsible>
+      </div>
     </div>
   );
 
@@ -516,7 +520,7 @@ export function OpeningsPage() {
           <div className="min-w-0">{sidebar}</div>
           <div className="min-w-0">
             <Tabs value={activeTab} onValueChange={(val) => navigate(`/openings/${val}`)}>
-              <TabsList className="w-full" data-testid="openings-tabs">
+              <TabsList variant="brand" className="w-full" data-testid="openings-tabs">
                 <TabsTrigger value="explorer" data-testid="tab-move-explorer" className="flex-1">
                   <ArrowRightLeft className="mr-1.5 h-4 w-4" />
                   Moves
@@ -653,12 +657,13 @@ export function OpeningsPage() {
           <div className="border-t border-border/40" />
 
           {/* More filters — collapsed by default on mobile */}
+          <div className="charcoal-texture rounded-md p-2">
           <Collapsible open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
             <CollapsibleTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-between px-2 text-sm font-medium bg-muted/50 hover:bg-muted! border border-border/40 rounded min-h-11 sm:min-h-0"
+                className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
                 data-testid="section-more-filters-mobile"
               >
                 More filters
@@ -671,14 +676,16 @@ export function OpeningsPage() {
               </div>
             </CollapsibleContent>
           </Collapsible>
+          </div>
 
           {/* Position bookmarks — collapsed by default */}
+          <div className="charcoal-texture rounded-md p-2">
           <Collapsible open={positionBookmarksOpen} onOpenChange={setPositionBookmarksOpen}>
             <CollapsibleTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full justify-between px-2 text-sm font-medium bg-muted/50 hover:bg-muted! border border-border/40 rounded min-h-11 sm:min-h-0"
+                className="w-full justify-between px-2 text-sm font-medium min-h-11 sm:min-h-0"
                 data-testid="section-position-bookmarks-mobile"
               >
                 <span className="flex items-center gap-1">
@@ -722,12 +729,13 @@ export function OpeningsPage() {
               </div>
             </CollapsibleContent>
           </Collapsible>
+          </div>
 
           <div className="border-t border-border/40" />
 
           {/* Tabs: Moves / Games / Compare */}
           <Tabs value={activeTab} onValueChange={(val) => navigate(`/openings/${val}`)}>
-            <TabsList className="w-full h-11!" data-testid="openings-tabs-mobile">
+            <TabsList variant="brand" className="w-full h-11!" data-testid="openings-tabs-mobile">
               <TabsTrigger value="explorer" className="flex-1" data-testid="tab-move-explorer-mobile">
                 <ArrowRightLeft className="mr-1.5 h-4 w-4" />
                 Moves

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -428,7 +428,9 @@ export function OpeningsPage() {
   const moveExplorerContent = (
     <div className="flex flex-col gap-4">
       {nextMoves.data && nextMoves.data.position_stats.total > 0 && (
-        <WDLBar stats={nextMoves.data.position_stats} />
+        <div className="charcoal-texture rounded-md p-4">
+          <WDLBar stats={nextMoves.data.position_stats} />
+        </div>
       )}
       <div className="charcoal-texture rounded-md p-4">
         <MoveExplorer
@@ -470,7 +472,9 @@ export function OpeningsPage() {
         </div>
       ) : gamesData ? (
         <>
-          <WDLBar stats={gamesData.stats} />
+          <div className="charcoal-texture rounded-md p-4">
+            <WDLBar stats={gamesData.stats} />
+          </div>
           <GameCardList
             games={gamesData.games}
             matchedCount={gamesData.matched_count}

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -491,10 +491,10 @@ export function OpeningsPage() {
         </div>
       ) : tsData ? (
         <>
-          <div>
+          <div className="charcoal-texture rounded-md p-4">
             <WDLBarChart bookmarks={bookmarks} wdlStatsMap={wdlStatsMap} />
           </div>
-          <div>
+          <div className="charcoal-texture rounded-md p-4">
             <WinRateChart bookmarks={bookmarks} series={tsData.series} />
           </div>
         </>


### PR DESCRIPTION
## Summary

- Centralized CSS variables (brand-brown, charcoal, inactive-bg) registered as Tailwind utilities
- Charcoal-texture containers with SVG feTurbulence noise overlay across all pages (Dashboard, Openings, Endgames, Import, GlobalStats)
- Brand brown (#6C4328) active subtab highlighting on Openings and Endgames
- Nav header: no border, full-height active tab highlight, logo links to homepage
- Full-width filter grid layout, consistent button/toggle styling (#171717 inactive, #262626 hover)
- GlobalStats restructured to sidebar layout with Platform + Recency filters only
- Game cards, board controls, move explorer, WDL bars in charcoal containers
- FilterPanel `visibleFilters` prop for page-specific filter subsets
- Recency filter moved to top of filter panel
- WDL bar chart rounded outer corners on Recharts stacked bars

## Test plan

- [x] `npm run build` passes with zero errors
- [x] `npm test` — all 38 tests pass
- [x] Visual verification approved across all pages (desktop + mobile)
- [ ] Verify charcoal containers render correctly on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)