### PR TITLE
Phase 37: Openings Reference Table Redesign

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -31,8 +31,8 @@ Requirements for v1.6 — UI Polish & Improvements.
 
 ### Openings Reference Table & Redesign
 
-- [ ] **ORT-01**: `openings` table contains all ~3641 rows from TSV with correct `ply_count` and `fen` values computed via python-chess
-- [ ] **ORT-02**: Deduplicated view returns one row per `(eco, name)` pair
+- [x] **ORT-01**: `openings` table contains all ~3641 rows from TSV with correct `ply_count` and `fen` values computed via python-chess
+- [x] **ORT-02**: Deduplicated view returns one row per `(eco, name)` pair
 - [ ] **ORT-03**: Endpoint returns top 10 openings per color with WDL stats computed in SQL, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below ply threshold
 - [ ] **ORT-04**: Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
 - [ ] **ORT-05**: Hovering/tapping a row shows a minimap popover of the opening position

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -34,8 +34,8 @@ Requirements for v1.6 — UI Polish & Improvements.
 - [x] **ORT-01**: `openings` table contains all ~3641 rows from TSV with correct `ply_count` and `fen` values computed via python-chess
 - [x] **ORT-02**: Deduplicated view returns one row per `(eco, name)` pair
 - [ ] **ORT-03**: Endpoint returns top 10 openings per color with WDL stats computed in SQL, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below ply threshold
-- [ ] **ORT-04**: Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
-- [ ] **ORT-05**: Hovering/tapping a row shows a minimap popover of the opening position
+- [x] **ORT-04**: Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
+- [x] **ORT-05**: Hovering/tapping a row shows a minimap popover of the opening position
 
 ## Future Requirements
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -29,6 +29,14 @@ Requirements for v1.6 — UI Polish & Improvements.
 - [x] **MPO-03**: Openings with fewer than 10 games are excluded; if no openings meet the threshold, an explanatory message is shown
 - [x] **MPO-04**: Openings are displayed as WDL charts (same WDLChartRow component) with ECO code in parentheses in the title label
 
+### Openings Reference Table & Redesign
+
+- [ ] **ORT-01**: `openings` table contains all ~3641 rows from TSV with correct `ply_count` and `fen` values computed via python-chess
+- [ ] **ORT-02**: Deduplicated view returns one row per `(eco, name)` pair
+- [ ] **ORT-03**: Endpoint returns top 10 openings per color with WDL stats computed in SQL, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below ply threshold
+- [ ] **ORT-04**: Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
+- [ ] **ORT-05**: Hovering/tapping a row shows a minimap popover of the opening position
+
 ## Future Requirements
 
 ### Pawn Structure Analysis
@@ -66,16 +74,21 @@ Which phases cover which requirements. Updated during roadmap creation.
 | WDL-02 | Phase 35 | Complete |
 | WDL-03 | Phase 35 | Complete |
 | WDL-04 | Phase 35 | Complete |
-| MPO-01 | Phase 36 | Not started |
-| MPO-02 | Phase 36 | Not started |
-| MPO-03 | Phase 36 | Not started |
-| MPO-04 | Phase 36 | Not started |
+| MPO-01 | Phase 36 | Complete |
+| MPO-02 | Phase 36 | Complete |
+| MPO-03 | Phase 36 | Complete |
+| MPO-04 | Phase 36 | Complete |
+| ORT-01 | Phase 37 | Not started |
+| ORT-02 | Phase 37 | Not started |
+| ORT-03 | Phase 37 | Not started |
+| ORT-04 | Phase 37 | Not started |
+| ORT-05 | Phase 37 | Not started |
 
 **Coverage:**
-- v1.6 requirements: 13 total
-- Mapped to phases: 13
+- v1.6 requirements: 18 total
+- Mapped to phases: 18
 - Unmapped: 0
 
 ---
 *Requirements defined: 2026-03-28*
-*Last updated: 2026-03-28 after Phase 36 planning*
+*Last updated: 2026-03-28 after Phase 37 planning*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -104,7 +104,7 @@
 **UI hint**: yes
 
 Plans:
-- [ ] 37-01-PLAN.md — Opening model, Alembic migration with dedup view, seed script, tests
+- [x] 37-01-PLAN.md — Opening model, Alembic migration with dedup view, seed script, tests
 - [ ] 37-02-PLAN.md — SQL-side WDL aggregation, filter params, updated schema/service/router, tests
 - [ ] 37-03-PLAN.md — Frontend table component, minimap popover, hook/API filter wiring, visual verification
 
@@ -195,7 +195,7 @@ Plans:
 | 34. Theme Improvements | v1.6 | 2/2 | Complete    | 2026-03-28 |
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
-| 37. Openings Reference Table & Redesign | v1.6 | 0/3 | In Progress | — |
+| 37. Openings Reference Table & Redesign | v1.6 | 1/3 | In Progress|  |
 
 ## Backlog
 
@@ -203,7 +203,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 1/1 plans complete
+**Plans:** 1/3 plans executed
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -86,7 +86,7 @@
 - [x] **Phase 34: Theme Improvements** — Centralize theme constants, charcoal containers with noise texture, filter button layout, consistent WDL chart styling, active subtab highlighting (completed 2026-03-28)
 - [x] **Phase 35: WDL Chart Refactoring** — Create shared WDL chart component based on endgame charts, replace all inconsistent WDL charts (custom and Recharts), clean up unused code (completed 2026-03-28)
 - [x] **Phase 36: Most Played Openings** — Add "Most Played Openings" sections (White/Black) to Opening Statistics subtab with top 5 openings as WDL charts, ECO codes, minimum 10 games threshold (completed 2026-03-28)
-- [ ] **Phase 37: Openings Reference Table & Most Played Openings Redesign** — Create openings DB table from TSV dataset with PGN/FEN/ply_count, redesign most played openings with filter support, dedicated table UI, minimap popover, SQL-side WDL aggregation, top 10
+- [x] **Phase 37: Openings Reference Table & Most Played Openings Redesign** — Create openings DB table from TSV dataset with PGN/FEN/ply_count, redesign most played openings with filter support, dedicated table UI, minimap popover, SQL-side WDL aggregation, top 10 (completed 2026-03-28)
 
 ## Phase Details
 
@@ -105,8 +105,8 @@
 
 Plans:
 - [x] 37-01-PLAN.md — Opening model, Alembic migration with dedup view, seed script, tests
-- [ ] 37-02-PLAN.md — SQL-side WDL aggregation, filter params, updated schema/service/router, tests
-- [ ] 37-03-PLAN.md — Frontend table component, minimap popover, hook/API filter wiring, visual verification
+- [x] 37-02-PLAN.md — SQL-side WDL aggregation, filter params, updated schema/service/router, tests
+- [x] 37-03-PLAN.md — Frontend table component, minimap popover, hook/API filter wiring, visual verification
 
 ### Phase 36: Most Played Openings
 **Goal**: Opening Statistics subtab shows the user's top 5 most played openings for White and Black as WDL charts, with ECO codes and a minimum 10 games threshold
@@ -195,7 +195,7 @@ Plans:
 | 34. Theme Improvements | v1.6 | 2/2 | Complete    | 2026-03-28 |
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
-| 37. Openings Reference Table & Redesign | v1.6 | 1/3 | In Progress|  |
+| 37. Openings Reference Table & Redesign | v1.6 | 3/3 | Complete   | 2026-03-28 |
 
 ## Backlog
 
@@ -203,7 +203,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 1/3 plans executed
+**Plans:** 3/3 plans complete
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -100,11 +100,13 @@
   3. Endpoint returns top 10 openings per color with WDL stats computed in SQL, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below ply threshold
   4. Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
   5. Hovering/tapping a row shows a minimap popover of the opening position
-**Plans**: 0 plans
+**Plans**: 3 plans
 **UI hint**: yes
 
 Plans:
-- [ ] TBD (run /gsd:plan-phase 37 to break down)
+- [ ] 37-01-PLAN.md — Opening model, Alembic migration with dedup view, seed script, tests
+- [ ] 37-02-PLAN.md — SQL-side WDL aggregation, filter params, updated schema/service/router, tests
+- [ ] 37-03-PLAN.md — Frontend table component, minimap popover, hook/API filter wiring, visual verification
 
 ### Phase 36: Most Played Openings
 **Goal**: Opening Statistics subtab shows the user's top 5 most played openings for White and Black as WDL charts, with ECO codes and a minimum 10 games threshold
@@ -193,7 +195,7 @@ Plans:
 | 34. Theme Improvements | v1.6 | 2/2 | Complete    | 2026-03-28 |
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
-| 37. Openings Reference Table & Redesign | v1.6 | 0/0 | Not Started | — |
+| 37. Openings Reference Table & Redesign | v1.6 | 0/3 | In Progress | — |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -226,3 +226,12 @@ Plans:
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)
 
+### Phase 999.4: Position-Based Most Played Openings via game_positions (BACKLOG)
+
+**Goal:** Redesign "Most Played Openings" to count how many games *passed through* each opening position (via `game_positions` Zobrist hash matching) instead of counting final opening name classifications from chess.com/lichess. Currently "1. e4" shows ~75 games (only games *classified* as "King's Pawn Game") while obscure specific lines rank higher. Position-based counting would show all ~2000+ games that played 1. e4, consistent with FlawChess's core Zobrist hash architecture. Requires JOIN from `openings` reference table to `game_positions` on FEN or precomputed hash, then `COUNT(DISTINCT game_id)`.
+**Requirements:** TBD
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (promote with /gsd:review-backlog when ready)
+

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -217,3 +217,12 @@ Plans:
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)
 
+### Phase 999.3: SQL-Side Aggregation for Remaining Python-Side DB Queries (BACKLOG)
+
+**Goal:** Replace remaining Python-side row-by-row W/D/L counting with SQL GROUP BY + COUNT().filter() aggregation. High-impact targets: `analysis_service.analyze()` and `get_next_moves()` (N rows → 1), `endgame_service._aggregate_endgame_stats()` (K rows → 6). Lower priority: rolling-window functions that need chronological row data.
+**Requirements:** TBD
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (promote with /gsd:review-backlog when ready)
+

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: executing
-last_updated: "2026-03-28T19:44:41.304Z"
+status: verifying
+last_updated: "2026-03-28T19:52:16.500Z"
 last_activity: 2026-03-28
 progress:
   total_phases: 6
   completed_phases: 3
-  total_plans: 8
+  total_plans: 5
   completed_plans: 6
 ---
 
@@ -16,9 +16,9 @@ progress:
 
 ## Current Position
 
-Phase: 37 (openings-reference-table-redesign) — EXECUTING
-Plan: 2 of 3
-Status: Ready to execute
+Phase: 999.1
+Plan: Not started
+Status: Phase complete — ready for verification
 Last activity: 2026-03-28
 
 ## Project Reference
@@ -81,8 +81,9 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 35-wdl-chart-refactoring]: Openings Statistics tab computes win_pct/draw_pct/loss_pct inline (wdlStatsMap has raw counts only) to satisfy WDLRowData interface
 - [Phase 36-most-played-openings]: Subquery-join pattern for top-N openings: SELECT top ECOs by COUNT HAVING >= min_games, then JOIN back for Python WDL aggregation — consistent with existing stats_repository patterns
 - [Phase 36-most-played-openings]: Most Played Openings uses all-time data (no filter params) per Phase 36 research recommendation
-- [Phase 37-01]: openings_dedup view uses DISTINCT ON (eco, name) ORDER BY eco, name, id — stable deterministic dedup picking lowest id per pair
-- [Phase 37-01]: Seed fixture uses asyncio.run() in sync session-scoped pytest fixture to avoid event loop conflicts with pytest-asyncio
+- [Phase 37-02]: Standalone MetaData() for _openings_dedup Table — keeps view invisible to Alembic autogenerate
+- [Phase 37-02]: SQL-side WDL via func.count().filter() replaces Python-side aggregation loop
+- [Phase 37-02]: TOP_OPENINGS_LIMIT raised from 5 to 10; MIN_PLY_WHITE=1, MIN_PLY_BLACK=2
 
 ### Critical v1.5 Constraints
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,23 +2,23 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: verifying
-last_updated: "2026-03-28T17:28:24.586Z"
+status: executing
+last_updated: "2026-03-28T19:44:41.304Z"
 last_activity: 2026-03-28
 progress:
-  total_phases: 5
+  total_phases: 6
   completed_phases: 3
-  total_plans: 5
-  completed_plans: 5
+  total_plans: 8
+  completed_plans: 6
 ---
 
 # Project State: FlawChess
 
 ## Current Position
 
-Phase: 999.1
-Plan: Not started
-Status: Phase complete — ready for verification
+Phase: 37 (openings-reference-table-redesign) — EXECUTING
+Plan: 2 of 3
+Status: Ready to execute
 Last activity: 2026-03-28
 
 ## Project Reference
@@ -81,6 +81,8 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 35-wdl-chart-refactoring]: Openings Statistics tab computes win_pct/draw_pct/loss_pct inline (wdlStatsMap has raw counts only) to satisfy WDLRowData interface
 - [Phase 36-most-played-openings]: Subquery-join pattern for top-N openings: SELECT top ECOs by COUNT HAVING >= min_games, then JOIN back for Python WDL aggregation — consistent with existing stats_repository patterns
 - [Phase 36-most-played-openings]: Most Played Openings uses all-time data (no filter params) per Phase 36 research recommendation
+- [Phase 37-01]: openings_dedup view uses DISTINCT ON (eco, name) ORDER BY eco, name, id — stable deterministic dedup picking lowest id per pair
+- [Phase 37-01]: Seed fixture uses asyncio.run() in sync session-scoped pytest fixture to avoid event loop conflicts with pytest-asyncio
 
 ### Critical v1.5 Constraints
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,13 @@ gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
 status: verifying
-last_updated: "2026-03-28T19:52:16.500Z"
+last_updated: "2026-03-28T19:59:11.755Z"
 last_activity: 2026-03-28
 progress:
   total_phases: 6
-  completed_phases: 3
-  total_plans: 5
-  completed_plans: 6
+  completed_phases: 4
+  total_plans: 8
+  completed_plans: 8
 ---
 
 # Project State: FlawChess
@@ -84,6 +84,8 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 37-02]: Standalone MetaData() for _openings_dedup Table — keeps view invisible to Alembic autogenerate
 - [Phase 37-02]: SQL-side WDL via func.count().filter() replaces Python-side aggregation loop
 - [Phase 37-02]: TOP_OPENINGS_LIMIT raised from 5 to 10; MIN_PLY_WHITE=1, MIN_PLY_BLACK=2
+- [Phase 37-03]: arePiecesDraggable not a valid prop in react-chessboard v5 — static minimap board achieved by omitting onPieceDrop/onSquareClick handlers
+- [Phase 37-03]: MostPlayedOpeningsTable replaces WDLChartRow in statisticsContent; filters from debouncedFilters now passed to useMostPlayedOpenings so Statistics tab openings react to filter changes
 
 ### Critical v1.5 Constraints
 

--- a/.planning/phases/37-openings-reference-table-redesign/37-01-PLAN.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-01-PLAN.md
@@ -1,0 +1,431 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - app/models/opening.py
+  - alembic/env.py
+  - alembic/versions/xxxx_create_openings_table.py
+  - scripts/seed_openings.py
+  - tests/test_seed_openings.py
+autonomous: true
+requirements: [ORT-01, ORT-02]
+
+must_haves:
+  truths:
+    - "openings table contains all ~3641 rows from TSV with correct ply_count and fen"
+    - "openings_dedup view returns one row per (eco, name) pair"
+    - "Seed script is idempotent — running twice does not duplicate rows"
+  artifacts:
+    - path: "app/models/opening.py"
+      provides: "Opening SQLAlchemy model"
+      contains: "class Opening"
+    - path: "scripts/seed_openings.py"
+      provides: "Idempotent seed script"
+      contains: "pgn_to_fen_and_ply"
+    - path: "tests/test_seed_openings.py"
+      provides: "Tests for seed + dedup view"
+      contains: "test_seed_inserts_rows"
+  key_links:
+    - from: "scripts/seed_openings.py"
+      to: "app/data/openings.tsv"
+      via: "TSV file read"
+      pattern: "openings\\.tsv"
+    - from: "alembic/env.py"
+      to: "app/models/opening.py"
+      via: "import for autogenerate"
+      pattern: "from app\\.models\\.opening import Opening"
+---
+
+<objective>
+Create the openings reference table infrastructure: SQLAlchemy model, Alembic migration with dedup view, idempotent seed script, and tests.
+
+Purpose: ORT-01 and ORT-02 require a persistent openings table seeded from the TSV dataset, with a deduplicated view for JOIN queries. This is the foundation for SQL-side WDL aggregation in Plan 02.
+Output: `openings` table with ~3641 rows, `openings_dedup` view with ~3301 rows, seed script, passing tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/37-openings-reference-table-redesign/37-RESEARCH.md
+
+@app/models/base.py
+@app/models/game.py
+@alembic/env.py
+@app/data/openings.tsv
+@scripts/__init__.py
+
+<interfaces>
+<!-- Key types and contracts the executor needs. -->
+
+From app/models/base.py:
+```python
+from sqlalchemy.orm import DeclarativeBase
+class Base(DeclarativeBase):
+    pass
+```
+
+From alembic/env.py (import pattern — add Opening import after existing model imports):
+```python
+from app.models.position_bookmark import PositionBookmark  # noqa: F401
+from app.models.game import Game  # noqa: F401
+from app.models.game_position import GamePosition  # noqa: F401
+from app.models.oauth_account import OAuthAccount  # noqa: F401
+from app.models.user import User  # noqa: F401
+# ADD: from app.models.opening import Opening  # noqa: F401
+```
+
+From scripts/__init__.py: exists (added in Phase 27) — scripts/ is a Python package.
+
+TSV format (app/data/openings.tsv):
+```
+eco	name	pgn
+A00	Amar Gambit	1. Nh3 d5 2. g3 e5 3. f4 Bxh3 4. Bxh3 exf4
+A00	Amar Opening	1. Nh3
+...
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create Opening model, Alembic migration with dedup view, and seed script</name>
+  <files>app/models/opening.py, alembic/env.py, scripts/seed_openings.py</files>
+  <read_first>
+    - app/models/base.py
+    - app/models/game.py (for model pattern reference)
+    - alembic/env.py (for import pattern)
+    - scripts/__init__.py (verify exists)
+    - app/data/openings.tsv (first 5 lines for format)
+  </read_first>
+  <action>
+1. Create `app/models/opening.py` with the Opening model:
+```python
+from sqlalchemy import Index, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+from app.models.base import Base
+
+class Opening(Base):
+    __tablename__ = "openings"
+    __table_args__ = (
+        UniqueConstraint("eco", "name", "pgn", name="uq_openings_eco_name_pgn"),
+        Index("ix_openings_eco_name", "eco", "name"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    eco: Mapped[str] = mapped_column(String(10), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    pgn: Mapped[str] = mapped_column(Text, nullable=False)
+    ply_count: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    fen: Mapped[str] = mapped_column(String(100), nullable=False)
+```
+
+2. Add `from app.models.opening import Opening  # noqa: F401` to `alembic/env.py` after the existing model imports.
+
+3. Run `uv run alembic revision --autogenerate -m "create openings table"` to generate the migration.
+
+4. Edit the generated migration to add the `openings_dedup` view in `upgrade()`:
+```python
+op.execute("""
+    CREATE VIEW openings_dedup AS
+    SELECT DISTINCT ON (eco, name)
+        id, eco, name, pgn, ply_count, fen
+    FROM openings
+    ORDER BY eco, name, id
+""")
+```
+And in `downgrade()`:
+```python
+op.execute("DROP VIEW IF EXISTS openings_dedup")
+```
+Place the DROP VIEW BEFORE `op.drop_table("openings")` in downgrade, and the CREATE VIEW AFTER `op.create_table(...)` in upgrade.
+
+5. Run `uv run alembic upgrade head` to apply the migration.
+
+6. Create `scripts/seed_openings.py`:
+```python
+"""Idempotent seed script: populate openings table from app/data/openings.tsv.
+
+Uses board.board_fen() (not board.fen()) per project convention.
+Uses INSERT ... ON CONFLICT DO NOTHING for idempotency.
+Run with: uv run python -m scripts.seed_openings
+"""
+import asyncio
+import csv
+import io
+import logging
+from pathlib import Path
+
+import chess
+import chess.pgn
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+TSV_PATH = Path(__file__).resolve().parent.parent / "app" / "data" / "openings.tsv"
+
+
+def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
+    """Compute piece-placement FEN and ply count from a PGN move sequence.
+
+    Uses board.board_fen() (not board.fen()) per project convention.
+    """
+    game = chess.pgn.read_game(io.StringIO(pgn_str))
+    if game is None:
+        raise ValueError(f"Failed to parse PGN: {pgn_str!r}")
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board.board_fen(), board.ply()
+
+
+async def seed_openings() -> int:
+    """Read TSV and insert rows into openings table. Returns count of inserted rows."""
+    engine = create_async_engine(settings.DATABASE_URL)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    inserted = 0
+    skipped = 0
+    errors = 0
+
+    async with async_session() as session:
+        with open(TSV_PATH, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for row_num, row in enumerate(reader, start=2):
+                eco = row["eco"]
+                name = row["name"]
+                pgn_str = row["pgn"]
+                try:
+                    fen, ply_count = pgn_to_fen_and_ply(pgn_str)
+                except Exception:
+                    logger.warning("Row %d: failed to parse PGN %r — skipping", row_num, pgn_str)
+                    errors += 1
+                    continue
+
+                result = await session.execute(
+                    text(
+                        "INSERT INTO openings (eco, name, pgn, ply_count, fen) "
+                        "VALUES (:eco, :name, :pgn, :ply_count, :fen) "
+                        "ON CONFLICT ON CONSTRAINT uq_openings_eco_name_pgn DO NOTHING"
+                    ),
+                    {"eco": eco, "name": name, "pgn": pgn_str, "ply_count": ply_count, "fen": fen},
+                )
+                if result.rowcount > 0:
+                    inserted += 1
+                else:
+                    skipped += 1
+
+        await session.commit()
+
+    await engine.dispose()
+    logger.info("Seed complete: %d inserted, %d skipped (already exist), %d errors", inserted, skipped, errors)
+    return inserted
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_openings())
+```
+
+7. Run the seed script: `uv run python -m scripts.seed_openings`
+
+8. Verify row count: `docker exec flawchess-dev-db-1 psql -U dev -d flawchess_dev -c "SELECT COUNT(*) FROM openings;"` — expect ~3641.
+
+9. Verify dedup view: `docker exec flawchess-dev-db-1 psql -U dev -d flawchess_dev -c "SELECT COUNT(*) FROM openings_dedup;"` — expect ~3301.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && docker exec flawchess-dev-db-1 psql -U dev -d flawchess_dev -c "SELECT COUNT(*) FROM openings;" && docker exec flawchess-dev-db-1 psql -U dev -d flawchess_dev -c "SELECT COUNT(*) FROM openings_dedup;"</automated>
+  </verify>
+  <acceptance_criteria>
+    - app/models/opening.py contains `class Opening(Base):`
+    - app/models/opening.py contains `__tablename__ = "openings"`
+    - app/models/opening.py contains `UniqueConstraint("eco", "name", "pgn"`
+    - app/models/opening.py contains `mapped_column(SmallInteger` for ply_count
+    - app/models/opening.py contains `mapped_column(String(100)` for fen
+    - alembic/env.py contains `from app.models.opening import Opening`
+    - Migration file contains `CREATE VIEW openings_dedup`
+    - Migration file contains `DISTINCT ON (eco, name)`
+    - Migration file contains `ORDER BY eco, name, id`
+    - Migration downgrade contains `DROP VIEW IF EXISTS openings_dedup`
+    - scripts/seed_openings.py contains `board.board_fen()` (not `board.fen()`)
+    - scripts/seed_openings.py contains `ON CONFLICT ON CONSTRAINT uq_openings_eco_name_pgn DO NOTHING`
+    - `SELECT COUNT(*) FROM openings` returns ~3641
+    - `SELECT COUNT(*) FROM openings_dedup` returns ~3301
+  </acceptance_criteria>
+  <done>openings table contains ~3641 rows with ply_count and fen computed via python-chess. openings_dedup view returns ~3301 unique (eco, name) rows. Seed script is idempotent.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write tests for seed script and dedup view</name>
+  <files>tests/test_seed_openings.py</files>
+  <read_first>
+    - tests/test_stats_repository.py (for test pattern, fixtures, _seed_game helper)
+    - tests/conftest.py (for db_session fixture)
+    - app/models/opening.py (just created in Task 1)
+    - scripts/seed_openings.py (just created in Task 1)
+  </read_first>
+  <action>
+Create `tests/test_seed_openings.py` with the following test classes:
+
+```python
+"""Tests for the openings seed script and dedup view.
+
+Coverage:
+- pgn_to_fen_and_ply: correct FEN and ply for known openings
+- seed_openings: inserts rows from TSV
+- seed_openings: idempotent (running twice does not duplicate)
+- openings_dedup: returns one row per (eco, name) pair
+"""
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.opening import Opening
+from scripts.seed_openings import pgn_to_fen_and_ply
+
+
+class TestPgnToFenAndPly:
+    """Unit tests for pgn_to_fen_and_ply helper."""
+
+    def test_single_move_opening(self) -> None:
+        """1. e4 should produce ply_count=1 and correct FEN."""
+        fen, ply = pgn_to_fen_and_ply("1. e4")
+        assert ply == 1
+        # After 1. e4, the board should have the pawn on e4
+        assert "4P3" in fen  # e4 pawn in rank 4
+
+    def test_two_move_opening(self) -> None:
+        """1. e4 e5 should produce ply_count=2."""
+        fen, ply = pgn_to_fen_and_ply("1. e4 e5")
+        assert ply == 2
+
+    def test_uses_board_fen_not_full_fen(self) -> None:
+        """FEN must be piece-placement only (no castling/en passant/move counters)."""
+        fen, _ = pgn_to_fen_and_ply("1. e4 e5")
+        # board_fen() has exactly 7 slashes (8 ranks separated by /)
+        assert fen.count("/") == 7
+        # board_fen() does NOT contain spaces (full FEN has spaces for castling etc.)
+        assert " " not in fen
+
+    def test_invalid_pgn_raises(self) -> None:
+        """Invalid PGN should raise ValueError."""
+        with pytest.raises(ValueError, match="Failed to parse PGN"):
+            pgn_to_fen_and_ply("")
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestSeedOpeningsIntegration:
+    """Integration tests verifying seed data exists in openings table.
+
+    These tests rely on the seed script having been run during test setup
+    (the migration + seed populate the openings table). They verify the
+    data is correct, not the seed script execution itself.
+    """
+
+    async def test_openings_table_has_expected_row_count(self, db_session: AsyncSession) -> None:
+        """openings table should have ~3641 rows from TSV."""
+        result = await db_session.execute(select(func.count()).select_from(Opening))
+        count = result.scalar_one()
+        # Allow small tolerance for TSV updates, but should be close to 3641
+        assert count >= 3600, f"Expected ~3641 rows, got {count}"
+
+    async def test_opening_row_has_valid_fen_and_ply(self, db_session: AsyncSession) -> None:
+        """Spot-check: a known opening has correct fen and ply_count."""
+        result = await db_session.execute(
+            select(Opening).where(Opening.eco == "B00", Opening.name == "King's Pawn Game")
+        )
+        opening = result.scalars().first()
+        assert opening is not None
+        assert opening.ply_count == 1  # 1. e4
+        assert "4P3" in opening.fen  # pawn on e4
+
+    async def test_seed_idempotent_no_duplicates(self, db_session: AsyncSession) -> None:
+        """UniqueConstraint prevents duplicate (eco, name, pgn) rows."""
+        # Count before — already seeded
+        result = await db_session.execute(select(func.count()).select_from(Opening))
+        count_before = result.scalar_one()
+        assert count_before >= 3600
+
+        # The UniqueConstraint ensures ON CONFLICT DO NOTHING works.
+        # We verify by checking there are no duplicate (eco, name, pgn) triples.
+        dup_result = await db_session.execute(
+            text(
+                "SELECT eco, name, pgn, COUNT(*) "
+                "FROM openings GROUP BY eco, name, pgn HAVING COUNT(*) > 1"
+            )
+        )
+        duplicates = dup_result.fetchall()
+        assert len(duplicates) == 0, f"Found duplicate rows: {duplicates}"
+
+    async def test_dedup_view_returns_fewer_rows(self, db_session: AsyncSession) -> None:
+        """openings_dedup should have fewer rows than openings (collapses duplicate eco+name)."""
+        total_result = await db_session.execute(select(func.count()).select_from(Opening))
+        total = total_result.scalar_one()
+
+        dedup_result = await db_session.execute(text("SELECT COUNT(*) FROM openings_dedup"))
+        dedup_count = dedup_result.scalar_one()
+
+        assert dedup_count < total, f"Dedup ({dedup_count}) should be < total ({total})"
+        assert dedup_count >= 3200, f"Expected ~3301 dedup rows, got {dedup_count}"
+
+    async def test_dedup_view_has_one_row_per_eco_name(self, db_session: AsyncSession) -> None:
+        """Each (eco, name) pair appears exactly once in the dedup view."""
+        result = await db_session.execute(
+            text(
+                "SELECT eco, name, COUNT(*) "
+                "FROM openings_dedup GROUP BY eco, name HAVING COUNT(*) > 1"
+            )
+        )
+        duplicates = result.fetchall()
+        assert len(duplicates) == 0, f"Dedup view has duplicate (eco, name): {duplicates}"
+```
+
+Note: The integration tests assume the seed script has already been run (the openings table is populated). If the test database is empty, these tests will fail — which is correct behavior (it means the seed wasn't run). The `test_seed_idempotent_no_duplicates` test verifies uniqueness constraint enforcement rather than re-running the seed.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run pytest tests/test_seed_openings.py -x -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/test_seed_openings.py contains `class TestPgnToFenAndPly`
+    - tests/test_seed_openings.py contains `class TestSeedOpeningsIntegration`
+    - tests/test_seed_openings.py contains `test_dedup_view_has_one_row_per_eco_name`
+    - tests/test_seed_openings.py contains `test_seed_idempotent_no_duplicates`
+    - tests/test_seed_openings.py contains `from scripts.seed_openings import pgn_to_fen_and_ply`
+    - `uv run pytest tests/test_seed_openings.py -x` exits 0
+  </acceptance_criteria>
+  <done>All seed and dedup view tests pass. ORT-01 and ORT-02 verified by automated tests.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run pytest tests/test_seed_openings.py -x -v` passes all tests
+- `SELECT COUNT(*) FROM openings` returns ~3641
+- `SELECT COUNT(*) FROM openings_dedup` returns ~3301
+- `uv run alembic revision --autogenerate -m "check"` produces empty migration (no pending changes)
+</verification>
+
+<success_criteria>
+- openings table has ~3641 rows with correct ply_count (SmallInteger) and fen (piece-placement only)
+- openings_dedup view returns ~3301 unique (eco, name) rows
+- Seed script is idempotent (ON CONFLICT DO NOTHING)
+- All tests in test_seed_openings.py pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/37-openings-reference-table-redesign/37-01-SUMMARY.md`
+</output>

--- a/.planning/phases/37-openings-reference-table-redesign/37-01-SUMMARY.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-01-SUMMARY.md
@@ -1,0 +1,131 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: 01
+subsystem: database
+tags: [postgresql, sqlalchemy, alembic, python-chess, seed-script]
+
+# Dependency graph
+requires:
+  - phase: 27-import-wiring-backfill
+    provides: scripts/__init__.py making scripts/ a Python package
+provides:
+  - openings SQLAlchemy model (app/models/opening.py)
+  - Alembic migration creating openings table and openings_dedup view
+  - Idempotent seed script populating 3641 rows from app/data/openings.tsv
+  - Test suite validating seed data and dedup view
+affects:
+  - 37-02 (WDL aggregation queries will JOIN against openings_dedup)
+  - 37-03 (frontend openings table will fetch data via the new openings reference)
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Idempotent seed via INSERT ... ON CONFLICT ON CONSTRAINT ... DO NOTHING"
+    - "openings_dedup view uses DISTINCT ON (eco, name) ORDER BY eco, name, id for stable dedup"
+    - "board.board_fen() (not board.fen()) for piece-placement-only FEN per project convention"
+    - "asyncio.run() in sync pytest fixture to seed test DB after alembic upgrade head"
+
+key-files:
+  created:
+    - app/models/opening.py
+    - alembic/versions/20260328_194057_1b941ecba0a6_create_openings_table.py
+    - scripts/seed_openings.py
+    - tests/test_seed_openings.py
+  modified:
+    - alembic/env.py
+
+key-decisions:
+  - "openings_dedup view uses DISTINCT ON (eco, name) ORDER BY eco, name, id — stable deterministic dedup picking lowest id per pair"
+  - "Seed fixture uses asyncio.run() in sync session-scoped pytest fixture to avoid event loop conflicts with pytest-asyncio"
+  - "REAL/Float(precision=24) autogenerate noise excluded from migration — semantically equivalent in PostgreSQL, pre-existing issue out of scope"
+
+patterns-established:
+  - "Seed scripts: asyncio.run() entry point, INSERT ON CONFLICT DO NOTHING, TSV via csv.DictReader"
+  - "Test seeding: session-scoped sync fixture depends on test_engine, calls asyncio.run(seed_fn()) after migrations"
+
+requirements-completed: [ORT-01, ORT-02]
+
+# Metrics
+duration: 4min
+completed: 2026-03-28
+---
+
+# Phase 37 Plan 01: Openings Reference Table Summary
+
+**PostgreSQL openings table with 3641 rows seeded from TSV, openings_dedup view with 3301 unique (eco, name) pairs, idempotent seed script using python-chess for FEN/ply computation**
+
+## Performance
+
+- **Duration:** ~4 min
+- **Started:** 2026-03-28T19:40:39Z
+- **Completed:** 2026-03-28T19:43:46Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+
+- Created Opening SQLAlchemy model with SmallInteger ply_count, UniqueConstraint on (eco, name, pgn), and index on (eco, name)
+- Created Alembic migration applying openings table + openings_dedup view (DISTINCT ON eco, name) in a single transaction
+- Created idempotent seed script using python-chess board.board_fen() for FEN computation; seeded 3641 rows with 0 errors
+- All 9 tests pass: 4 unit tests for pgn_to_fen_and_ply, 5 integration tests for table/view correctness
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create Opening model, migration with dedup view, and seed script** - `dbfe475` (feat)
+2. **Task 2: Write tests for seed script and dedup view** - `cd849a0` (test)
+
+**Plan metadata:** (docs commit below)
+
+## Files Created/Modified
+
+- `app/models/opening.py` - Opening SQLAlchemy model (eco, name, pgn, ply_count, fen)
+- `alembic/versions/20260328_194057_1b941ecba0a6_create_openings_table.py` - Migration: openings table + openings_dedup view
+- `scripts/seed_openings.py` - Idempotent seed script reading app/data/openings.tsv
+- `tests/test_seed_openings.py` - Test suite for seed script and dedup view
+- `alembic/env.py` - Added Opening import for autogenerate support
+
+## Decisions Made
+
+- openings_dedup view uses `DISTINCT ON (eco, name) ORDER BY eco, name, id` for stable deterministic dedup (lowest id per eco+name pair)
+- Test seeding uses `asyncio.run()` in a sync session-scoped pytest fixture (depends on `test_engine`) to avoid event loop conflicts with pytest-asyncio
+- Excluded REAL/Float(precision=24) autogenerate noise from migration — semantically equivalent in PostgreSQL, pre-existing issue out of scope
+
+## Deviations from Plan
+
+**1. [Rule 1 - Bug] Fixed asyncio.get_event_loop() in test fixture**
+- **Found during:** Task 2 (test execution)
+- **Issue:** `asyncio.get_event_loop().run_until_complete()` raises RuntimeError in pytest-asyncio session-scoped sync fixture — no current event loop in thread
+- **Fix:** Replaced with `asyncio.run(seed_openings())` which creates its own event loop
+- **Files modified:** tests/test_seed_openings.py
+- **Verification:** All 9 tests pass
+- **Committed in:** cd849a0 (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (Rule 1 - Bug)
+**Impact on plan:** Necessary fix for test infrastructure. No scope creep.
+
+## Issues Encountered
+
+- Alembic autogenerate included pre-existing REAL/Float(precision=24) alter_column noise for game_positions.clock_seconds and games.white_accuracy/black_accuracy — these are semantically equivalent in PostgreSQL and were excluded from the migration per project convention (seen in previous phases).
+
+## Known Stubs
+
+None — all data is real (seeded from openings.tsv with computed FEN/ply values).
+
+## User Setup Required
+
+None - no external service configuration required. The seed script must be run against production when deploying this migration: `uv run python -m scripts.seed_openings`
+
+## Next Phase Readiness
+
+- openings table (3641 rows) and openings_dedup view (3301 rows) ready for Plan 02 WDL aggregation queries
+- Opening model importable from app.models.opening for JOIN queries
+- Seed script is idempotent; safe to re-run after production deployment
+
+---
+*Phase: 37-openings-reference-table-redesign*
+*Completed: 2026-03-28*

--- a/.planning/phases/37-openings-reference-table-redesign/37-02-PLAN.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-02-PLAN.md
@@ -1,0 +1,593 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: 02
+type: execute
+wave: 2
+depends_on: ["37-01"]
+files_modified:
+  - app/repositories/stats_repository.py
+  - app/services/stats_service.py
+  - app/routers/stats.py
+  - app/schemas/stats.py
+  - tests/test_stats_repository.py
+  - tests/test_stats_router.py
+autonomous: true
+requirements: [ORT-03]
+
+must_haves:
+  truths:
+    - "Endpoint returns top 10 openings per color with WDL computed in SQL"
+    - "Endpoint accepts recency, time_control, platform, rated, opponent_type filters"
+    - "Openings below ply threshold are excluded"
+    - "Response includes pgn and fen fields for each opening"
+  artifacts:
+    - path: "app/repositories/stats_repository.py"
+      provides: "SQL-side WDL aggregation query"
+      contains: "query_top_openings_sql_wdl"
+    - path: "app/services/stats_service.py"
+      provides: "Updated service with filter params and TOP_OPENINGS_LIMIT=10"
+      contains: "TOP_OPENINGS_LIMIT = 10"
+    - path: "app/routers/stats.py"
+      provides: "Endpoint with filter query params"
+      contains: "opponent_type"
+    - path: "app/schemas/stats.py"
+      provides: "OpeningWDL with pgn and fen fields"
+      contains: "pgn: str"
+  key_links:
+    - from: "app/routers/stats.py"
+      to: "app/services/stats_service.py"
+      via: "get_most_played_openings call with filter args"
+      pattern: "stats_service\\.get_most_played_openings"
+    - from: "app/repositories/stats_repository.py"
+      to: "openings_dedup view"
+      via: "JOIN for pgn/fen/ply_count"
+      pattern: "openings_dedup"
+---
+
+<objective>
+Redesign the most-played-openings backend: SQL-side WDL aggregation via `func.count().filter()`, filter parameter support, JOIN to `openings_dedup` for pgn/fen, top 10 limit, ply threshold.
+
+Purpose: ORT-03 requires the endpoint to return top 10 openings with SQL-computed WDL stats, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below a ply threshold. This replaces the Phase 36 Python-side aggregation.
+Output: Updated repository, service, router, schema, and passing tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/37-openings-reference-table-redesign/37-RESEARCH.md
+@.planning/phases/37-openings-reference-table-redesign/37-01-SUMMARY.md
+
+@app/repositories/stats_repository.py
+@app/services/stats_service.py
+@app/routers/stats.py
+@app/schemas/stats.py
+@app/repositories/endgame_repository.py
+@app/services/analysis_service.py
+@tests/test_stats_repository.py
+@tests/test_stats_router.py
+
+<interfaces>
+<!-- Existing patterns to follow -->
+
+From app/repositories/endgame_repository.py — filter pattern:
+```python
+def _apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff):
+    if time_control is not None:
+        stmt = stmt.where(Game.time_control_bucket.in_(time_control))
+    if platform is not None:
+        stmt = stmt.where(Game.platform.in_(platform))
+    if rated is not None:
+        stmt = stmt.where(Game.rated == rated)
+    if opponent_type == "human":
+        stmt = stmt.where(Game.is_computer_game == False)  # noqa: E712
+    elif opponent_type == "bot":
+        stmt = stmt.where(Game.is_computer_game == True)  # noqa: E712
+    if recency_cutoff is not None:
+        stmt = stmt.where(Game.played_at >= recency_cutoff)
+    return stmt
+```
+
+From app/services/analysis_service.py — recency helper:
+```python
+def recency_cutoff(recency: str | None) -> datetime.datetime | None:
+```
+
+From app/models/opening.py (created in Plan 01):
+```python
+class Opening(Base):
+    __tablename__ = "openings"
+    id, eco, name, pgn, ply_count, fen
+```
+
+The `openings_dedup` view (created in Plan 01):
+```sql
+SELECT DISTINCT ON (eco, name) id, eco, name, pgn, ply_count, fen
+FROM openings ORDER BY eco, name, id
+```
+
+Current OpeningWDL schema (to be extended with pgn, fen):
+```python
+class OpeningWDL(BaseModel):
+    opening_eco: str
+    opening_name: str
+    label: str
+    wins: int; draws: int; losses: int; total: int
+    win_pct: float; draw_pct: float; loss_pct: float
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement SQL-side WDL query, update schema/service/router with filters</name>
+  <files>app/repositories/stats_repository.py, app/services/stats_service.py, app/routers/stats.py, app/schemas/stats.py</files>
+  <read_first>
+    - app/repositories/stats_repository.py (current query_top_openings_by_color)
+    - app/services/stats_service.py (current get_most_played_openings, _aggregate_top_openings, constants)
+    - app/routers/stats.py (current endpoint signature)
+    - app/schemas/stats.py (current OpeningWDL, MostPlayedOpeningsResponse)
+    - app/repositories/endgame_repository.py (for _apply_game_filters pattern)
+    - app/services/analysis_service.py (for recency_cutoff import)
+    - app/models/game.py (for Game columns: is_computer_game, rated, platform, time_control_bucket, played_at)
+  </read_first>
+  <action>
+**1. Update `app/schemas/stats.py`** — add `pgn` and `fen` fields to `OpeningWDL`:
+```python
+class OpeningWDL(BaseModel):
+    """WDL stats for a single opening, with ECO code, PGN, FEN, and display label."""
+
+    opening_eco: str
+    opening_name: str
+    label: str          # "Opening Name (ECO)" — precomputed for UI
+    pgn: str            # PGN move sequence for display
+    fen: str            # Piece-placement FEN for minimap popover
+    wins: int
+    draws: int
+    losses: int
+    total: int
+    win_pct: float
+    draw_pct: float
+    loss_pct: float
+```
+
+**2. Update `app/repositories/stats_repository.py`** — add new SQL-side WDL query function:
+
+Add these imports at the top:
+```python
+import datetime
+from typing import Literal
+from sqlalchemy import Column, Date, MetaData, SmallInteger, String, Table, Text, and_, case, cast, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.game import Game
+```
+
+Add the `_openings_dedup` Table object (using standalone MetaData, NOT Base.metadata — keeps it invisible to Alembic autogenerate):
+```python
+_openings_dedup = Table(
+    "openings_dedup",
+    MetaData(),
+    Column("id"),
+    Column("eco", String(10)),
+    Column("name", String(200)),
+    Column("pgn", Text),
+    Column("ply_count", SmallInteger),
+    Column("fen", String(100)),
+)
+```
+
+Add the `_apply_game_filters` helper (same pattern as endgame_repository.py):
+```python
+def _apply_game_filters(
+    stmt,
+    time_control: list[str] | None,
+    platform: list[str] | None,
+    rated: bool | None,
+    opponent_type: str,
+    recency_cutoff: datetime.datetime | None,
+):
+    """Apply standard game filter WHERE clauses to a statement."""
+    if time_control is not None:
+        stmt = stmt.where(Game.time_control_bucket.in_(time_control))
+    if platform is not None:
+        stmt = stmt.where(Game.platform.in_(platform))
+    if rated is not None:
+        stmt = stmt.where(Game.rated == rated)
+    if opponent_type == "human":
+        stmt = stmt.where(Game.is_computer_game == False)  # noqa: E712
+    elif opponent_type == "bot":
+        stmt = stmt.where(Game.is_computer_game == True)  # noqa: E712
+    if recency_cutoff is not None:
+        stmt = stmt.where(Game.played_at >= recency_cutoff)
+    return stmt
+```
+
+Add the new query function:
+```python
+async def query_top_openings_sql_wdl(
+    session: AsyncSession,
+    user_id: int,
+    color: Literal["white", "black"],
+    min_games: int,
+    limit: int,
+    min_ply: int,
+    recency_cutoff: datetime.datetime | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
+) -> list[tuple]:
+    """Return top openings with SQL-side WDL aggregation.
+
+    JOINs games to openings_dedup to get pgn/fen and filter by min_ply.
+    Returns (eco, name, pgn, fen, total, wins, draws, losses) tuples.
+    Uses func.count().filter() for SQL-side WDL — no Python-side aggregation.
+    """
+    win_cond = or_(
+        and_(Game.result == "1-0", Game.user_color == "white"),
+        and_(Game.result == "0-1", Game.user_color == "black"),
+    )
+    draw_cond = Game.result == "1/2-1/2"
+    loss_cond = or_(
+        and_(Game.result == "0-1", Game.user_color == "white"),
+        and_(Game.result == "1-0", Game.user_color == "black"),
+    )
+
+    stmt = (
+        select(
+            Game.opening_eco,
+            Game.opening_name,
+            _openings_dedup.c.pgn,
+            _openings_dedup.c.fen,
+            func.count().label("total"),
+            func.count().filter(win_cond).label("wins"),
+            func.count().filter(draw_cond).label("draws"),
+            func.count().filter(loss_cond).label("losses"),
+        )
+        .join(
+            _openings_dedup,
+            and_(
+                Game.opening_eco == _openings_dedup.c.eco,
+                Game.opening_name == _openings_dedup.c.name,
+            ),
+        )
+        .where(
+            Game.user_id == user_id,
+            Game.user_color == color,
+            Game.opening_eco.is_not(None),
+            Game.opening_name.is_not(None),
+            _openings_dedup.c.ply_count >= min_ply,
+        )
+        .group_by(
+            Game.opening_eco,
+            Game.opening_name,
+            _openings_dedup.c.pgn,
+            _openings_dedup.c.fen,
+        )
+        .having(func.count() >= min_games)
+        .order_by(func.count().desc())
+        .limit(limit)
+    )
+
+    stmt = _apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff)
+
+    result = await session.execute(stmt)
+    return list(result.fetchall())
+```
+
+Keep the old `query_top_openings_by_color` function in place (don't delete it) — it may be referenced elsewhere. But the service will no longer call it.
+
+**3. Update `app/services/stats_service.py`**:
+
+Update constants:
+```python
+TOP_OPENINGS_LIMIT = 10  # was 5 in Phase 36
+MIN_PLY_WHITE = 1  # White needs at least 1 ply in opening
+MIN_PLY_BLACK = 2  # Black needs at least 2 plies in opening
+```
+
+Add import for the new query function:
+```python
+from app.repositories.stats_repository import (
+    query_rating_history,
+    query_results_by_color,
+    query_results_by_time_control,
+    query_top_openings_by_color,
+    query_top_openings_sql_wdl,
+)
+```
+
+Replace `get_most_played_openings` function body:
+```python
+async def get_most_played_openings(
+    session: AsyncSession,
+    user_id: int,
+    recency: str | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
+) -> MostPlayedOpeningsResponse:
+    """Return top 10 most played openings per color with SQL-side WDL stats.
+
+    JOINs to openings_dedup for pgn/fen. Filters by recency, time_control,
+    platform, rated, and opponent_type. Excludes openings below ply threshold.
+    """
+    cutoff = recency_cutoff(recency)
+
+    white_rows = await query_top_openings_sql_wdl(
+        session,
+        user_id=user_id,
+        color="white",
+        min_games=MIN_GAMES_FOR_OPENING,
+        limit=TOP_OPENINGS_LIMIT,
+        min_ply=MIN_PLY_WHITE,
+        recency_cutoff=cutoff,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
+    )
+    black_rows = await query_top_openings_sql_wdl(
+        session,
+        user_id=user_id,
+        color="black",
+        min_games=MIN_GAMES_FOR_OPENING,
+        limit=TOP_OPENINGS_LIMIT,
+        min_ply=MIN_PLY_BLACK,
+        recency_cutoff=cutoff,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
+    )
+
+    def rows_to_openings(rows: list[tuple]) -> list[OpeningWDL]:
+        openings = []
+        for eco, name, pgn, fen, total, wins, draws, losses in rows:
+            if total > 0:
+                win_pct = round(wins / total * 100, 1)
+                draw_pct = round(draws / total * 100, 1)
+                loss_pct = round(losses / total * 100, 1)
+            else:
+                win_pct = draw_pct = loss_pct = 0.0
+            openings.append(
+                OpeningWDL(
+                    opening_eco=eco,
+                    opening_name=name,
+                    label=f"{name} ({eco})",
+                    pgn=pgn,
+                    fen=fen,
+                    wins=wins,
+                    draws=draws,
+                    losses=losses,
+                    total=total,
+                    win_pct=win_pct,
+                    draw_pct=draw_pct,
+                    loss_pct=loss_pct,
+                )
+            )
+        return openings
+
+    return MostPlayedOpeningsResponse(
+        white=rows_to_openings(white_rows),
+        black=rows_to_openings(black_rows),
+    )
+```
+
+Keep `_aggregate_top_openings` function in place (don't delete it) — it's no longer called from `get_most_played_openings` but removing it is cleanup, not this phase's scope.
+
+**4. Update `app/routers/stats.py`** — add filter params to the endpoint:
+```python
+@router.get("/stats/most-played-openings", response_model=MostPlayedOpeningsResponse)
+async def get_most_played_openings(
+    session: Annotated[AsyncSession, Depends(get_async_session)],
+    user: Annotated[User, Depends(current_active_user)],
+    recency: str | None = Query(default=None),
+    time_control: list[str] | None = Query(default=None),
+    platform: list[str] | None = Query(default=None),
+    rated: bool | None = Query(default=None),
+    opponent_type: str = Query(default="human"),
+) -> MostPlayedOpeningsResponse:
+    """Return top 10 most played openings per color with SQL-side WDL stats.
+
+    Optionally filtered by recency, time_control, platform, rated, opponent_type.
+    """
+    return await stats_service.get_most_played_openings(
+        session,
+        user.id,
+        recency=recency,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
+    )
+```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run ruff check app/repositories/stats_repository.py app/services/stats_service.py app/routers/stats.py app/schemas/stats.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - app/schemas/stats.py OpeningWDL class contains `pgn: str`
+    - app/schemas/stats.py OpeningWDL class contains `fen: str`
+    - app/repositories/stats_repository.py contains `async def query_top_openings_sql_wdl(`
+    - app/repositories/stats_repository.py contains `_openings_dedup = Table(`
+    - app/repositories/stats_repository.py contains `MetaData()` (not `Base.metadata`)
+    - app/repositories/stats_repository.py contains `func.count().filter(win_cond)`
+    - app/repositories/stats_repository.py contains `_openings_dedup.c.ply_count >= min_ply`
+    - app/repositories/stats_repository.py contains `Game.opening_eco.is_not(None)`
+    - app/services/stats_service.py contains `TOP_OPENINGS_LIMIT = 10`
+    - app/services/stats_service.py contains `MIN_PLY_WHITE = 1`
+    - app/services/stats_service.py contains `MIN_PLY_BLACK = 2`
+    - app/services/stats_service.py contains `query_top_openings_sql_wdl`
+    - app/routers/stats.py contains `opponent_type: str = Query(default="human")`
+    - app/routers/stats.py contains `time_control: list[str] | None = Query(default=None)`
+    - `uv run ruff check` on all 4 files exits 0
+  </acceptance_criteria>
+  <done>Backend returns top 10 openings per color with SQL-side WDL, filter support, pgn/fen from openings_dedup JOIN, and ply threshold filtering.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update and extend backend tests for SQL WDL query and endpoint filters</name>
+  <files>tests/test_stats_repository.py, tests/test_stats_router.py</files>
+  <read_first>
+    - tests/test_stats_repository.py (current TestQueryTopOpeningsByColor class)
+    - tests/test_stats_router.py (current most_played_openings tests)
+    - tests/conftest.py (for fixtures, ensure_test_user)
+    - app/repositories/stats_repository.py (updated in Task 1)
+    - app/schemas/stats.py (updated in Task 1)
+  </read_first>
+  <action>
+**1. Update `tests/test_stats_repository.py`:**
+
+Add import for `query_top_openings_sql_wdl` alongside existing imports:
+```python
+from app.repositories.stats_repository import (
+    query_rating_history,
+    query_results_by_color,
+    query_results_by_time_control,
+    query_top_openings_by_color,
+    query_top_openings_sql_wdl,
+)
+```
+
+Add a new test class `TestQueryTopOpeningsSqlWDL` after the existing `TestQueryTopOpeningsByColor` class. The tests need games with `opening_eco`/`opening_name` that match entries in the `openings_dedup` view (which is populated from the seed script). Use known ECO codes from the TSV like `"B00"` with name `"King's Pawn Game"` (pgn: `"1. e4"`, ply_count=1).
+
+```python
+@pytest.mark.asyncio(loop_scope="session")
+class TestQueryTopOpeningsSqlWDL:
+    """Tests for the SQL-side WDL aggregation query (Phase 37)."""
+
+    async def test_sql_wdl_returns_correct_counts(self, db_session: AsyncSession) -> None:
+        """SQL WDL should compute wins/draws/losses in SQL, not Python."""
+        # Seed 3 wins + 2 draws for King's Pawn Game as white
+        for _ in range(3):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+        for _ in range(2):
+            await _seed_game(db_session, user_id=99999, result="1/2-1/2", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=1)
+        assert len(rows) >= 1
+        # Find the King's Pawn Game row
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 1
+        eco, name, pgn, fen, total, wins, draws, losses = kpg[0]
+        assert wins == 3
+        assert draws == 2
+        assert losses == 0
+        assert total == 5
+        assert pgn  # non-empty PGN from openings_dedup
+        assert fen   # non-empty FEN from openings_dedup
+        assert "/" in fen  # FEN has rank separators
+
+    async def test_sql_wdl_excludes_below_min_games(self, db_session: AsyncSession) -> None:
+        """Openings below min_games threshold should not appear."""
+        await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                         opening_eco="B00", opening_name="King's Pawn Game")
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=100, limit=10, min_ply=1)
+        assert len(rows) == 0
+
+    async def test_sql_wdl_filters_by_time_control(self, db_session: AsyncSession) -> None:
+        """time_control filter should restrict results."""
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game",
+                             time_control_bucket="blitz")
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game",
+                             time_control_bucket="rapid")
+
+        # Filter to blitz only
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=1,
+            time_control=["blitz"])
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 1
+        assert kpg[0][4] == 10  # total = 10 blitz games only
+
+    async def test_sql_wdl_ply_threshold_excludes_short_openings(self, db_session: AsyncSession) -> None:
+        """min_ply filter should exclude openings with ply_count below threshold."""
+        # King's Pawn Game has ply_count=1 (1. e4)
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+        # With min_ply=5, King's Pawn Game (ply=1) should be excluded
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=5)
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 0
+```
+
+**2. Update `tests/test_stats_router.py`:**
+
+Find the existing test(s) for `GET /stats/most-played-openings` and update them to verify:
+- Response includes `pgn` and `fen` fields
+- Endpoint accepts filter query params (add a test with `?time_control=blitz`)
+- Response schema validation (Pydantic would fail if pgn/fen missing)
+
+Add or update test methods:
+```python
+async def test_most_played_openings_includes_pgn_fen(self, ...):
+    """Response should include pgn and fen fields per ORT-03."""
+    response = await client.get("/stats/most-played-openings", ...)
+    assert response.status_code == 200
+    data = response.json()
+    # If there are openings, they should have pgn and fen
+    for opening in data.get("white", []) + data.get("black", []):
+        assert "pgn" in opening
+        assert "fen" in opening
+
+async def test_most_played_openings_accepts_filters(self, ...):
+    """Endpoint should accept filter params without error."""
+    response = await client.get(
+        "/stats/most-played-openings",
+        params={"recency": "month", "time_control": ["blitz"], "rated": True},
+        ...
+    )
+    assert response.status_code == 200
+```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - tests/test_stats_repository.py contains `class TestQueryTopOpeningsSqlWDL`
+    - tests/test_stats_repository.py contains `from app.repositories.stats_repository import` with `query_top_openings_sql_wdl`
+    - tests/test_stats_repository.py contains `test_sql_wdl_returns_correct_counts`
+    - tests/test_stats_repository.py contains `test_sql_wdl_ply_threshold_excludes_short_openings`
+    - tests/test_stats_router.py contains test verifying `pgn` and `fen` in response
+    - `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x` exits 0
+  </acceptance_criteria>
+  <done>SQL-side WDL aggregation tested with correct counts, filter params verified, ply threshold tested, endpoint returns pgn and fen fields. ORT-03 fully verified.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x -v` passes all tests
+- `uv run ruff check app/repositories/ app/services/ app/routers/ app/schemas/` clean
+- `curl` to local dev server returns top 10 openings with pgn/fen fields
+</verification>
+
+<success_criteria>
+- Endpoint returns top 10 (not 5) openings per color
+- WDL computed in SQL via func.count().filter(), not Python-side aggregation
+- Endpoint accepts recency, time_control, platform, rated, opponent_type filters
+- Response includes pgn and fen for each opening (from openings_dedup JOIN)
+- Openings below ply threshold excluded
+- All repository and router tests pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/37-openings-reference-table-redesign/37-02-SUMMARY.md`
+</output>

--- a/.planning/phases/37-openings-reference-table-redesign/37-02-SUMMARY.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-02-SUMMARY.md
@@ -1,0 +1,141 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: 02
+subsystem: api
+tags: [fastapi, sqlalchemy, postgresql, pytest, openings]
+
+# Dependency graph
+requires:
+  - phase: 37-01
+    provides: openings table, openings_dedup view with eco/name/pgn/ply_count/fen columns
+provides:
+  - SQL-side WDL aggregation via func.count().filter() in query_top_openings_sql_wdl
+  - openings_dedup JOIN returning pgn/fen per opening in response
+  - Filter params: recency, time_control, platform, rated, opponent_type on most-played-openings endpoint
+  - Top 10 (was 5) openings per color with ply threshold filtering
+affects:
+  - 37-03 (frontend openings reference table reads pgn/fen from this endpoint)
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "SQL-side WDL with func.count().filter(condition) — no Python-side aggregation loop"
+    - "Standalone MetaData() for view table objects (not Base.metadata) — invisible to Alembic autogenerate"
+    - "_apply_game_filters helper pattern reused from endgame_repository.py"
+
+key-files:
+  created: []
+  modified:
+    - app/repositories/stats_repository.py
+    - app/services/stats_service.py
+    - app/routers/stats.py
+    - app/schemas/stats.py
+    - tests/test_stats_repository.py
+    - tests/test_stats_router.py
+
+key-decisions:
+  - "Standalone MetaData() for _openings_dedup Table — keeps view invisible to Alembic autogenerate"
+  - "SQL-side WDL via func.count().filter() replaces Python-side _aggregate_top_openings loop"
+  - "TOP_OPENINGS_LIMIT raised from 5 to 10; MIN_PLY_WHITE=1, MIN_PLY_BLACK=2 added"
+  - "Old query_top_openings_by_color and _aggregate_top_openings kept in place — cleanup is out of scope for this plan"
+
+requirements-completed: [ORT-03]
+
+# Metrics
+duration: 10min
+completed: 2026-03-28
+---
+
+# Phase 37 Plan 02: Backend WDL Aggregation & Filter Params Summary
+
+**SQL-side WDL aggregation via func.count().filter(), openings_dedup JOIN for pgn/fen, top-10 limit, ply threshold, and full filter param support on /stats/most-played-openings**
+
+## Performance
+
+- **Duration:** ~10 min
+- **Started:** 2026-03-28T19:40:00Z
+- **Completed:** 2026-03-28T19:50:55Z
+- **Tasks:** 2
+- **Files modified:** 6
+
+## Accomplishments
+
+- Added `query_top_openings_sql_wdl` using `func.count().filter()` for SQL-side WDL — no Python aggregation loop
+- Added `_openings_dedup` Table with standalone MetaData (Alembic-invisible), joined to return pgn/fen per opening
+- Added `_apply_game_filters` helper mirroring endgame_repository.py pattern for recency/time_control/platform/rated/opponent_type
+- Updated `OpeningWDL` schema with `pgn: str` and `fen: str` fields
+- Raised `TOP_OPENINGS_LIMIT` from 5 to 10; added `MIN_PLY_WHITE=1` and `MIN_PLY_BLACK=2` constants
+- Updated endpoint to accept all filter query params; 55 tests pass including 4 new SQL WDL tests and 3 new endpoint filter tests
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: SQL-side WDL query, schema/service/router updates** - `3bef909` (feat)
+2. **Task 2: Repository and router tests** - `8ca4c31` (test)
+
+## Files Created/Modified
+
+- `app/repositories/stats_repository.py` - Added _openings_dedup Table, _apply_game_filters, query_top_openings_sql_wdl
+- `app/services/stats_service.py` - Updated get_most_played_openings with filter params, TOP_OPENINGS_LIMIT=10, MIN_PLY constants
+- `app/routers/stats.py` - Added recency/time_control/platform/rated/opponent_type query params to endpoint
+- `app/schemas/stats.py` - Added pgn and fen fields to OpeningWDL
+- `tests/test_stats_repository.py` - Added TestQueryTopOpeningsSqlWDL (4 tests)
+- `tests/test_stats_router.py` - Added 3 most-played-openings tests (pgn/fen presence, filters, opponent_type)
+
+## Decisions Made
+
+- Standalone `MetaData()` for `_openings_dedup` Table keeps the view object invisible to Alembic autogenerate (same pattern as other projects using views)
+- SQL-side WDL via `func.count().filter(condition)` replaces the Python-side `_aggregate_top_openings` loop — cleaner, fewer round-trips
+- Old `query_top_openings_by_color` and `_aggregate_top_openings` kept in place — removal is out of scope (no callers, but cleanup belongs in a dedicated refactor task)
+
+## Deviations from Plan
+
+**1. [Rule 3 - Blocking] Cherry-picked 37-01 migration into worktree**
+- **Found during:** Task 2 (test execution)
+- **Issue:** This worktree branch didn't have the 37-01 Alembic migration (`1b941ecba0a6`) created by Plan 01 in the main worktree. The conftest.py `alembic upgrade head` failed with "No such revision".
+- **Fix:** Cherry-picked the 37-01 feat/test commits (dbfe475, cd849a0) into this worktree. The 37-01 docs commit was skipped due to .planning file conflicts.
+- **Files modified:** alembic/versions/20260328_194057_1b941ecba0a6_create_openings_table.py, app/models/opening.py, scripts/seed_openings.py, tests/test_seed_openings.py
+- **Verification:** All 55 tests pass
+- **Committed in:** 0a41374, f4601f7 (cherry-pick commits)
+
+---
+
+**Total deviations:** 1 auto-fixed (Rule 3 - Blocking)
+**Impact on plan:** Necessary to obtain prerequisite migration from parallel worktree. No scope creep.
+
+## Issues Encountered
+
+- Tests from worktree must be run with the worktree as CWD (not the main project dir) to pick up the new test classes — the main project's tests didn't have the new code yet.
+- `seed_openings_for_tests` autouse fixture must be in scope for SQL WDL tests (needs populated `openings_dedup`). Solved by including `tests/test_seed_openings.py` in the pytest invocation.
+
+## Known Stubs
+
+None — all data is real (joined from seeded openings_dedup view).
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Endpoint returns pgn/fen for each opening — ready for Plan 03 frontend minimap popovers
+- Filter params fully wired — frontend filter UI can immediately wire to all params
+- Top 10 limit and ply threshold active
+
+## Self-Check: PASSED
+
+- FOUND: app/repositories/stats_repository.py
+- FOUND: app/schemas/stats.py
+- FOUND: tests/test_stats_repository.py
+- FOUND: commit 3bef909 (feat)
+- FOUND: commit 8ca4c31 (test)
+- FOUND: query_top_openings_sql_wdl function
+- FOUND: pgn: str field in OpeningWDL
+- FOUND: TOP_OPENINGS_LIMIT = 10
+- FOUND: TestQueryTopOpeningsSqlWDL class
+
+---
+*Phase: 37-openings-reference-table-redesign*
+*Completed: 2026-03-28*

--- a/.planning/phases/37-openings-reference-table-redesign/37-03-PLAN.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-03-PLAN.md
@@ -1,0 +1,563 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: 03
+type: execute
+wave: 3
+depends_on: ["37-02"]
+files_modified:
+  - frontend/src/types/stats.ts
+  - frontend/src/api/client.ts
+  - frontend/src/hooks/useStats.ts
+  - frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+  - frontend/src/components/stats/MinimapPopover.tsx
+  - frontend/src/pages/Openings.tsx
+autonomous: false
+requirements: [ORT-04, ORT-05]
+
+must_haves:
+  truths:
+    - "User sees a table with ECO, opening name, PGN, game count, and mini WDL bar per opening"
+    - "User sees top 10 openings (not 5) per color"
+    - "Hovering or tapping a row shows a minimap popover with the opening position"
+    - "Filters (recency, time control, platform, rated, opponent type) affect which openings are shown"
+  artifacts:
+    - path: "frontend/src/components/stats/MostPlayedOpeningsTable.tsx"
+      provides: "Dedicated table component for most played openings"
+      contains: "MostPlayedOpeningsTable"
+    - path: "frontend/src/components/stats/MinimapPopover.tsx"
+      provides: "Hover/tap popover with static Chessboard"
+      contains: "MinimapPopover"
+    - path: "frontend/src/types/stats.ts"
+      provides: "Updated OpeningWDL with pgn/fen fields"
+      contains: "pgn: string"
+  key_links:
+    - from: "frontend/src/pages/Openings.tsx"
+      to: "frontend/src/components/stats/MostPlayedOpeningsTable.tsx"
+      via: "component import and render"
+      pattern: "MostPlayedOpeningsTable"
+    - from: "frontend/src/hooks/useStats.ts"
+      to: "frontend/src/api/client.ts"
+      via: "statsApi.getMostPlayedOpenings with filter params"
+      pattern: "getMostPlayedOpenings"
+    - from: "frontend/src/components/stats/MostPlayedOpeningsTable.tsx"
+      to: "frontend/src/components/stats/MinimapPopover.tsx"
+      via: "wraps each row's name cell"
+      pattern: "MinimapPopover"
+---
+
+<objective>
+Redesign the Most Played Openings frontend: update types/API/hook for filter support and new fields, create dedicated table component with ECO/name/PGN columns and mini WDL bars, add minimap popover on hover/tap.
+
+Purpose: ORT-04 requires a dedicated table UI replacing WDLChartRow, and ORT-05 requires a minimap popover showing the opening position. The hook must pass filter params to the redesigned backend endpoint.
+Output: New MostPlayedOpeningsTable and MinimapPopover components, updated hook with filter support, visual checkpoint.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/phases/37-openings-reference-table-redesign/37-RESEARCH.md
+@.planning/phases/37-openings-reference-table-redesign/37-02-SUMMARY.md
+
+@frontend/src/types/stats.ts
+@frontend/src/api/client.ts
+@frontend/src/hooks/useStats.ts
+@frontend/src/pages/Openings.tsx
+@frontend/src/components/ui/info-popover.tsx
+@frontend/src/components/board/ChessBoard.tsx
+@frontend/src/components/stats/WDLChartRow.tsx
+@frontend/src/lib/theme.ts
+@frontend/src/components/filters/FilterPanel.tsx
+
+<interfaces>
+<!-- Key types and contracts -->
+
+From frontend/src/types/stats.ts (to be updated):
+```typescript
+export interface OpeningWDL {
+  opening_eco: string;
+  opening_name: string;
+  label: string;
+  // ADD: pgn: string;
+  // ADD: fen: string;
+  wins: number; draws: number; losses: number; total: number;
+  win_pct: number; draw_pct: number; loss_pct: number;
+}
+```
+
+From frontend/src/components/filters/FilterPanel.tsx:
+```typescript
+export interface FilterState {
+  matchSide: MatchSide;
+  timeControls: TimeControl[] | null;
+  platforms: Platform[] | null;
+  rated: boolean | null;
+  opponentType: OpponentType;
+  recency: Recency | null;
+  color: Color;
+}
+```
+
+From frontend/src/lib/theme.ts:
+```typescript
+export const BOARD_DARK_SQUARE = '#B68965';
+export const BOARD_LIGHT_SQUARE = '#F0DAB7';
+export const WDL_WIN = '...';
+export const WDL_DRAW = '...';
+export const WDL_LOSS = '...';
+export const GLASS_OVERLAY = '...';
+```
+
+From frontend/src/components/ui/info-popover.tsx (pattern for Radix Popover):
+```typescript
+import { Popover as PopoverPrimitive } from "radix-ui"
+// Uses: PopoverPrimitive.Root, .Trigger, .Portal, .Content
+// Pattern: controlled open state, onMouseEnter/Leave with timeout, onOpenChange
+```
+
+From frontend/src/pages/Openings.tsx:
+```typescript
+const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
+const debouncedFilters = useDebounce(filters, 300);
+// useMostPlayedOpenings() currently takes no args
+// statisticsContent references mostPlayedData.white and mostPlayedData.black
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update types, API client, hook, create MinimapPopover and MostPlayedOpeningsTable, wire into Openings page</name>
+  <files>frontend/src/types/stats.ts, frontend/src/api/client.ts, frontend/src/hooks/useStats.ts, frontend/src/components/stats/MostPlayedOpeningsTable.tsx, frontend/src/components/stats/MinimapPopover.tsx, frontend/src/pages/Openings.tsx</files>
+  <read_first>
+    - frontend/src/types/stats.ts (current OpeningWDL interface)
+    - frontend/src/api/client.ts (current statsApi.getMostPlayedOpenings)
+    - frontend/src/hooks/useStats.ts (current useMostPlayedOpenings)
+    - frontend/src/pages/Openings.tsx (full file — understand statisticsContent, debouncedFilters usage, maxTotalWhite/maxTotalBlack)
+    - frontend/src/components/ui/info-popover.tsx (Radix Popover pattern to replicate)
+    - frontend/src/components/board/ChessBoard.tsx (react-chessboard import pattern)
+    - frontend/src/lib/theme.ts (board square colors, WDL colors, GLASS_OVERLAY)
+    - frontend/src/components/stats/WDLChartRow.tsx (WDL bar rendering to reference for mini bar)
+    - frontend/src/components/filters/FilterPanel.tsx (FilterState interface, DEFAULT_FILTERS)
+    - frontend/src/types/api.ts (Recency, Platform, TimeControl, OpponentType types)
+  </read_first>
+  <action>
+**1. Update `frontend/src/types/stats.ts`** — add `pgn` and `fen` to `OpeningWDL`:
+```typescript
+export interface OpeningWDL {
+  opening_eco: string;
+  opening_name: string;
+  label: string;
+  pgn: string;
+  fen: string;
+  wins: number;
+  draws: number;
+  losses: number;
+  total: number;
+  win_pct: number;
+  draw_pct: number;
+  loss_pct: number;
+}
+```
+
+**2. Update `frontend/src/api/client.ts`** — add filter params to `getMostPlayedOpenings`:
+```typescript
+getMostPlayedOpenings: (params?: {
+  recency?: string | null;
+  time_control?: string[] | null;
+  platform?: string[] | null;
+  rated?: boolean | null;
+  opponent_type?: string;
+}) =>
+  apiClient.get<MostPlayedOpeningsResponse>('/stats/most-played-openings', {
+    params: {
+      ...(params?.recency ? { recency: params.recency } : {}),
+      ...(params?.time_control ? { time_control: params.time_control } : {}),
+      ...(params?.platform ? { platform: params.platform } : {}),
+      ...(params?.rated !== undefined && params?.rated !== null ? { rated: params.rated } : {}),
+      ...(params?.opponent_type && params.opponent_type !== 'all' ? { opponent_type: params.opponent_type } : {}),
+    },
+  }).then(r => r.data),
+```
+
+**3. Update `frontend/src/hooks/useStats.ts`** — add filter params to `useMostPlayedOpenings`:
+
+Import the filter types needed:
+```typescript
+import type { Platform, Recency, TimeControl, OpponentType } from '@/types/api';
+```
+
+Replace `useMostPlayedOpenings`:
+```typescript
+export function useMostPlayedOpenings(filters?: {
+  recency: Recency | null;
+  timeControls: TimeControl[] | null;
+  platforms: Platform[] | null;
+  rated: boolean | null;
+  opponentType: OpponentType;
+}) {
+  const normalizedRecency = filters?.recency === 'all' ? null : (filters?.recency ?? null);
+  const timeControl = filters?.timeControls ?? null;
+  const platform = filters?.platforms ?? null;
+  const rated = filters?.rated ?? null;
+  const opponentType = filters?.opponentType ?? 'human';
+
+  return useQuery({
+    queryKey: ['mostPlayedOpenings', normalizedRecency, timeControl, platform, rated, opponentType],
+    queryFn: () => statsApi.getMostPlayedOpenings({
+      recency: normalizedRecency,
+      time_control: timeControl,
+      platform: platform,
+      rated: rated,
+      opponent_type: opponentType,
+    }),
+  });
+}
+```
+
+**4. Create `frontend/src/components/stats/MinimapPopover.tsx`**:
+
+Follow the info-popover.tsx pattern exactly — controlled state, hover timeout, Portal, onMouseEnter/Leave on both trigger and content.
+
+```tsx
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+import { Chessboard } from "react-chessboard"
+import { BOARD_DARK_SQUARE, BOARD_LIGHT_SQUARE } from "@/lib/theme"
+
+const MINIMAP_BOARD_SIZE = 180;
+
+interface MinimapPopoverProps {
+  fen: string;
+  children: React.ReactNode;
+  testId: string;
+}
+
+function MinimapPopover({ fen, children, testId }: MinimapPopoverProps) {
+  const [open, setOpen] = React.useState(false);
+  const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = () => {
+    hoverTimeout.current = setTimeout(() => setOpen(true), 150);
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+    setOpen(false);
+  };
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <div
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          data-testid={testId}
+          className="cursor-pointer"
+        >
+          {children}
+        </div>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="right"
+          sideOffset={8}
+          avoidCollisions
+          onMouseEnter={() => {
+            if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+          }}
+          onMouseLeave={handleMouseLeave}
+          className="z-[100] rounded-md shadow-lg overflow-hidden"
+          data-testid={`${testId}-popover`}
+        >
+          <Chessboard
+            id="minimap-board"
+            position={fen}
+            boardWidth={MINIMAP_BOARD_SIZE}
+            arePiecesDraggable={false}
+            customDarkSquareStyle={{ backgroundColor: BOARD_DARK_SQUARE }}
+            customLightSquareStyle={{ backgroundColor: BOARD_LIGHT_SQUARE }}
+          />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}
+
+export { MinimapPopover };
+```
+
+**5. Create `frontend/src/components/stats/MostPlayedOpeningsTable.tsx`**:
+
+This component renders a table of openings with three visual columns per row:
+- Column 1: ECO code + opening name (split on `: ` for line break) + PGN moves in muted text
+- Column 2: game count number as link to games tab
+- Column 3: mini WDL bar (inline div segments using WDL_WIN/WDL_DRAW/WDL_LOSS/GLASS_OVERLAY from theme.ts)
+
+Each row wraps the name cell in `MinimapPopover` for hover/tap position preview.
+
+```tsx
+import type { OpeningWDL } from "@/types/stats"
+import { MinimapPopover } from "./MinimapPopover"
+import { FolderOpen } from "lucide-react"
+import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
+import { useNavigate } from "react-router-dom"
+
+interface MostPlayedOpeningsTableProps {
+  openings: OpeningWDL[];
+  testIdPrefix: string;
+}
+
+/** Format opening name: split on ": " and insert line break if colon found. */
+function formatName(name: string): React.ReactNode {
+  const parts = name.split(": ");
+  if (parts.length > 1) {
+    return (
+      <>
+        <span className="font-medium">{parts[0]}:</span>
+        <br />
+        <span>{parts.slice(1).join(": ")}</span>
+      </>
+    );
+  }
+  return <span className="font-medium">{name}</span>;
+}
+
+function MiniWDLBar({ win_pct, draw_pct, loss_pct }: { win_pct: number; draw_pct: number; loss_pct: number }) {
+  return (
+    <div className="flex h-4 w-full min-w-[80px] overflow-hidden rounded-sm" data-testid="mini-wdl-bar">
+      {win_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {win_pct >= 15 ? `${Math.round(win_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {draw_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {draw_pct >= 15 ? `${Math.round(draw_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {loss_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {loss_pct >= 15 ? `${Math.round(loss_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MostPlayedOpeningsTable({ openings, testIdPrefix }: MostPlayedOpeningsTableProps) {
+  const navigate = useNavigate();
+
+  if (openings.length === 0) return null;
+
+  return (
+    <div className="space-y-1" data-testid={`${testIdPrefix}-table`}>
+      {openings.map((o) => (
+        <div
+          key={`${o.opening_eco}-${o.opening_name}`}
+          className="grid grid-cols-[1fr_auto_minmax(80px,120px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors"
+          data-testid={`${testIdPrefix}-row-${o.opening_eco}`}
+        >
+          {/* Column 1: ECO + Name + PGN */}
+          <MinimapPopover fen={o.fen} testId={`${testIdPrefix}-minimap-${o.opening_eco}`}>
+            <div className="min-w-0">
+              <div className="text-sm leading-tight">
+                <span className="text-muted-foreground mr-1.5">{o.opening_eco}</span>
+                {formatName(o.opening_name)}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5 truncate">{o.pgn}</div>
+            </div>
+          </MinimapPopover>
+
+          {/* Column 2: Game count with link to games tab */}
+          <button
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={`View ${o.total} games for ${o.opening_name}`}
+            data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
+            onClick={() => navigate('/openings/games')}
+          >
+            <span className="tabular-nums">{o.total}</span>
+            <FolderOpen className="h-3.5 w-3.5" />
+          </button>
+
+          {/* Column 3: Mini WDL bar */}
+          <MiniWDLBar win_pct={o.win_pct} draw_pct={o.draw_pct} loss_pct={o.loss_pct} />
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+**6. Update `frontend/src/pages/Openings.tsx`**:
+
+a) Update the `useMostPlayedOpenings` call to pass filter params. Extract the relevant fields from `debouncedFilters`:
+```typescript
+const { data: mostPlayedData } = useMostPlayedOpenings({
+  recency: debouncedFilters.recency,
+  timeControls: debouncedFilters.timeControls,
+  platforms: debouncedFilters.platforms,
+  rated: debouncedFilters.rated,
+  opponentType: debouncedFilters.opponentType,
+});
+```
+
+b) Add import for `MostPlayedOpeningsTable`:
+```typescript
+import { MostPlayedOpeningsTable } from '@/components/stats/MostPlayedOpeningsTable';
+```
+
+c) Remove the `maxTotalWhite` and `maxTotalBlack` computations (no longer needed — we don't use WDLChartRow).
+
+d) In `statisticsContent`, replace the `WDLChartRow` mapping blocks for white and black with `MostPlayedOpeningsTable`:
+```tsx
+const statisticsContent = (
+  <div className="flex flex-col gap-4">
+    {mostPlayedData && (mostPlayedData.white.length > 0 || mostPlayedData.black.length > 0) && (
+      <div className="charcoal-texture rounded-md p-4" data-testid="most-played-openings">
+        <h2 className="text-lg font-medium mb-3">Most Played Openings</h2>
+        <div className="space-y-6">
+          {/* White section */}
+          <div data-testid="mpo-white-section">
+            <h3 className="text-base font-medium mb-2 flex items-center gap-1.5">
+              <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white" />
+              White
+            </h3>
+            {mostPlayedData.white.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Not enough games with White to show top openings (minimum 10 games per opening).</p>
+            ) : (
+              <MostPlayedOpeningsTable
+                openings={mostPlayedData.white}
+                testIdPrefix="mpo-white"
+              />
+            )}
+          </div>
+          {/* Black section */}
+          <div data-testid="mpo-black-section">
+            <h3 className="text-base font-medium mb-2 flex items-center gap-1.5">
+              <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900" />
+              Black
+            </h3>
+            {mostPlayedData.black.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Not enough games with Black to show top openings (minimum 10 games per opening).</p>
+            ) : (
+              <MostPlayedOpeningsTable
+                openings={mostPlayedData.black}
+                testIdPrefix="mpo-black"
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    )}
+    ...rest of statisticsContent unchanged...
+```
+
+e) Remove the `WDLChartRow` import if it's no longer used in `statisticsContent` (it may still be used by "Results by Opening" below — check before removing).
+
+f) Verify `statisticsContent` is used in both desktop and mobile TabsContent blocks. Since it's a shared variable defined once, changes propagate automatically — but confirm by searching for `{statisticsContent}` occurrences.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build && npm run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - frontend/src/types/stats.ts OpeningWDL contains `pgn: string` and `fen: string`
+    - frontend/src/api/client.ts getMostPlayedOpenings accepts params with recency, time_control, platform, rated, opponent_type
+    - frontend/src/hooks/useStats.ts useMostPlayedOpenings accepts filters parameter
+    - frontend/src/hooks/useStats.ts useMostPlayedOpenings queryKey includes filter values
+    - frontend/src/components/stats/MinimapPopover.tsx contains `Chessboard` import from `react-chessboard`
+    - frontend/src/components/stats/MinimapPopover.tsx contains `boardWidth={MINIMAP_BOARD_SIZE}`
+    - frontend/src/components/stats/MinimapPopover.tsx contains `arePiecesDraggable={false}`
+    - frontend/src/components/stats/MinimapPopover.tsx contains `data-testid={testId}`
+    - frontend/src/components/stats/MinimapPopover.tsx contains `data-testid={\`${testId}-popover\`}`
+    - frontend/src/components/stats/MostPlayedOpeningsTable.tsx contains `data-testid={`
+    - frontend/src/components/stats/MostPlayedOpeningsTable.tsx contains `MiniWDLBar`
+    - frontend/src/components/stats/MostPlayedOpeningsTable.tsx contains `MinimapPopover`
+    - frontend/src/components/stats/MostPlayedOpeningsTable.tsx contains `FolderOpen`
+    - frontend/src/pages/Openings.tsx contains `MostPlayedOpeningsTable` import
+    - frontend/src/pages/Openings.tsx contains `useMostPlayedOpenings({` (with filter args)
+    - `npm run build` exits 0
+    - `npm run lint` exits 0
+  </acceptance_criteria>
+  <done>Frontend renders dedicated table with ECO/name/PGN, game count link, mini WDL bar per row. Filters affect which openings are shown. Build and lint pass.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Visual verification of Most Played Openings redesign</name>
+  <what-built>
+    Complete frontend redesign of Most Played Openings section:
+    - Dedicated table layout with ECO code, opening name (split at colon), PGN moves, game count, mini WDL bar
+    - Top 10 openings per color (up from 5)
+    - Minimap popover on hover/tap showing the opening position
+    - Filter support (recency, time control, platform, rated, opponent type) affecting results
+  </what-built>
+  <how-to-verify>
+    1. Start backend: `uv run uvicorn app.main:app --reload`
+    2. Start frontend: `cd frontend && npm run dev`
+    3. Navigate to Openings page > Statistics subtab
+    4. Verify "Most Played Openings" section shows a table (not WDL bar charts) with:
+       - ECO code + opening name + PGN moves per row
+       - Game count with folder icon
+       - Mini WDL bar with win/draw/loss segments
+    5. Hover over an opening name — verify minimap popover appears showing correct position
+    6. On mobile viewport (toggle Chrome DevTools responsive mode):
+       - Verify table is readable on small screens
+       - Tap an opening name — verify minimap popover appears on tap
+    7. Change a filter (e.g. time control to "Blitz" only) — verify openings update accordingly
+    8. Verify up to 10 openings per color are shown (if user has enough games)
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe issues to fix</resume-signal>
+  <files>frontend/src/pages/Openings.tsx</files>
+  <action>Human visual verification of the Most Played Openings redesign. No code changes — verify the UI renders correctly on desktop and mobile.</action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build</automated>
+  </verify>
+  <done>User has approved the visual design of the Most Played Openings table, minimap popover, and filter integration.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `npm run build` passes (no TypeScript errors)
+- `npm run lint` passes
+- Visual: Table layout with ECO/name/PGN, game count, mini WDL bar
+- Visual: Minimap popover appears on hover (desktop) and tap (mobile)
+- Visual: Changing filters updates the openings list
+</verification>
+
+<success_criteria>
+- MostPlayedOpeningsTable component renders dedicated table layout replacing WDLChartRow
+- MinimapPopover shows static board position on hover/tap
+- Filter params (recency, time_control, platform, rated, opponent_type) passed to backend
+- Top 10 openings per color displayed
+- All data-testid attributes present on interactive elements
+- Build and lint pass
+- User approves visual design
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/37-openings-reference-table-redesign/37-03-SUMMARY.md`
+</output>

--- a/.planning/phases/37-openings-reference-table-redesign/37-03-SUMMARY.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-03-SUMMARY.md
@@ -1,0 +1,120 @@
+---
+phase: 37-openings-reference-table-redesign
+plan: "03"
+subsystem: ui
+tags: [react, typescript, radix-ui, react-chessboard, tanstack-query, tailwind]
+
+requires:
+  - phase: 37-02
+    provides: "Backend endpoint with filter params, OpeningWDL schema with pgn/fen fields"
+
+provides:
+  - "MostPlayedOpeningsTable component: dedicated table UI with ECO/name/PGN columns, game count link, mini WDL bars"
+  - "MinimapPopover component: hover/tap Radix popover with static Chessboard showing opening position"
+  - "useMostPlayedOpenings hook: accepts filter params (recency, timeControls, platforms, rated, opponentType)"
+  - "API client getMostPlayedOpenings: passes filter params to backend"
+  - "OpeningWDL type: pgn and fen fields added"
+
+affects:
+  - openings-statistics-tab
+  - most-played-openings
+
+tech-stack:
+  added: []
+  patterns:
+    - "MinimapPopover follows info-popover.tsx Radix Popover pattern: controlled open state, hover timeout, Portal, onMouseEnter/Leave on both trigger and content"
+    - "MostPlayedOpeningsTable uses CSS grid-cols-[1fr_auto_minmax(80px,120px)] for compact 3-column layout"
+    - "MiniWDLBar uses inline div segments with WDL_WIN/WDL_DRAW/WDL_LOSS from theme.ts and GLASS_OVERLAY"
+
+key-files:
+  created:
+    - frontend/src/components/stats/MinimapPopover.tsx
+    - frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+  modified:
+    - frontend/src/types/stats.ts
+    - frontend/src/api/client.ts
+    - frontend/src/hooks/useStats.ts
+    - frontend/src/pages/Openings.tsx
+
+key-decisions:
+  - "arePiecesDraggable not a valid prop in react-chessboard v5 — omitted, static board achieved by absence of onPieceDrop/onSquareClick handlers"
+  - "MIN_PCT_FOR_LABEL = 15: threshold for showing percent label inside WDL bar segment (avoids cramped text)"
+  - "MostPlayedOpeningsTable replaces WDLChartRow mapping blocks in statisticsContent; maxTotalWhite/maxTotalBlack removed as no longer needed"
+  - "Filter params now passed from debouncedFilters to useMostPlayedOpenings so Statistics subtab openings react to filter changes"
+
+requirements-completed: [ORT-04, ORT-05]
+
+duration: 4min
+completed: 2026-03-28
+---
+
+# Phase 37 Plan 03: Most Played Openings Frontend Redesign Summary
+
+**Dedicated table UI replacing WDLChartRow bars: ECO/name/PGN columns, mini WDL bars, minimap popover on hover/tap, filter-aware results**
+
+## Performance
+
+- **Duration:** 4 min
+- **Started:** 2026-03-28T19:54:45Z
+- **Completed:** 2026-03-28T19:58:07Z
+- **Tasks:** 1 of 2 (Task 2 is checkpoint:human-verify — awaiting user approval)
+- **Files modified:** 6
+
+## Accomplishments
+- Created `MostPlayedOpeningsTable` component with 3-column grid layout: opening info (ECO + name + PGN), game count with folder icon link, mini WDL bar
+- Created `MinimapPopover` component using Radix Popover with 150ms hover delay, Portal, and static 180px Chessboard
+- Updated `useMostPlayedOpenings` hook to accept and propagate all filter params (recency, timeControls, platforms, rated, opponentType) to the backend
+- Replaced `WDLChartRow` mappings in `statisticsContent` with `MostPlayedOpeningsTable`, removed obsolete `maxTotalWhite/maxTotalBlack` computations
+- `OpeningWDL` type updated with `pgn` and `fen` fields to match Wave 2 backend schema
+
+## Task Commits
+
+1. **Task 1: Update types/API/hook, create MinimapPopover and MostPlayedOpeningsTable, wire into Openings page** - `f2c0ec4` (feat)
+
+## Files Created/Modified
+- `frontend/src/types/stats.ts` — Added `pgn: string` and `fen: string` to `OpeningWDL` interface
+- `frontend/src/api/client.ts` — `getMostPlayedOpenings` now accepts filter params object
+- `frontend/src/hooks/useStats.ts` — `useMostPlayedOpenings` accepts filter params, query key includes all filter values
+- `frontend/src/components/stats/MinimapPopover.tsx` — New: Radix Popover wrapping Chessboard for opening position preview
+- `frontend/src/components/stats/MostPlayedOpeningsTable.tsx` — New: Table with ECO/name/PGN, game count, mini WDL bar per row
+- `frontend/src/pages/Openings.tsx` — Wired MostPlayedOpeningsTable, pass debouncedFilters to useMostPlayedOpenings
+
+## Decisions Made
+- `arePiecesDraggable` is not a prop in react-chessboard v5 (API uses `options.onPieceDrop` absence for static boards) — omitted, static board is achieved by not providing interaction handlers
+- `MIN_PCT_FOR_LABEL = 15` constant extracted for mini WDL bar label display threshold
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Removed invalid `arePiecesDraggable={false}` prop from MinimapPopover**
+- **Found during:** Task 1 (MinimapPopover creation)
+- **Issue:** Plan acceptance criteria listed `arePiecesDraggable={false}` but react-chessboard v5 uses `options` wrapper API with no such prop — TypeScript would reject it
+- **Fix:** Omitted the prop; static board achieved by absence of `onPieceDrop`/`onSquareClick` handlers in options
+- **Files modified:** frontend/src/components/stats/MinimapPopover.tsx
+- **Verification:** `npm run build` passes with no TypeScript errors
+- **Committed in:** f2c0ec4 (Task 1 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 bug — invalid prop for react-chessboard v5 API)
+**Impact on plan:** Fix essential for TypeScript correctness. Functionally identical result (static non-interactive board).
+
+## Issues Encountered
+None.
+
+## User Setup Required
+None — no external service configuration required.
+
+## Next Phase Readiness
+- Frontend redesign complete, awaiting user visual verification (Task 2 checkpoint)
+- Upon approval, plan 37-03 is fully complete and Phase 37 is done
+
+## Self-Check: PASSED
+- `frontend/src/components/stats/MinimapPopover.tsx` — FOUND
+- `frontend/src/components/stats/MostPlayedOpeningsTable.tsx` — FOUND
+- Commit `f2c0ec4` — FOUND (git log confirms)
+
+---
+*Phase: 37-openings-reference-table-redesign*
+*Completed: 2026-03-28*

--- a/.planning/phases/37-openings-reference-table-redesign/37-RESEARCH.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-RESEARCH.md
@@ -1,0 +1,771 @@
+# Phase 37: Openings Reference Table & Most Played Openings Redesign - Research
+
+**Researched:** 2026-03-28
+**Domain:** PostgreSQL seeding + SQLAlchemy model + SQL-side WDL aggregation + React table with popover
+**Confidence:** HIGH
+
+## Summary
+
+Phase 37 has three connected work streams. First, a new `openings` PostgreSQL table is seeded from
+`app/data/openings.tsv` (~3641 rows). Each row stores ECO code, name, PGN, ply count (computed via
+`board.ply()` in python-chess), and FEN (computed via `board.board_fen()`). A deduplicated DB view
+`openings_dedup` collapses the 204 duplicate `(eco, name)` pairs — keeping one representative FEN
+and PGN per pair — for use in JOIN queries against the `games` table.
+
+Second, the `GET /stats/most-played-openings` endpoint (Phase 36, fully implemented) is redesigned.
+It gains filter parameters (recency, time_control, platform, rated, opponent_type), increases the
+result limit from 5 to 10, and moves WDL computation from Python-side aggregation (join + fetch all
+rows) to SQL-side aggregation using `func.count().filter(...)` — a single GROUP BY query per color.
+The response schema gains new fields per opening: `fen` (from `openings_dedup`) and `pgn`.
+
+Third, the Most Played Openings section in `Openings.tsx` is redesigned: the existing `WDLChartRow`
+component is replaced with a dedicated `MostPlayedOpeningsTable` component that renders a
+three-column layout (ECO+name+PGN / game count with folder icon / mini WDL bar). Row hover/tap
+shows a `MinimapPopover` using `Chessboard` from `react-chessboard` with a static position.
+
+**Primary recommendation:** Implement in four distinct waves: (1) DB model + seed script + migration
++ dedup view, (2) redesigned backend endpoint with SQL-side WDL + filter params, (3) updated
+frontend API client + hook + types, (4) new `MostPlayedOpeningsTable` + `MinimapPopover` components
+replacing the old `WDLChartRow` usage in `statisticsContent`.
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| ORT-01 | `openings` table contains all ~3641 rows from TSV with correct `ply_count` and `fen` via python-chess | New `Opening` SQLAlchemy model + Alembic migration + seed script using `chess.pgn.read_game` |
+| ORT-02 | Deduplicated view returns one row per `(eco, name)` pair | `CREATE VIEW openings_dedup AS ... DISTINCT ON (eco, name)` — defined in migration |
+| ORT-03 | Endpoint returns top 10 openings per color with SQL-side WDL stats, filtered by recency/time_control/platform/rated/opponent_type, excluding openings below ply threshold | Updated `query_top_openings_sql_wdl()` in `stats_repository.py` using `func.count().filter()` + JOIN to `openings_dedup` |
+| ORT-04 | Frontend renders dedicated table with ECO/name/PGN, game count link, mini WDL bar | New `MostPlayedOpeningsTable` component — replaces `WDLChartRow` rows in `statisticsContent` |
+| ORT-05 | Hovering/tapping a row shows a minimap popover of the opening position | `MinimapPopover` component wrapping Radix `Popover` + `Chessboard` from `react-chessboard` |
+</phase_requirements>
+
+## Project Constraints (from CLAUDE.md)
+
+- **No magic numbers:** `TOP_OPENINGS_LIMIT = 10`, `MIN_PLY_WHITE = 1`, `MIN_PLY_BLACK = 2`,
+  `MIN_GAMES_FOR_OPENING = 10` must be named constants. Mirror relevant ones in the frontend component.
+- **Theme constants in theme.ts:** Any new color values must go in `theme.ts`. The mini WDL bar
+  reuses existing `WDL_WIN`, `WDL_DRAW`, `WDL_LOSS`, `GLASS_OVERLAY` constants.
+- **Type safety:** New TypeScript interfaces must be explicit. Use `Literal["white", "black"]` in
+  Python function signatures for color parameters.
+- **data-testid on all interactive/layout elements:** Table container, each row, the minimap
+  trigger, and the popover must have `data-testid`.
+- **Always check mobile variants:** `statisticsContent` is referenced in both desktop and mobile
+  `<TabsContent>` blocks in `Openings.tsx`. The variable is shared (defined once) — changes
+  propagate automatically, but verify before shipping.
+- **SQLAlchemy 2.x async:** `select()` API only; no legacy 1.x patterns.
+- **No SQLite:** PostgreSQL only.
+- **Pydantic v2 throughout.**
+- **Foreign key constraints mandatory:** The `openings` table is standalone (no FK to other tables),
+  but must have appropriate indexed columns for JOIN performance.
+- **API responses never expose internal hashes.**
+- **Semantic HTML + ARIA:** Minimap trigger must have `aria-label`. Table rows that are clickable
+  must use semantic elements or role attributes.
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| SQLAlchemy 2.x async | project-wide | New `Opening` model, `openings_dedup` view, updated query | Project ORM |
+| Alembic | project-wide | Migration to create `openings` table + `openings_dedup` view | Project migration tool |
+| python-chess | >=1.10.0 | Compute `ply_count` and `fen` from PGN during seeding | Project chess logic library |
+| FastAPI | 0.115.x | Updated endpoint with new filter params | Project framework |
+| Pydantic v2 | project-wide | Updated response schema with `fen`/`pgn` fields | Project validation |
+| TanStack Query | project-wide | Updated `useMostPlayedOpenings` hook with filter params | Project data fetching |
+| react-chessboard | 5.x | Static board render in minimap popover | Already project dependency |
+| radix-ui Popover | 1.4.3 | Minimap popover trigger/content | Already used via `InfoPopover` |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `func.count().filter()` | SQLAlchemy 2.x | SQL-side WDL aggregation | Replaces Python-side `_aggregate_top_openings` |
+| `DISTINCT ON (eco, name)` | PostgreSQL | Deduplicated view | One row per opening name in JOIN |
+| lucide-react | project-wide | `FolderOpen` or `ExternalLink` icon for games link | Consistent with existing icon usage |
+
+**No new npm packages or Python packages required.** All dependencies are already installed.
+
+## Architecture Patterns
+
+### Backend: New `Opening` SQLAlchemy Model
+
+```python
+# app/models/opening.py — NEW FILE
+from sqlalchemy import Index, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Opening(Base):
+    __tablename__ = "openings"
+    __table_args__ = (
+        UniqueConstraint("eco", "name", "pgn", name="uq_openings_eco_name_pgn"),
+        Index("ix_openings_eco_name", "eco", "name"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    eco: Mapped[str] = mapped_column(String(10), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    pgn: Mapped[str] = mapped_column(Text, nullable=False)
+    ply_count: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    fen: Mapped[str] = mapped_column(String(100), nullable=False)
+```
+
+**Rationale for UniqueConstraint on `(eco, name, pgn)`:** All 3641 rows are kept (including 204
+duplicate `(eco, name)` pairs with different PGN/transpositions). The triple uniqueness constraint
+prevents duplicate inserts during repeated seed runs.
+
+### Backend: Seed Script
+
+```
+scripts/seed_openings.py   — NEW: one-shot idempotent seeding from TSV
+```
+
+The seed script reads `app/data/openings.tsv`, computes `ply_count` and `fen` via python-chess for
+each row, and bulk-inserts with `INSERT INTO openings ... ON CONFLICT DO NOTHING`. This is safe to
+run multiple times.
+
+```python
+# Source: python-chess docs — chess.pgn.read_game, board.board_fen(), board.ply()
+import chess.pgn, io
+
+def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
+    game = chess.pgn.read_game(io.StringIO(pgn_str))
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board.board_fen(), board.ply()
+```
+
+**PGN parse failure handling:** Wrap each row in a try/except. On error, log and skip — don't abort
+the entire seed. The TSV is the lichess openings database (high quality), so failures should be
+rare, but the constraint is documented in CLAUDE.md: "wrap per-game in try/except."
+
+### Backend: Alembic Migration
+
+The migration does two things:
+1. Creates the `openings` table (Alembic autogenerate after adding `Opening` to `alembic/env.py`).
+2. Creates the `openings_dedup` view with a raw SQL `execute()` call.
+
+```python
+# In the migration upgrade():
+op.execute("""
+    CREATE VIEW openings_dedup AS
+    SELECT DISTINCT ON (eco, name)
+        id, eco, name, pgn, ply_count, fen
+    FROM openings
+    ORDER BY eco, name, id
+""")
+```
+
+**DISTINCT ON ordering:** `ORDER BY eco, name, id` picks the lowest `id` (first-inserted row) as
+the representative per `(eco, name)` pair. This is deterministic given a fixed seed order.
+
+```python
+# In the migration downgrade():
+op.execute("DROP VIEW IF EXISTS openings_dedup")
+```
+
+### Backend: SQL-side WDL Aggregation
+
+The redesigned repository function performs a single JOIN+GROUP BY query instead of the current
+subquery + full row fetch approach. This is fundamentally more efficient (no Python iteration over
+individual game rows) and required by ORT-03.
+
+```python
+# Source: SQLAlchemy 2.x docs — func.count().filter() verified above
+from sqlalchemy import func, or_, and_, select
+from app.models.game import Game
+# Note: openings_dedup is a DB view — use text() or reflect with Table()
+
+async def query_top_openings_sql_wdl(
+    session: AsyncSession,
+    user_id: int,
+    color: Literal["white", "black"],
+    min_games: int,
+    limit: int,
+    min_ply: int,
+    recency_cutoff: datetime.datetime | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
+) -> list[tuple]:
+    """Return WDL aggregates per (eco, name) with filter support.
+
+    Joins games to openings_dedup to get fen and pgn.
+    Filters by min_ply from openings_dedup.ply_count.
+    Returns (eco, name, pgn, fen, total, wins, draws, losses) tuples.
+    """
+    white_win = and_(Game.result == "1-0", Game.user_color == "white")
+    black_win = and_(Game.result == "0-1", Game.user_color == "black")
+    win_cond = or_(white_win, black_win)
+    draw_cond = Game.result == "1/2-1/2"
+
+    # openings_dedup as a reflected table (or use text subquery)
+    ...
+```
+
+**Implementation note on `openings_dedup` access:** Since SQLAlchemy ORM models map to tables, not
+views, the `openings_dedup` view must be accessed via `text()`-based subquery or by reflecting it.
+The cleanest approach is to define a `Table()` object for the view:
+
+```python
+from sqlalchemy import Table, Column, String, SmallInteger, MetaData
+_openings_dedup = Table(
+    "openings_dedup",
+    MetaData(),
+    Column("id", primary_key=True),
+    Column("eco", String(10)),
+    Column("name", String(200)),
+    Column("pgn", Text),
+    Column("ply_count", SmallInteger),
+    Column("fen", String(100)),
+)
+```
+
+This avoids ORM mapping complexity while still getting type-checked column access.
+
+### Backend: Updated Response Schema
+
+```python
+# app/schemas/stats.py — updated OpeningWDL
+class OpeningWDL(BaseModel):
+    opening_eco: str
+    opening_name: str
+    label: str          # "Opening Name (ECO)" — precomputed for UI
+    pgn: str            # NEW: PGN move sequence for display
+    fen: str            # NEW: position FEN for minimap popover
+    wins: int
+    draws: int
+    losses: int
+    total: int
+    win_pct: float
+    draw_pct: float
+    loss_pct: float
+```
+
+**Backward compatibility note:** Adding `pgn` and `fen` fields to `OpeningWDL` breaks the existing
+`GET /stats/most-played-openings` response. Since Phase 36 was just implemented and Phase 37
+replaces the endpoint behavior, this is expected — the frontend is also being redesigned.
+
+### Backend: Updated Service + Router
+
+```python
+# stats_service.py — updated constants
+TOP_OPENINGS_LIMIT = 10  # was 5 in Phase 36
+MIN_PLY_WHITE = 1         # NEW: white needs at least 1 ply
+MIN_PLY_BLACK = 2         # NEW: black needs at least 2 plies
+
+# stats_router.py — new filter params
+@router.get("/stats/most-played-openings", response_model=MostPlayedOpeningsResponse)
+async def get_most_played_openings(
+    session: ...,
+    user: ...,
+    recency: str | None = Query(default=None),
+    time_control: list[str] | None = Query(default=None),
+    platform: list[str] | None = Query(default=None),
+    rated: bool | None = Query(default=None),
+    opponent_type: str = Query(default="human"),
+) -> MostPlayedOpeningsResponse:
+    ...
+```
+
+**Color and matchSide are NOT filter params** — the response already splits by color (white/black),
+so no color param is needed. matchSide is for board hash analysis, not this feature.
+
+### Frontend: Updated Hook
+
+```typescript
+// hooks/useStats.ts — updated useMostPlayedOpenings
+export function useMostPlayedOpenings(filters: MostPlayedFilters) {
+  const { recency, timeControls, platforms, rated, opponentType } = filters;
+  const normalizedRecency = recency === 'all' ? null : recency;
+  const platform = ...; // flatten array to string if single
+  return useQuery({
+    queryKey: ['mostPlayedOpenings', normalizedRecency, timeControls, platforms, rated, opponentType],
+    queryFn: () => statsApi.getMostPlayedOpenings({ ... }),
+  });
+}
+```
+
+The hook takes a subset of `FilterState` (not the full board-explorer filter). **Color and
+matchSide are excluded** per the design decision.
+
+### Frontend: New `MostPlayedOpeningsTable` Component
+
+New file: `frontend/src/components/stats/MostPlayedOpeningsTable.tsx`
+
+Three-column table per row:
+- Column 1: ECO code + opening name (break after colon if present in name) + PGN moves on next line(s)
+- Column 2: game count number + `FolderOpen` (or `ExternalLink`) icon as link to `/openings/games`
+- Column 3: mini WDL bar (reuse the WDL bar segment markup from `WDLChartRow`, not the full row component)
+
+**Name formatting:** Split on `: ` and insert a line break if colon is found. Example:
+`"Ruy Lopez: Morphy Defense"` → `Ruy Lopez:` / `Morphy Defense`.
+
+**PGN display:** Render the PGN string as-is below the name in `text-xs text-muted-foreground`.
+Truncate long PGN strings to fit column width on mobile (or wrap naturally).
+
+### Frontend: `MinimapPopover` Component
+
+New file: `frontend/src/components/stats/MinimapPopover.tsx`
+
+Wraps Radix `Popover` from `radix-ui` (same import pattern as `InfoPopover` — `import { Popover as
+PopoverPrimitive } from "radix-ui"`). Trigger is the opening name cell (the row itself acts as
+hover trigger). On hover/tap, renders a static `Chessboard` at a small fixed size (e.g. 180px).
+
+```tsx
+import { Popover as PopoverPrimitive } from "radix-ui";
+import { Chessboard } from "react-chessboard";
+
+// Minimal static board — no drag/drop, no arrows
+<Chessboard
+  id="minimap-board"
+  position={fen}
+  boardWidth={180}
+  arePiecesDraggable={false}
+  customDarkSquareStyle={{ backgroundColor: BOARD_DARK_SQUARE }}
+  customLightSquareStyle={{ backgroundColor: BOARD_LIGHT_SQUARE }}
+/>
+```
+
+**react-chessboard static rendering:** `arePiecesDraggable={false}` and no `onPieceDrop` prop
+disables interaction. `boardWidth` prop sets fixed pixel size.
+
+**Mobile support:** Popover trigger on mobile should open on tap (click), not just hover. Use
+`onClick` toggle for mobile compatibility (same approach as `InfoPopover` which uses `onMouseEnter`
++ `onOpenChange`).
+
+### Recommended Project Structure Changes
+
+```
+app/
+├── models/opening.py               # NEW: Opening SQLAlchemy model
+├── repositories/stats_repository.py # MODIFIED: new query function
+├── services/stats_service.py        # MODIFIED: SQL WDL, new constants, filter params
+├── routers/stats.py                 # MODIFIED: new query params
+└── schemas/stats.py                 # MODIFIED: pgn/fen fields on OpeningWDL
+
+scripts/
+└── seed_openings.py                 # NEW: idempotent seed script
+
+alembic/versions/
+└── XXXXXX_create_openings_table.py  # NEW: table + view + alembic/env.py import
+
+frontend/src/
+├── components/stats/               # NEW directory
+│   ├── MostPlayedOpeningsTable.tsx # NEW: dedicated table component
+│   └── MinimapPopover.tsx          # NEW: hover/tap popover with static board
+├── types/stats.ts                  # MODIFIED: pgn/fen fields on OpeningWDL
+├── api/client.ts                   # MODIFIED: getMostPlayedOpenings with filter params
+├── hooks/useStats.ts               # MODIFIED: useMostPlayedOpenings with filter params
+└── pages/Openings.tsx              # MODIFIED: wire filters, replace WDLChartRow with new table
+```
+
+### Anti-Patterns to Avoid
+
+- **Full-scan seed:** Don't INSERT + DELETE on every restart. Use `ON CONFLICT DO NOTHING` to make
+  seeding idempotent.
+- **ORM model for the view:** Don't map `openings_dedup` as a SQLAlchemy ORM class — it's a view,
+  and autogenerate will try to drop/recreate it. Use `Table()` with `MetaData()` (not
+  `Base.metadata`) so it's invisible to Alembic autogenerate.
+- **Python-side WDL aggregation:** Phase 37 mandates SQL-side aggregation. Do not retain the old
+  `_aggregate_top_openings` path for the new query. Keep the function in case it's used elsewhere
+  but don't call it from the redesigned service function.
+- **Passing color filter to the endpoint:** Color is not a filter here — the response has separate
+  `white` and `black` lists. The `color` filter in `FilterPanel` is for the board hash explorer
+  feature, not for Most Played Openings.
+- **Using `board.fen()` instead of `board.board_fen()`:** CLAUDE.md is explicit: use
+  `board.board_fen()` (piece placement only). `board.fen()` includes castling/en passant which
+  would mismatch existing FEN comparisons in the codebase.
+- **Hard-coding popover width/board size:** Extract `MINIMAP_BOARD_SIZE = 180` as a named constant.
+- **Forgetting `data-testid="chessboard"` and `id="chessboard"` on the minimap board:** CLAUDE.md
+  requires `data-testid="chessboard"`. For the minimap, use a unique id like `"minimap-board"` to
+  avoid conflicting with the main board's `id="chessboard"`.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| WDL bar rendering | Custom bar markup | Reuse WDL bar segment CSS from `WDLChartRow` (extract or copy inline) | Consistent visual output, existing tested pattern |
+| Chess position display | Custom SVG/canvas rendering | `Chessboard` from `react-chessboard` with `arePiecesDraggable={false}` | Already project dependency, handles piece rendering |
+| Popover behavior | Custom CSS hover/focus management | `Popover` from `radix-ui` | Already used in `InfoPopover`, handles Portal, z-index, animation |
+| FEN computation | Manual board state parsing | `chess.pgn.read_game` + `board.board_fen()` | python-chess handles all edge cases (castling, en passant, en passant ignored per CLAUDE.md) |
+| Idempotent seeding | Manual SELECT + conditional INSERT | `INSERT ... ON CONFLICT DO NOTHING` with `UniqueConstraint` | Single-pass, safe for repeated runs |
+
+## Common Pitfalls
+
+### Pitfall 1: Alembic Autogenerate Detecting the View
+
+**What goes wrong:** If `openings_dedup` Table is added to `Base.metadata`, Alembic autogenerate
+will try to CREATE TABLE for the view on every run (or error when it detects a mismatch).
+**Why it happens:** Alembic treats any table in `Base.metadata` as a managed table.
+**How to avoid:** Define the `_openings_dedup` Table with a standalone `MetaData()` instance, NOT
+`Base.metadata`. The view DDL goes in a handwritten `op.execute()` in the migration.
+**Warning signs:** `alembic revision --autogenerate` adds unexpected CREATE TABLE statements.
+
+### Pitfall 2: `board.fen()` vs `board.board_fen()`
+
+**What goes wrong:** The FEN stored in `openings.fen` includes castling rights and en passant
+targets if `board.fen()` is used. The FEN is only used for minimap display in Phase 37, so this
+won't cause position-matching bugs today — but storing the wrong FEN format is inconsistent with
+the codebase convention and would cause issues if the column is ever used for matching.
+**Why it happens:** Confusion between the two python-chess methods.
+**How to avoid:** Always use `board.board_fen()` per CLAUDE.md. Document in the seed script.
+
+### Pitfall 3: DISTINCT ON Ordering in `openings_dedup`
+
+**What goes wrong:** Without an explicit `ORDER BY eco, name, id`, PostgreSQL's `DISTINCT ON`
+behavior is non-deterministic (it picks an arbitrary row per group on repeated runs).
+**Why it happens:** `DISTINCT ON (cols)` requires the first `ORDER BY` columns to match the
+DISTINCT columns.
+**How to avoid:** Always `ORDER BY eco, name, id` in the view definition.
+
+### Pitfall 4: NULL opening_eco / opening_name in Games Join
+
+**What goes wrong:** Games with NULL `opening_eco` or `opening_name` cannot join to
+`openings_dedup`. If not filtered, they produce NULL values in the result set.
+**Why it happens:** `Game.opening_eco` and `Game.opening_name` are nullable (CLAUDE.md note about
+NULL columns was documented in Phase 36 research).
+**How to avoid:** Add `.where(Game.opening_eco.is_not(None), Game.opening_name.is_not(None))` to
+the updated repository query.
+
+### Pitfall 5: `func.count().filter()` Precedence
+
+**What goes wrong:** `func.count().filter(A & B | C)` may not parse as intended due to Python
+operator precedence — `&` binds tighter than `|`, but wrapping with `and_()` / `or_()` is clearer.
+**Why it happens:** SQLAlchemy's column operators `&`, `|`, `~` have precedence issues.
+**How to avoid:** Always use explicit `and_()` / `or_()` imports from `sqlalchemy` for compound
+conditions. Verified pattern in Pitfall verification above:
+```python
+win_cond = or_(
+    and_(Game.result == "1-0", Game.user_color == "white"),
+    and_(Game.result == "0-1", Game.user_color == "black"),
+)
+wins_col = func.count().filter(win_cond).label("wins")
+```
+
+### Pitfall 6: Seed Script Import Path
+
+**What goes wrong:** `scripts/seed_openings.py` imports from `app.*` but the `scripts/` package
+must be importable. Phase 27 added `scripts/__init__.py` for this purpose.
+**Why it happens:** Python package resolution when running scripts from the repo root.
+**How to avoid:** Verify `scripts/__init__.py` exists (it does — added in Phase 27). Run seed
+script with `uv run python -m scripts.seed_openings` to use module mode.
+
+### Pitfall 7: Popover Z-Index / Portal Stacking
+
+**What goes wrong:** The minimap popover appears behind other page elements (sticky filter bar,
+modal dialogs) because the z-index is insufficient.
+**Why it happens:** Radix `PopoverContent` uses z-50 by default, which conflicts with other z-50
+elements.
+**How to avoid:** Use `PopoverPrimitive.Portal` (same as `InfoPopover`) to portal the content to
+`document.body`. This ensures correct stacking context. Use `z-[100]` or similar if conflicts arise.
+
+### Pitfall 8: Mobile Missing Hover Trigger
+
+**What goes wrong:** On mobile/touch devices, `onMouseEnter`/`onMouseLeave` events don't fire.
+The minimap popover never opens.
+**Why it happens:** Touch devices don't have hover. The existing `InfoPopover` handles this via
+`onOpenChange` (which fires on click/tap).
+**How to avoid:** Use `onOpenChange` as the primary toggle, or combine hover + click: set `open`
+state on `onMouseEnter` and toggle on click. The simplest pattern: let Radix manage open state
+via `onOpenChange` (uncontrolled). On mobile, a tap opens the popover; a tap outside closes it.
+For desktop, add `onMouseEnter`/`onMouseLeave` to the trigger for hover behavior.
+
+## Code Examples
+
+### python-chess FEN + ply computation (verified)
+
+```python
+# Source: verified via uv run python3, 2026-03-28
+import chess
+import chess.pgn
+import io
+
+def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
+    """Compute piece-placement FEN and ply count from a PGN move sequence.
+
+    Uses board.board_fen() (not board.fen()) per project convention.
+    """
+    game = chess.pgn.read_game(io.StringIO(pgn_str))
+    if game is None:
+        raise ValueError(f"Failed to parse PGN: {pgn_str!r}")
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board.board_fen(), board.ply()
+```
+
+### SQL-side WDL aggregate (verified SQLAlchemy 2.x)
+
+```python
+# Source: verified via uv run python3 with SQLAlchemy 2.x, 2026-03-28
+from sqlalchemy import and_, func, or_
+
+win_cond = or_(
+    and_(Game.result == "1-0", Game.user_color == "white"),
+    and_(Game.result == "0-1", Game.user_color == "black"),
+)
+draw_cond = Game.result == "1/2-1/2"
+loss_cond = or_(
+    and_(Game.result == "0-1", Game.user_color == "white"),
+    and_(Game.result == "1-0", Game.user_color == "black"),
+)
+
+stmt = (
+    select(
+        Game.opening_eco,
+        Game.opening_name,
+        func.count().label("total"),
+        func.count().filter(win_cond).label("wins"),
+        func.count().filter(draw_cond).label("draws"),
+        func.count().filter(loss_cond).label("losses"),
+    )
+    .where(
+        Game.user_id == user_id,
+        Game.user_color == color,
+        Game.opening_eco.is_not(None),
+        Game.opening_name.is_not(None),
+    )
+    .group_by(Game.opening_eco, Game.opening_name)
+    .having(func.count() >= min_games)
+    .order_by(func.count().desc())
+    .limit(limit)
+)
+# Generates: count(*) FILTER (WHERE result='1-0' AND user_color='white' OR ...)
+```
+
+### Alembic migration for view (pattern)
+
+```python
+# In migration upgrade():
+op.execute("""
+    CREATE VIEW openings_dedup AS
+    SELECT DISTINCT ON (eco, name)
+        id, eco, name, pgn, ply_count, fen
+    FROM openings
+    ORDER BY eco, name, id
+""")
+
+# In migration downgrade():
+op.execute("DROP VIEW IF EXISTS openings_dedup")
+op.drop_table("openings")
+```
+
+### MinimapPopover trigger pattern
+
+```tsx
+// Source: info-popover.tsx pattern adapted for row hover, 2026-03-28
+import { Popover as PopoverPrimitive } from "radix-ui";
+import { Chessboard } from "react-chessboard";
+import { BOARD_DARK_SQUARE, BOARD_LIGHT_SQUARE } from "@/lib/theme";
+
+const MINIMAP_BOARD_SIZE = 180;
+
+export function MinimapPopover({ fen, children, testId }: MinimapPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const hoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = () => {
+    hoverTimeout.current = setTimeout(() => setOpen(true), 150);
+  };
+  const handleMouseLeave = () => {
+    if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+    setOpen(false);
+  };
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <div
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          data-testid={testId}
+        >
+          {children}
+        </div>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="right"
+          sideOffset={8}
+          onMouseEnter={() => { if (hoverTimeout.current) clearTimeout(hoverTimeout.current); }}
+          onMouseLeave={handleMouseLeave}
+          className="z-50 rounded-md shadow-lg overflow-hidden"
+          data-testid={`${testId}-popover`}
+        >
+          <Chessboard
+            id="minimap-board"
+            position={fen}
+            boardWidth={MINIMAP_BOARD_SIZE}
+            arePiecesDraggable={false}
+            customDarkSquareStyle={{ backgroundColor: BOARD_DARK_SQUARE }}
+            customLightSquareStyle={{ backgroundColor: BOARD_LIGHT_SQUARE }}
+          />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}
+```
+
+### `openings_dedup` Table object for non-ORM access
+
+```python
+# In stats_repository.py — table object for view access
+from sqlalchemy import Column, MetaData, SmallInteger, String, Table, Text
+
+_openings_dedup = Table(
+    "openings_dedup",
+    MetaData(),  # NOT Base.metadata — keeps it invisible to Alembic autogenerate
+    Column("id"),
+    Column("eco", String(10)),
+    Column("name", String(200)),
+    Column("pgn", Text),
+    Column("ply_count", SmallInteger),
+    Column("fen", String(100)),
+)
+```
+
+## TSV Dataset Facts (verified)
+
+| Fact | Value | Source |
+|------|-------|--------|
+| Total rows | 3641 | `wc -l openings.tsv` minus header |
+| Unique `(eco, name)` pairs | 3301 | Python analysis |
+| Duplicate `(eco, name)` pairs | 340 (204 unique pairs with 2+ PGNs) | Python analysis |
+| Max PGN ply count | 22 | `1. e4 e5 2. Nf3 Nc6 ... 11. Rxe5 c6` |
+| TSV columns | eco, name, pgn | Header row verified |
+| TSV path | `app/data/openings.tsv` | Direct inspection |
+
+## Filter Parameters: Mapping to Backend
+
+| Frontend FilterState field | Backend param | Included? | Notes |
+|---------------------------|---------------|-----------|-------|
+| `recency` | `recency` | YES | Via `recency_cutoff()` helper |
+| `timeControls` | `time_control` | YES | Array param |
+| `platforms` | `platform` | YES | Array param |
+| `rated` | `rated` | YES | `bool | None` |
+| `opponentType` | `opponent_type` | YES | Default `"human"` |
+| `color` | — | IGNORED | Response already splits by color |
+| `matchSide` | — | IGNORED | Board hash feature only |
+
+## State of the Art
+
+| Old Approach | Current Approach | Impact |
+|--------------|------------------|--------|
+| Python-side WDL aggregation (fetch rows + iterate) | SQL-side `COUNT(*) FILTER (WHERE ...)` | Single DB round-trip, no Python loop over game rows |
+| Top 5 openings, no filters | Top 10 openings, full filter support | More useful, consistent with other stats endpoints |
+| `WDLChartRow` for each opening | Dedicated `MostPlayedOpeningsTable` with ECO/name/PGN columns | Better information density, adds PGN display |
+| No position preview | `MinimapPopover` on hover/tap | Quick position reference without navigating away |
+| No openings DB table (TSV only in memory via trie) | `openings` table + `openings_dedup` view | Enables SQL JOINs for richer aggregation |
+
+## Open Questions
+
+1. **Minimap popover position on mobile**
+   - What we know: On mobile, the popover `side="right"` may go off-screen.
+   - What's unclear: Whether Radix auto-flips the side when space is insufficient.
+   - Recommendation: Use `side="top"` with `align="start"` as fallback, or test on a narrow
+     viewport. Radix's collision detection should handle this automatically via `avoidCollisions`.
+
+2. **Game count link: navigate to games tab or filter by opening?**
+   - What we know: The games tab shows position-filtered games (using hash). The design says
+     "game count link with folder icon to open games" — but no mechanism exists to filter by
+     opening name in the games tab (analysis endpoint uses hash, not eco/name).
+   - What's unclear: Whether "open games" means navigate to `/openings/games` (unfiltered) or
+     provide a filtered view.
+   - Recommendation: For Phase 37, link to `/openings/games` (navigate to games tab) as the
+     simplest correct interpretation. A filtered game list by opening name would require a new
+     backend endpoint. Flag this if the user expects filtered games.
+
+3. **WHERE to wire `useMostPlayedOpenings` filter params in `Openings.tsx`**
+   - What we know: `Openings.tsx` already has `debouncedFilters` (full `FilterState`).
+   - What's unclear: Whether a separate filter state is needed, or whether the existing
+     `debouncedFilters` is passed directly (minus `color` and `matchSide`).
+   - Recommendation: Pass `debouncedFilters` directly, extracting only the relevant fields
+     (recency, timeControls, platforms, rated, opponentType). No separate state needed.
+
+## Environment Availability
+
+Step 2.6: SKIPPED — all dependencies (Python libraries, npm packages, PostgreSQL) are already
+available in the project environment. No new external services or tools are required.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | pytest + pytest-asyncio |
+| Config file | `pyproject.toml` (project root) |
+| Quick run command | `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x` |
+| Full suite command | `uv run pytest` |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| ORT-01 | Seed script inserts ~3641 rows with correct `ply_count` and `fen` | unit | `uv run pytest tests/test_seed_openings.py -x` | ❌ Wave 0 |
+| ORT-01 | Seed script is idempotent (safe to run twice) | unit | `uv run pytest tests/test_seed_openings.py -x -k idempotent` | ❌ Wave 0 |
+| ORT-02 | `openings_dedup` view returns one row per `(eco, name)` | integration | `uv run pytest tests/test_seed_openings.py -x -k dedup_view` | ❌ Wave 0 |
+| ORT-03 | `query_top_openings_sql_wdl` returns top 10 with correct WDL counts | unit | `uv run pytest tests/test_stats_repository.py -x -k sql_wdl` | ❌ Wave 0 |
+| ORT-03 | Filter params (recency/time_control/platform/rated/opponent_type) affect results | unit | `uv run pytest tests/test_stats_repository.py -x -k sql_wdl_filters` | ❌ Wave 0 |
+| ORT-03 | Ply threshold (min_ply) excludes short openings | unit | `uv run pytest tests/test_stats_repository.py -x -k ply_threshold` | ❌ Wave 0 |
+| ORT-03 | `GET /stats/most-played-openings` returns 200 with `pgn` and `fen` fields | integration | `uv run pytest tests/test_stats_router.py -x -k most_played_openings` | ✅ (extend) |
+| ORT-03 | `GET /stats/most-played-openings` accepts filter params | integration | `uv run pytest tests/test_stats_router.py -x -k most_played_openings` | ✅ (extend) |
+
+**Note on ORT-04 and ORT-05:** These are pure frontend requirements. They are validated via visual
+inspection and browser automation testing (data-testid presence), not pytest. Mark as manual-only.
+
+| Req ID | Behavior | Test Type | Notes |
+|--------|----------|-----------|-------|
+| ORT-04 | Table renders ECO/name/PGN, game count link, mini WDL bar | manual + browser | Verify `data-testid="mpo-table"` in DOM |
+| ORT-05 | Hover/tap shows minimap popover with correct position | manual + browser | Verify `data-testid="minimap-popover"` in DOM |
+
+### Sampling Rate
+- **Per task commit:** `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x`
+- **Per wave merge:** `uv run pytest`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+- [ ] `tests/test_seed_openings.py` — new test file covering ORT-01, ORT-02
+- [ ] `tests/test_stats_repository.py` — add `TestQueryTopOpeningsSqlWDL` class for ORT-03 (replace/extend `TestQueryTopOpeningsByColor`)
+- [ ] `tests/test_stats_router.py` — extend `TestGetMostPlayedOpenings` for ORT-03 (new params, `pgn`/`fen` fields)
+
+The existing `TestQueryTopOpeningsByColor` in `test_stats_repository.py` tests the Phase 36 Python-
+aggregation approach. Phase 37 replaces this with SQL-side aggregation — the old tests should be
+updated to the new function signature, not kept alongside.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Direct codebase inspection: `app/data/openings.tsv` — 3641 rows, columns: eco/name/pgn, confirmed
+- Direct codebase inspection: `app/services/opening_lookup.py` — TSV loading pattern confirmed
+- Direct codebase inspection: `app/models/game.py` — `opening_eco` (String(10)), `opening_name` (String(200)) nullable confirmed
+- Direct codebase inspection: `app/repositories/stats_repository.py` — Phase 36 `query_top_openings_by_color` confirmed implemented
+- Direct codebase inspection: `app/services/stats_service.py` — `TOP_OPENINGS_LIMIT = 5`, `_aggregate_top_openings` confirmed
+- Direct codebase inspection: `app/routers/stats.py` — endpoint confirmed with no filter params
+- Direct codebase inspection: `app/repositories/endgame_repository.py` — `_apply_game_filters` filter pattern (time_control/platform/rated/opponent_type) confirmed
+- Direct codebase inspection: `frontend/src/components/ui/info-popover.tsx` — Radix Popover usage pattern confirmed
+- Direct codebase inspection: `frontend/src/components/board/ChessBoard.tsx` — `react-chessboard` import pattern confirmed
+- Direct codebase inspection: `frontend/node_modules/radix-ui/dist/index.d.ts` — `Popover` export from `radix-ui` confirmed
+- Verified: `func.count().filter()` SQLAlchemy 2.x syntax compiles to `COUNT(*) FILTER (WHERE ...)`
+- Verified: `board.board_fen()` + `board.ply()` produce correct output for TSV PGN strings
+
+### Secondary (MEDIUM confidence)
+- `DISTINCT ON` PostgreSQL behavior: deterministic only with explicit `ORDER BY` matching DISTINCT columns (standard PostgreSQL docs behavior)
+- Alembic autogenerate exclusion for views: using standalone `MetaData()` instance is the documented approach to exclude objects from autogenerate
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all libraries already in project, verified imports
+- Architecture: HIGH — patterns directly confirmed from codebase inspection
+- Pitfalls: HIGH — multiple pitfalls verified by direct inspection (NULL columns, board_fen vs fen, alembic view issue)
+- SQL-side WDL: HIGH — `func.count().filter()` syntax verified via SQLAlchemy 2.x compilation
+- Frontend minimap: HIGH — react-chessboard and radix-ui Popover both confirmed available
+
+**Research date:** 2026-03-28
+**Valid until:** 2026-04-28 (stable dependencies, no fast-moving external APIs)

--- a/.planning/phases/37-openings-reference-table-redesign/37-VALIDATION.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-VALIDATION.md
@@ -2,8 +2,8 @@
 phase: 37
 slug: openings-reference-table-redesign
 status: draft
-nyquist_compliant: false
-wave_0_complete: false
+nyquist_compliant: true
+wave_0_complete: true
 created: 2026-03-28
 ---
 
@@ -38,7 +38,7 @@ created: 2026-03-28
 
 | Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
 |---------|------|------|-------------|-----------|-------------------|-------------|--------|
-| 37-01-01 | 01 | 1 | ORT-01, ORT-02 | unit + migration | `uv run pytest tests/test_openings.py -x` | ❌ W0 | ⬜ pending |
+| 37-01-01 | 01 | 1 | ORT-01, ORT-02 | unit + migration | `uv run pytest tests/test_seed_openings.py -x` | ✅ (created by Plan 37-01 Task 2) | ⬜ pending |
 | 37-02-01 | 02 | 2 | ORT-03 | unit + integration | `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x` | ✅ | ⬜ pending |
 | 37-03-01 | 03 | 2 | ORT-04, ORT-05 | build | `cd frontend && npm run build` | ✅ | ⬜ pending |
 
@@ -48,9 +48,7 @@ created: 2026-03-28
 
 ## Wave 0 Requirements
 
-- [ ] `tests/test_openings.py` — stubs for ORT-01, ORT-02 (opening model, seed, dedup view)
-
-*Existing test infrastructure covers ORT-03 through ORT-05.*
+*Existing infrastructure covers all phase requirements. Plan 37-01 Task 2 creates `tests/test_seed_openings.py` for ORT-01/ORT-02. Existing `tests/test_stats_repository.py` and `tests/test_stats_router.py` cover ORT-03.*
 
 ---
 

--- a/.planning/phases/37-openings-reference-table-redesign/37-VALIDATION.md
+++ b/.planning/phases/37-openings-reference-table-redesign/37-VALIDATION.md
@@ -1,0 +1,76 @@
+---
+phase: 37
+slug: openings-reference-table-redesign
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-28
+---
+
+# Phase 37 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | pytest (backend) + vitest (frontend) |
+| **Config file** | pyproject.toml / frontend/vitest.config.ts |
+| **Quick run command** | `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x` |
+| **Full suite command** | `uv run pytest && cd frontend && npm run build` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x`
+- **After every plan wave:** Run `uv run pytest && cd frontend && npm run build`
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 37-01-01 | 01 | 1 | ORT-01, ORT-02 | unit + migration | `uv run pytest tests/test_openings.py -x` | ❌ W0 | ⬜ pending |
+| 37-02-01 | 02 | 2 | ORT-03 | unit + integration | `uv run pytest tests/test_stats_repository.py tests/test_stats_router.py -x` | ✅ | ⬜ pending |
+| 37-03-01 | 03 | 2 | ORT-04, ORT-05 | build | `cd frontend && npm run build` | ✅ | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `tests/test_openings.py` — stubs for ORT-01, ORT-02 (opening model, seed, dedup view)
+
+*Existing test infrastructure covers ORT-03 through ORT-05.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Opening table renders correctly with ECO/name/PGN columns | ORT-04 | Visual layout verification | Navigate to Opening Statistics subtab, verify table structure |
+| Minimap popover shows correct position on hover/tap | ORT-05 | Visual + interaction verification | Hover over a row, verify chessboard shows opening position |
+| Mobile responsive table layout | ORT-04 | Device-specific layout | Test on 375px viewport width |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,6 +14,7 @@ from app.models.game import Game  # noqa: F401
 from app.models.game_position import GamePosition  # noqa: F401
 from app.models.oauth_account import OAuthAccount  # noqa: F401
 from app.models.user import User  # noqa: F401
+from app.models.opening import Opening  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/alembic/versions/20260328_194057_1b941ecba0a6_create_openings_table.py
+++ b/alembic/versions/20260328_194057_1b941ecba0a6_create_openings_table.py
@@ -1,0 +1,47 @@
+"""create openings table
+
+Revision ID: 1b941ecba0a6
+Revises: fb62990270fd
+Create Date: 2026-03-28 19:40:57.321501+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1b941ecba0a6'
+down_revision: Union[str, Sequence[str], None] = 'fb62990270fd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('openings',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('eco', sa.String(length=10), nullable=False),
+    sa.Column('name', sa.String(length=200), nullable=False),
+    sa.Column('pgn', sa.Text(), nullable=False),
+    sa.Column('ply_count', sa.SmallInteger(), nullable=False),
+    sa.Column('fen', sa.String(length=100), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('eco', 'name', 'pgn', name='uq_openings_eco_name_pgn')
+    )
+    op.create_index('ix_openings_eco_name', 'openings', ['eco', 'name'], unique=False)
+    op.execute("""
+        CREATE VIEW openings_dedup AS
+        SELECT DISTINCT ON (eco, name)
+            id, eco, name, pgn, ply_count, fen
+        FROM openings
+        ORDER BY eco, name, id
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP VIEW IF EXISTS openings_dedup")
+    op.drop_index('ix_openings_eco_name', table_name='openings')
+    op.drop_table('openings')

--- a/app/models/opening.py
+++ b/app/models/opening.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Index, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Opening(Base):
+    __tablename__ = "openings"
+    __table_args__ = (
+        UniqueConstraint("eco", "name", "pgn", name="uq_openings_eco_name_pgn"),
+        Index("ix_openings_eco_name", "eco", "name"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    eco: Mapped[str] = mapped_column(String(10), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    pgn: Mapped[str] = mapped_column(Text, nullable=False)
+    ply_count: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    fen: Mapped[str] = mapped_column(String(100), nullable=False)

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -3,10 +3,22 @@
 import datetime
 from typing import Literal
 
-from sqlalchemy import Date, case, cast, func, select
+from sqlalchemy import Column, Date, MetaData, SmallInteger, String, Table, Text, and_, case, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
+
+# Standalone MetaData (not Base.metadata) keeps the view invisible to Alembic autogenerate.
+_openings_dedup = Table(
+    "openings_dedup",
+    MetaData(),
+    Column("id"),
+    Column("eco", String(10)),
+    Column("name", String(200)),
+    Column("pgn", Text),
+    Column("ply_count", SmallInteger),
+    Column("fen", String(100)),
+)
 
 
 async def query_rating_history(
@@ -169,6 +181,101 @@ async def query_top_openings_by_color(
             Game.user_color == color,
         )
     )
+
+    result = await session.execute(stmt)
+    return list(result.fetchall())
+
+
+def _apply_game_filters(
+    stmt,
+    time_control: list[str] | None,
+    platform: list[str] | None,
+    rated: bool | None,
+    opponent_type: str,
+    recency_cutoff: datetime.datetime | None,
+):
+    """Apply standard game filter WHERE clauses to a statement."""
+    if time_control is not None:
+        stmt = stmt.where(Game.time_control_bucket.in_(time_control))
+    if platform is not None:
+        stmt = stmt.where(Game.platform.in_(platform))
+    if rated is not None:
+        stmt = stmt.where(Game.rated == rated)
+    if opponent_type == "human":
+        stmt = stmt.where(Game.is_computer_game == False)  # noqa: E712
+    elif opponent_type == "bot":
+        stmt = stmt.where(Game.is_computer_game == True)  # noqa: E712
+    if recency_cutoff is not None:
+        stmt = stmt.where(Game.played_at >= recency_cutoff)
+    return stmt
+
+
+async def query_top_openings_sql_wdl(
+    session: AsyncSession,
+    user_id: int,
+    color: Literal["white", "black"],
+    min_games: int,
+    limit: int,
+    min_ply: int,
+    recency_cutoff: datetime.datetime | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
+) -> list[tuple]:
+    """Return top openings with SQL-side WDL aggregation.
+
+    JOINs games to openings_dedup to get pgn/fen and filter by min_ply.
+    Returns (eco, name, pgn, fen, total, wins, draws, losses) tuples.
+    Uses func.count().filter() for SQL-side WDL — no Python-side aggregation.
+    """
+    win_cond = or_(
+        and_(Game.result == "1-0", Game.user_color == "white"),
+        and_(Game.result == "0-1", Game.user_color == "black"),
+    )
+    draw_cond = Game.result == "1/2-1/2"
+    loss_cond = or_(
+        and_(Game.result == "0-1", Game.user_color == "white"),
+        and_(Game.result == "1-0", Game.user_color == "black"),
+    )
+
+    stmt = (
+        select(
+            Game.opening_eco,
+            Game.opening_name,
+            _openings_dedup.c.pgn,
+            _openings_dedup.c.fen,
+            func.count().label("total"),
+            func.count().filter(win_cond).label("wins"),
+            func.count().filter(draw_cond).label("draws"),
+            func.count().filter(loss_cond).label("losses"),
+        )
+        .join(
+            _openings_dedup,
+            and_(
+                Game.opening_eco == _openings_dedup.c.eco,
+                Game.opening_name == _openings_dedup.c.name,
+            ),
+        )
+        .where(
+            Game.user_id == user_id,
+            Game.user_color == color,
+            Game.opening_eco.is_not(None),
+            Game.opening_name.is_not(None),
+            _openings_dedup.c.ply_count >= min_ply,
+        )
+        .group_by(
+            Game.opening_eco,
+            Game.opening_name,
+            _openings_dedup.c.pgn,
+            _openings_dedup.c.fen,
+        )
+        .having(func.count() >= min_games)
+        .order_by(func.count().desc())
+        .limit(limit)
+    )
+
+    stmt = _apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff)
 
     result = await session.execute(stmt)
     return list(result.fetchall())

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -68,21 +68,34 @@ async def query_results_by_time_control(
     recency_cutoff: datetime.datetime | None,
     platform: str | None = None,
 ) -> list[tuple]:
-    """Return (time_control_bucket, result, user_color) tuples for all games.
+    """Return (time_control_bucket, total, wins, draws, losses) via SQL aggregation.
 
     Excludes games where time_control_bucket is NULL.
     Optionally filtered by platform (chess.com or lichess).
     """
+    win_cond = or_(
+        and_(Game.result == "1-0", Game.user_color == "white"),
+        and_(Game.result == "0-1", Game.user_color == "black"),
+    )
+    draw_cond = Game.result == "1/2-1/2"
+    loss_cond = or_(
+        and_(Game.result == "0-1", Game.user_color == "white"),
+        and_(Game.result == "1-0", Game.user_color == "black"),
+    )
+
     stmt = (
         select(
             Game.time_control_bucket,
-            Game.result,
-            Game.user_color,
+            func.count().label("total"),
+            func.count().filter(win_cond).label("wins"),
+            func.count().filter(draw_cond).label("draws"),
+            func.count().filter(loss_cond).label("losses"),
         )
         .where(
             Game.user_id == user_id,
             Game.time_control_bucket.is_not(None),
         )
+        .group_by(Game.time_control_bucket)
     )
 
     if recency_cutoff is not None:
@@ -101,20 +114,34 @@ async def query_results_by_color(
     recency_cutoff: datetime.datetime | None,
     platform: str | None = None,
 ) -> list[tuple]:
-    """Return (user_color, result) tuples for all games.
+    """Return (user_color, total, wins, draws, losses) via SQL aggregation.
 
     Excludes games where user_color is NULL.
     Optionally filtered by platform (chess.com or lichess).
     """
+    win_cond = or_(
+        and_(Game.result == "1-0", Game.user_color == "white"),
+        and_(Game.result == "0-1", Game.user_color == "black"),
+    )
+    draw_cond = Game.result == "1/2-1/2"
+    loss_cond = or_(
+        and_(Game.result == "0-1", Game.user_color == "white"),
+        and_(Game.result == "1-0", Game.user_color == "black"),
+    )
+
     stmt = (
         select(
             Game.user_color,
-            Game.result,
+            func.count().label("total"),
+            func.count().filter(win_cond).label("wins"),
+            func.count().filter(draw_cond).label("draws"),
+            func.count().filter(loss_cond).label("losses"),
         )
         .where(
             Game.user_id == user_id,
             Game.user_color.is_not(None),
         )
+        .group_by(Game.user_color)
     )
 
     if recency_cutoff is not None:
@@ -122,65 +149,6 @@ async def query_results_by_color(
 
     if platform is not None:
         stmt = stmt.where(Game.platform == platform)
-
-    result = await session.execute(stmt)
-    return list(result.fetchall())
-
-
-async def query_top_openings_by_color(
-    session: AsyncSession,
-    user_id: int,
-    color: Literal["white", "black"],
-    min_games: int,
-    limit: int,
-) -> list[tuple]:
-    """Return (opening_eco, opening_name, result, user_color) tuples for top openings.
-
-    Finds the top-N (eco, name) pairs by game count among games where the user
-    played the given color, then fetches individual game rows for each of those
-    top openings for Python-side WDL aggregation.
-
-    Excludes games with NULL opening_eco or NULL opening_name.
-    Excludes openings with fewer than min_games games.
-    Returns at most limit distinct openings (by game count descending).
-    """
-    # Subquery: find top-N (eco, name) pairs by game count
-    top_openings_subq = (
-        select(
-            Game.opening_eco.label("eco"),
-            Game.opening_name.label("name"),
-        )
-        .where(
-            Game.user_id == user_id,
-            Game.user_color == color,
-            Game.opening_eco.is_not(None),
-            Game.opening_name.is_not(None),
-        )
-        .group_by(Game.opening_eco, Game.opening_name)
-        .having(func.count() >= min_games)
-        .order_by(func.count().desc())
-        .limit(limit)
-        .subquery()
-    )
-
-    # Main query: fetch individual game rows for the top openings
-    stmt = (
-        select(
-            Game.opening_eco,
-            Game.opening_name,
-            Game.result,
-            Game.user_color,
-        )
-        .join(
-            top_openings_subq,
-            (Game.opening_eco == top_openings_subq.c.eco)
-            & (Game.opening_name == top_openings_subq.c.name),
-        )
-        .where(
-            Game.user_id == user_id,
-            Game.user_color == color,
-        )
-    )
 
     result = await session.execute(stmt)
     return list(result.fetchall())

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -263,6 +263,8 @@ async def query_top_openings_sql_wdl(
             Game.opening_eco.is_not(None),
             Game.opening_name.is_not(None),
             _openings_dedup.c.ply_count >= min_ply,
+            # White openings end on odd ply (white's last move), black on even ply
+            _openings_dedup.c.ply_count % 2 == (1 if color == "white" else 0),
         )
         .group_by(
             Game.opening_eco,

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -48,6 +48,22 @@ async def get_global_stats(
 async def get_most_played_openings(
     session: Annotated[AsyncSession, Depends(get_async_session)],
     user: Annotated[User, Depends(current_active_user)],
+    recency: str | None = Query(default=None),
+    time_control: list[str] | None = Query(default=None),
+    platform: list[str] | None = Query(default=None),
+    rated: bool | None = Query(default=None),
+    opponent_type: str = Query(default="human"),
 ) -> MostPlayedOpeningsResponse:
-    """Return top 5 most played openings per color with WDL stats."""
-    return await stats_service.get_most_played_openings(session, user.id)
+    """Return top 10 most played openings per color with SQL-side WDL stats.
+
+    Optionally filtered by recency, time_control, platform, rated, opponent_type.
+    """
+    return await stats_service.get_most_played_openings(
+        session,
+        user.id,
+        recency=recency,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
+    )

--- a/app/schemas/stats.py
+++ b/app/schemas/stats.py
@@ -39,11 +39,13 @@ class GlobalStatsResponse(BaseModel):
 
 
 class OpeningWDL(BaseModel):
-    """WDL stats for a single opening, with ECO code and display label."""
+    """WDL stats for a single opening, with ECO code, PGN, FEN, and display label."""
 
     opening_eco: str
     opening_name: str
     label: str          # "Opening Name (ECO)" — precomputed for UI
+    pgn: str            # PGN move sequence for display
+    fen: str            # Piece-placement FEN for minimap popover
     wins: int
     draws: int
     losses: int

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -9,6 +9,7 @@ from app.repositories.stats_repository import (
     query_results_by_color,
     query_results_by_time_control,
     query_top_openings_by_color,
+    query_top_openings_sql_wdl,
 )
 from app.schemas.stats import (
     GlobalStatsResponse,
@@ -24,7 +25,11 @@ from app.services.analysis_service import derive_user_result, recency_cutoff
 MIN_GAMES_FOR_OPENING = 10
 
 # Maximum number of top openings to return per color.
-TOP_OPENINGS_LIMIT = 5
+TOP_OPENINGS_LIMIT = 10
+
+# Minimum ply count for an opening to be included: white needs 1 ply, black needs 2.
+MIN_PLY_WHITE = 1
+MIN_PLY_BLACK = 2
 
 # Ordered time control buckets for consistent output ordering.
 _TIME_CONTROL_ORDER = ["bullet", "blitz", "rapid", "classical"]
@@ -236,30 +241,74 @@ def _aggregate_top_openings(rows: list[tuple]) -> list[OpeningWDL]:
 async def get_most_played_openings(
     session: AsyncSession,
     user_id: int,
+    recency: str | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
 ) -> MostPlayedOpeningsResponse:
-    """Return top 5 most played openings per color (white/black) with WDL stats.
+    """Return top 10 most played openings per color with SQL-side WDL stats.
 
-    Calls query_top_openings_by_color for each color, aggregates individual game
-    rows into OpeningWDL objects, and returns a MostPlayedOpeningsResponse.
-
-    Openings with fewer than MIN_GAMES_FOR_OPENING games are excluded.
+    JOINs to openings_dedup for pgn/fen. Filters by recency, time_control,
+    platform, rated, and opponent_type. Excludes openings below ply threshold.
     """
-    white_rows = await query_top_openings_by_color(
+    cutoff = recency_cutoff(recency)
+
+    white_rows = await query_top_openings_sql_wdl(
         session,
         user_id=user_id,
         color="white",
         min_games=MIN_GAMES_FOR_OPENING,
         limit=TOP_OPENINGS_LIMIT,
+        min_ply=MIN_PLY_WHITE,
+        recency_cutoff=cutoff,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
     )
-    black_rows = await query_top_openings_by_color(
+    black_rows = await query_top_openings_sql_wdl(
         session,
         user_id=user_id,
         color="black",
         min_games=MIN_GAMES_FOR_OPENING,
         limit=TOP_OPENINGS_LIMIT,
+        min_ply=MIN_PLY_BLACK,
+        recency_cutoff=cutoff,
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
     )
 
+    def rows_to_openings(rows: list[tuple]) -> list[OpeningWDL]:
+        openings = []
+        for eco, name, pgn, fen, total, wins, draws, losses in rows:
+            if total > 0:
+                win_pct = round(wins / total * 100, 1)
+                draw_pct = round(draws / total * 100, 1)
+                loss_pct = round(losses / total * 100, 1)
+            else:
+                win_pct = draw_pct = loss_pct = 0.0
+            openings.append(
+                OpeningWDL(
+                    opening_eco=eco,
+                    opening_name=name,
+                    label=f"{name} ({eco})",
+                    pgn=pgn,
+                    fen=fen,
+                    wins=wins,
+                    draws=draws,
+                    losses=losses,
+                    total=total,
+                    win_pct=win_pct,
+                    draw_pct=draw_pct,
+                    loss_pct=loss_pct,
+                )
+            )
+        return openings
+
     return MostPlayedOpeningsResponse(
-        white=_aggregate_top_openings(white_rows),
-        black=_aggregate_top_openings(black_rows),
+        white=rows_to_openings(white_rows),
+        black=rows_to_openings(black_rows),
     )

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,14 +1,11 @@
 """Stats service: aggregation logic for rating history and global stats."""
 
-from collections import defaultdict
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
     query_rating_history,
     query_results_by_color,
     query_results_by_time_control,
-    query_top_openings_by_color,
     query_top_openings_sql_wdl,
 )
 from app.schemas.stats import (
@@ -19,7 +16,7 @@ from app.schemas.stats import (
     RatingHistoryResponse,
     WDLByCategory,
 )
-from app.services.analysis_service import derive_user_result, recency_cutoff
+from app.services.analysis_service import recency_cutoff
 
 # Minimum number of games required for an opening to appear in top openings.
 MIN_GAMES_FOR_OPENING = 10
@@ -36,9 +33,6 @@ _TIME_CONTROL_ORDER = ["bullet", "blitz", "rapid", "classical"]
 
 # Color ordering for consistent output.
 _COLOR_ORDER = ["white", "black"]
-
-# Maps derive_user_result() return values to WDL dict keys.
-_OUTCOME_KEY_MAP = {"win": "wins", "draw": "draws", "loss": "losses"}
 
 
 async def get_rating_history(
@@ -96,35 +90,22 @@ async def get_rating_history(
     )
 
 
-def _aggregate_wdl(
-    rows: list,
+def _rows_to_wdl_categories(
+    rows: list[tuple],
     label_fn,
     label_order: list[str],
 ) -> list[WDLByCategory]:
-    """Aggregate (label_key, result, user_color) rows into WDLByCategory list.
+    """Convert SQL-aggregated (label_key, total, wins, draws, losses) rows to WDLByCategory list.
 
-    Args:
-        rows: Iterable of (label_key, result, user_color) tuples.
-        label_fn: Callable from label_key to display label string.
-        label_order: Ordered list of label keys for output ordering.
+    Rows are already aggregated by the database — no Python-side counting needed.
     """
-    counts: dict[str, dict[str, int]] = defaultdict(
-        lambda: {"wins": 0, "draws": 0, "losses": 0}
-    )
-
-    for label_key, result, user_color in rows:
-        outcome = derive_user_result(result, user_color)
-        counts[label_key][_OUTCOME_KEY_MAP[outcome]] += 1
+    row_map = {row[0]: row for row in rows}
 
     categories = []
     for key in label_order:
-        if key not in counts:
+        if key not in row_map:
             continue
-        c = counts[key]
-        wins = c["wins"]
-        draws = c["draws"]
-        losses = c["losses"]
-        total = wins + draws + losses
+        _, total, wins, draws, losses = row_map[key]
         if total > 0:
             win_pct = round(wins / total * 100, 1)
             draw_pct = round(draws / total * 100, 1)
@@ -156,11 +137,7 @@ async def get_global_stats(
 ) -> GlobalStatsResponse:
     """Return global W/D/L breakdowns by time control and by color.
 
-    Calls recency_cutoff() to resolve the optional recency filter, queries
-    results by time control and by color, aggregates using derive_user_result(),
-    and returns a GlobalStatsResponse.
-
-    When platform is provided, only games from that platform are included.
+    Both queries return SQL-aggregated (label, total, wins, draws, losses) rows.
     """
     cutoff = recency_cutoff(recency)
 
@@ -171,15 +148,14 @@ async def get_global_stats(
         session, user_id=user_id, recency_cutoff=cutoff, platform=platform
     )
 
-    by_time_control = _aggregate_wdl(
+    by_time_control = _rows_to_wdl_categories(
         rows=tc_rows,
         label_fn=lambda key: key.title(),
         label_order=_TIME_CONTROL_ORDER,
     )
 
-    # color_rows are (user_color, result) — map to (label_key, result, user_color)
-    by_color = _aggregate_wdl(
-        rows=[(user_color, result, user_color) for user_color, result in color_rows],
+    by_color = _rows_to_wdl_categories(
+        rows=color_rows,
         label_fn=lambda key: key.title(),
         label_order=_COLOR_ORDER,
     )
@@ -188,54 +164,6 @@ async def get_global_stats(
         by_time_control=by_time_control,
         by_color=by_color,
     )
-
-
-def _aggregate_top_openings(rows: list[tuple]) -> list[OpeningWDL]:
-    """Aggregate (opening_eco, opening_name, result, user_color) rows into OpeningWDL list.
-
-    Groups rows by (opening_eco, opening_name), counts wins/draws/losses,
-    computes percentages, sets display label, and sorts by total descending.
-    """
-    counts: dict[tuple[str, str], dict[str, int]] = defaultdict(
-        lambda: {"wins": 0, "draws": 0, "losses": 0}
-    )
-
-    for opening_eco, opening_name, result, user_color in rows:
-        key = (opening_eco, opening_name)
-        outcome = derive_user_result(result, user_color)
-        counts[key][_OUTCOME_KEY_MAP[outcome]] += 1
-
-    openings = []
-    for (opening_eco, opening_name), c in counts.items():
-        wins = c["wins"]
-        draws = c["draws"]
-        losses = c["losses"]
-        total = wins + draws + losses
-        if total > 0:
-            win_pct = round(wins / total * 100, 1)
-            draw_pct = round(draws / total * 100, 1)
-            loss_pct = round(losses / total * 100, 1)
-        else:
-            win_pct = draw_pct = loss_pct = 0.0
-
-        openings.append(
-            OpeningWDL(
-                opening_eco=opening_eco,
-                opening_name=opening_name,
-                label=f"{opening_name} ({opening_eco})",
-                wins=wins,
-                draws=draws,
-                losses=losses,
-                total=total,
-                win_pct=win_pct,
-                draw_pct=draw_pct,
-                loss_pct=loss_pct,
-            )
-        )
-
-    # Sort by total descending (preserves top-N ordering from the repository query)
-    openings.sort(key=lambda o: o.total, reverse=True)
-    return openings
 
 
 async def get_most_played_openings(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,9 +98,22 @@ export const statsApi = {
     apiClient.get<GlobalStatsResponse>('/stats/global', {
       params: { ...(recency ? { recency } : {}), ...(platform ? { platform } : {}) },
     }).then(r => r.data),
-  getMostPlayedOpenings: () =>
-    apiClient.get<MostPlayedOpeningsResponse>('/stats/most-played-openings')
-      .then(r => r.data),
+  getMostPlayedOpenings: (params?: {
+    recency?: string | null;
+    time_control?: string[] | null;
+    platform?: string[] | null;
+    rated?: boolean | null;
+    opponent_type?: string;
+  }) =>
+    apiClient.get<MostPlayedOpeningsResponse>('/stats/most-played-openings', {
+      params: {
+        ...(params?.recency ? { recency: params.recency } : {}),
+        ...(params?.time_control ? { time_control: params.time_control } : {}),
+        ...(params?.platform ? { platform: params.platform } : {}),
+        ...(params?.rated !== undefined && params?.rated !== null ? { rated: params.rated } : {}),
+        ...(params?.opponent_type && params.opponent_type !== 'all' ? { opponent_type: params.opponent_type } : {}),
+      },
+    }).then(r => r.data),
 };
 
 // ─── Endgame Analytics API ────────────────────────────────────────────────────

--- a/frontend/src/components/charts/WDLChartRow.tsx
+++ b/frontend/src/components/charts/WDLChartRow.tsx
@@ -12,6 +12,9 @@ import {
 } from '@/lib/theme';
 import type { WDLRowData } from '@/types/charts';
 
+// Minimum percentage for a segment to show its inline label
+const MIN_PCT_FOR_LABEL = 15;
+
 interface WDLChartRowProps {
   /** WDL statistics data */
   data: WDLRowData;
@@ -109,28 +112,46 @@ export function WDLChartRow({
         </div>
       )}
 
-      {/* Stacked WDL bar with glass overlay — dimmed for low sample size */}
+      {/* Stacked WDL bar with glass overlay and inline labels — dimmed for low sample size */}
       <div
         className={cn('flex w-full overflow-hidden rounded mb-0', barHeight)}
         style={dimStyle}
       >
         {data.win_pct > 0 && (
           <div
-            className="transition-all"
+            className="relative flex items-center justify-center text-xs font-medium transition-all"
             style={{ width: `${data.win_pct}%`, backgroundColor: WDL_WIN, backgroundImage: GLASS_OVERLAY }}
-          />
+          >
+            {data.win_pct >= MIN_PCT_FOR_LABEL && (
+              <span className="relative z-10 text-white drop-shadow-sm">
+                {Math.round(data.win_pct)}% ({data.wins})
+              </span>
+            )}
+          </div>
         )}
         {data.draw_pct > 0 && (
           <div
-            className="transition-all"
+            className="relative flex items-center justify-center text-xs font-medium transition-all"
             style={{ width: `${data.draw_pct}%`, backgroundColor: WDL_DRAW, backgroundImage: GLASS_OVERLAY }}
-          />
+          >
+            {data.draw_pct >= MIN_PCT_FOR_LABEL && (
+              <span className="relative z-10 text-white drop-shadow-sm">
+                {Math.round(data.draw_pct)}% ({data.draws})
+              </span>
+            )}
+          </div>
         )}
         {data.loss_pct > 0 && (
           <div
-            className="transition-all"
+            className="relative flex items-center justify-center text-xs font-medium transition-all"
             style={{ width: `${data.loss_pct}%`, backgroundColor: WDL_LOSS, backgroundImage: GLASS_OVERLAY }}
-          />
+          >
+            {data.loss_pct >= MIN_PCT_FOR_LABEL && (
+              <span className="relative z-10 text-white drop-shadow-sm">
+                {Math.round(data.loss_pct)}% ({data.losses})
+              </span>
+            )}
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/charts/WDLChartRow.tsx
+++ b/frontend/src/components/charts/WDLChartRow.tsx
@@ -168,13 +168,6 @@ export function WDLChartRow({
           />
         </div>
       )}
-
-      {/* WDL legend text row — dimmed for low sample size */}
-      <div className="flex justify-center gap-3 text-sm" style={dimStyle}>
-        <span style={{ color: WDL_WIN }}>W: {data.wins} ({Math.round(data.win_pct)}%)</span>
-        <span style={{ color: WDL_DRAW }}>D: {data.draws} ({Math.round(data.draw_pct)}%)</span>
-        <span style={{ color: WDL_LOSS }}>L: {data.losses} ({Math.round(data.loss_pct)}%)</span>
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/move-explorer/MoveExplorer.tsx
+++ b/frontend/src/components/move-explorer/MoveExplorer.tsx
@@ -172,7 +172,7 @@ function MoveRow({ entry, selectedMove, onRowClick, onRowKeyDown, onMoveHover }:
       </td>
       <td className="py-1 pl-2">
         {!hasWdl ? (
-          <div className="flex h-4 w-full overflow-hidden rounded-sm bg-muted" />
+          <div className="flex h-5 w-full overflow-hidden rounded-sm bg-muted" />
         ) : (
           <MiniWDLBar win_pct={entry.win_pct} draw_pct={entry.draw_pct} loss_pct={entry.loss_pct} />
         )}

--- a/frontend/src/components/move-explorer/MoveExplorer.tsx
+++ b/frontend/src/components/move-explorer/MoveExplorer.tsx
@@ -2,7 +2,8 @@ import { useState, useMemo, useRef } from 'react';
 import { Chess } from 'chess.js';
 import { ArrowLeftRight } from 'lucide-react';
 import { Popover as PopoverPrimitive } from 'radix-ui';
-import { WDL_WIN, WDL_DRAW, WDL_LOSS, MIN_GAMES_FOR_RELIABLE_STATS, UNRELIABLE_OPACITY } from '@/lib/theme';
+import { MIN_GAMES_FOR_RELIABLE_STATS, UNRELIABLE_OPACITY } from '@/lib/theme';
+import { MiniWDLBar } from '@/components/stats/MiniWDLBar';
 import { InfoPopover } from '@/components/ui/info-popover';
 import { cn } from '@/lib/utils';
 import type { NextMoveEntry } from '@/types/api';
@@ -128,7 +129,7 @@ export function MoveExplorer({ moves, isLoading, isError, position, onMoveClick,
   );
 }
 
-/** Move row with WDL popover on row hover */
+/** Move row with inline MiniWDLBar showing percentages */
 function MoveRow({ entry, selectedMove, onRowClick, onRowKeyDown, onMoveHover }: {
   entry: NextMoveEntry;
   selectedMove: string | null;
@@ -136,86 +137,47 @@ function MoveRow({ entry, selectedMove, onRowClick, onRowKeyDown, onMoveHover }:
   onRowKeyDown: (e: React.KeyboardEvent, entry: NextMoveEntry) => void;
   onMoveHover?: (moveSan: string | null) => void;
 }) {
-  const [open, setOpen] = useState(false);
-  const hoverTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasWdl = entry.win_pct > 0 || entry.draw_pct > 0 || entry.loss_pct > 0;
   const isBelowThreshold = entry.game_count < MIN_GAMES_FOR_RELIABLE_STATS;
 
-  const handleMouseEnter = () => {
-    onMoveHover?.(entry.move_san);
-    if (hasWdl) {
-      hoverTimeout.current = setTimeout(() => setOpen(true), 100);
-    }
-  };
-
-  const handleMouseLeave = () => {
-    onMoveHover?.(null);
-    if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
-    setOpen(false);
-  };
-
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-      <PopoverPrimitive.Trigger asChild>
-        <tr
-          data-testid={`move-explorer-row-${entry.move_san}`}
-          className={cn(
-            'cursor-pointer hover:bg-accent min-h-[44px]',
-            selectedMove === entry.move_san && 'bg-accent',
-          )}
-          style={isBelowThreshold ? { opacity: UNRELIABLE_OPACITY } : undefined}
-          role="button"
-          tabIndex={0}
-          onClick={() => onRowClick(entry)}
-          onKeyDown={(e) => onRowKeyDown(e, entry)}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          <td className="py-1 text-sm text-foreground font-normal truncate">
-            {entry.move_san}
-          </td>
-          <td className="py-1 text-right tabular-nums">
-            <span className="inline-flex items-center justify-end gap-0.5">
-              {entry.transposition_count > entry.game_count && (
-                <TranspositionInfo
-                  moveSan={entry.move_san}
-                  transpositionCount={entry.transposition_count}
-                  gameCount={entry.game_count}
-                />
-              )}
-              {entry.game_count}
-            </span>
-          </td>
-          <td className="py-1 pl-2">
-            {!hasWdl ? (
-              <div className="flex h-3 w-full overflow-hidden rounded bg-muted" />
-            ) : (
-              <div className="flex h-3 w-full overflow-hidden rounded">
-                {entry.win_pct > 0 && <div style={{ width: `${entry.win_pct}%`, backgroundColor: WDL_WIN }} />}
-                {entry.draw_pct > 0 && <div style={{ width: `${entry.draw_pct}%`, backgroundColor: WDL_DRAW }} />}
-                {entry.loss_pct > 0 && <div style={{ width: `${entry.loss_pct}%`, backgroundColor: WDL_LOSS }} />}
-              </div>
-            )}
-          </td>
-        </tr>
-      </PopoverPrimitive.Trigger>
-      {hasWdl && (
-        <PopoverPrimitive.Portal>
-          <PopoverPrimitive.Content
-            side="top"
-            sideOffset={4}
-            className={cn(
-              'z-50 max-w-xs rounded-md border-0 outline-none bg-foreground px-3 py-1.5 text-xs text-background pointer-events-none',
-              'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
-              'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
-              'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',
-            )}
-          >
-            W: {entry.win_pct.toFixed(0)}% · D: {entry.draw_pct.toFixed(0)}% · L: {entry.loss_pct.toFixed(0)}%
-          </PopoverPrimitive.Content>
-        </PopoverPrimitive.Portal>
+    <tr
+      data-testid={`move-explorer-row-${entry.move_san}`}
+      className={cn(
+        'cursor-pointer hover:bg-accent min-h-[44px]',
+        selectedMove === entry.move_san && 'bg-accent',
       )}
-    </PopoverPrimitive.Root>
+      style={isBelowThreshold ? { opacity: UNRELIABLE_OPACITY } : undefined}
+      role="button"
+      tabIndex={0}
+      onClick={() => onRowClick(entry)}
+      onKeyDown={(e) => onRowKeyDown(e, entry)}
+      onMouseEnter={() => onMoveHover?.(entry.move_san)}
+      onMouseLeave={() => onMoveHover?.(null)}
+    >
+      <td className="py-1 text-sm text-foreground font-normal truncate">
+        {entry.move_san}
+      </td>
+      <td className="py-1 text-right tabular-nums">
+        <span className="inline-flex items-center justify-end gap-0.5">
+          {entry.transposition_count > entry.game_count && (
+            <TranspositionInfo
+              moveSan={entry.move_san}
+              transpositionCount={entry.transposition_count}
+              gameCount={entry.game_count}
+            />
+          )}
+          {entry.game_count}
+        </span>
+      </td>
+      <td className="py-1 pl-2">
+        {!hasWdl ? (
+          <div className="flex h-4 w-full overflow-hidden rounded-sm bg-muted" />
+        ) : (
+          <MiniWDLBar win_pct={entry.win_pct} draw_pct={entry.draw_pct} loss_pct={entry.loss_pct} />
+        )}
+      </td>
+    </tr>
   );
 }
 

--- a/frontend/src/components/stats/MiniWDLBar.tsx
+++ b/frontend/src/components/stats/MiniWDLBar.tsx
@@ -7,16 +7,16 @@ interface MiniWDLBarProps {
   win_pct: number;
   draw_pct: number;
   loss_pct: number;
-  /** Bar height class, default "h-4" */
+  /** Bar height class, default "h-5" */
   heightClass?: string;
 }
 
-export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-4" }: MiniWDLBarProps) {
+export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-5" }: MiniWDLBarProps) {
   return (
     <div className={`flex ${heightClass} w-full min-w-[80px] overflow-hidden rounded-sm`} data-testid="mini-wdl-bar">
       {win_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
+          className="relative flex items-center justify-center text-[11px] font-medium"
           style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
@@ -27,7 +27,7 @@ export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-4" }:
       )}
       {draw_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
+          className="relative flex items-center justify-center text-[11px] font-medium"
           style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
@@ -38,7 +38,7 @@ export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-4" }:
       )}
       {loss_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
+          className="relative flex items-center justify-center text-[11px] font-medium"
           style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />

--- a/frontend/src/components/stats/MiniWDLBar.tsx
+++ b/frontend/src/components/stats/MiniWDLBar.tsx
@@ -1,0 +1,52 @@
+import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
+
+// Minimum percentage to show label text inside a WDL bar segment
+const MIN_PCT_FOR_LABEL = 15;
+
+interface MiniWDLBarProps {
+  win_pct: number;
+  draw_pct: number;
+  loss_pct: number;
+  /** Bar height class, default "h-4" */
+  heightClass?: string;
+}
+
+export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-4" }: MiniWDLBarProps) {
+  return (
+    <div className={`flex ${heightClass} w-full min-w-[80px] overflow-hidden rounded-sm`} data-testid="mini-wdl-bar">
+      {win_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {win_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(win_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {draw_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {draw_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(draw_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {loss_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {loss_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(loss_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/stats/MinimapPopover.tsx
+++ b/frontend/src/components/stats/MinimapPopover.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Popover as PopoverPrimitive } from "radix-ui"
+import { createPortal } from "react-dom"
 import { Chessboard } from "react-chessboard"
 import { BOARD_DARK_SQUARE, BOARD_LIGHT_SQUARE } from "@/lib/theme"
 
@@ -12,41 +12,78 @@ interface MinimapPopoverProps {
   testId: string;
 }
 
+/**
+ * Minimap that follows the mouse cursor (top-left corner anchored to pointer).
+ * On touch devices, opens on tap and closes on tap-outside.
+ */
 function MinimapPopover({ fen, boardOrientation = "white", children, testId }: MinimapPopoverProps) {
-  const [open, setOpen] = React.useState(false);
+  const [visible, setVisible] = React.useState(false);
+  const [pos, setPos] = React.useState({ x: 0, y: 0 });
   const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerRef = React.useRef<HTMLDivElement>(null);
 
-  const handleMouseEnter = () => {
-    hoverTimeout.current = setTimeout(() => setOpen(true), 150);
+  const handleMouseMove = (e: React.MouseEvent) => {
+    setPos({ x: e.clientX + 12, y: e.clientY + 12 });
+  };
+
+  const handleMouseEnter = (e: React.MouseEvent) => {
+    setPos({ x: e.clientX + 12, y: e.clientY + 12 });
+    hoverTimeout.current = setTimeout(() => setVisible(true), 150);
   };
 
   const handleMouseLeave = () => {
     if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
-    setOpen(false);
+    setVisible(false);
   };
 
+  // Touch: tap to toggle
+  const handleClick = (e: React.MouseEvent) => {
+    if ('ontouchstart' in window) {
+      e.preventDefault();
+      // Position near the trigger element for touch
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) {
+        setPos({ x: rect.right + 8, y: rect.top });
+      }
+      setVisible(v => !v);
+    }
+  };
+
+  // Close on outside tap (touch)
+  React.useEffect(() => {
+    if (!visible || !('ontouchstart' in window)) return;
+    const handleTouch = (e: TouchEvent) => {
+      if (triggerRef.current && !triggerRef.current.contains(e.target as Node)) {
+        setVisible(false);
+      }
+    };
+    document.addEventListener('touchstart', handleTouch);
+    return () => document.removeEventListener('touchstart', handleTouch);
+  }, [visible]);
+
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
-      <PopoverPrimitive.Trigger asChild>
+    <>
+      <div
+        ref={triggerRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onMouseMove={handleMouseMove}
+        onClick={handleClick}
+        data-testid={testId}
+        className="cursor-pointer"
+      >
+        {children}
+      </div>
+      {visible && createPortal(
         <div
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          data-testid={testId}
-          className="cursor-pointer"
-        >
-          {children}
-        </div>
-      </PopoverPrimitive.Trigger>
-      <PopoverPrimitive.Portal>
-        <PopoverPrimitive.Content
-          side="right"
-          sideOffset={8}
-          avoidCollisions
-          onMouseEnter={() => {
-            if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+          style={{
+            position: 'fixed',
+            left: pos.x,
+            top: pos.y,
+            zIndex: 100,
+            pointerEvents: 'none',
           }}
-          onMouseLeave={handleMouseLeave}
-          className="z-[100] rounded-md shadow-lg overflow-hidden"
+          className="rounded-md shadow-lg overflow-hidden"
           data-testid={`${testId}-popover`}
         >
           <Chessboard
@@ -62,9 +99,10 @@ function MinimapPopover({ fen, boardOrientation = "white", children, testId }: M
               lightSquareStyle: { backgroundColor: BOARD_LIGHT_SQUARE },
             }}
           />
-        </PopoverPrimitive.Content>
-      </PopoverPrimitive.Portal>
-    </PopoverPrimitive.Root>
+        </div>,
+        document.body
+      )}
+    </>
   );
 }
 

--- a/frontend/src/components/stats/MinimapPopover.tsx
+++ b/frontend/src/components/stats/MinimapPopover.tsx
@@ -7,11 +7,12 @@ const MINIMAP_BOARD_SIZE = 180;
 
 interface MinimapPopoverProps {
   fen: string;
+  boardOrientation?: "white" | "black";
   children: React.ReactNode;
   testId: string;
 }
 
-function MinimapPopover({ fen, children, testId }: MinimapPopoverProps) {
+function MinimapPopover({ fen, boardOrientation = "white", children, testId }: MinimapPopoverProps) {
   const [open, setOpen] = React.useState(false);
   const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -52,6 +53,7 @@ function MinimapPopover({ fen, children, testId }: MinimapPopoverProps) {
             options={{
               id: "minimap-board",
               position: fen,
+              boardOrientation,
               boardStyle: {
                 width: MINIMAP_BOARD_SIZE,
                 height: MINIMAP_BOARD_SIZE,

--- a/frontend/src/components/stats/MinimapPopover.tsx
+++ b/frontend/src/components/stats/MinimapPopover.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+import { Chessboard } from "react-chessboard"
+import { BOARD_DARK_SQUARE, BOARD_LIGHT_SQUARE } from "@/lib/theme"
+
+const MINIMAP_BOARD_SIZE = 180;
+
+interface MinimapPopoverProps {
+  fen: string;
+  children: React.ReactNode;
+  testId: string;
+}
+
+function MinimapPopover({ fen, children, testId }: MinimapPopoverProps) {
+  const [open, setOpen] = React.useState(false);
+  const hoverTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = () => {
+    hoverTimeout.current = setTimeout(() => setOpen(true), 150);
+  };
+
+  const handleMouseLeave = () => {
+    if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+    setOpen(false);
+  };
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+      <PopoverPrimitive.Trigger asChild>
+        <div
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          data-testid={testId}
+          className="cursor-pointer"
+        >
+          {children}
+        </div>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="right"
+          sideOffset={8}
+          avoidCollisions
+          onMouseEnter={() => {
+            if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+          }}
+          onMouseLeave={handleMouseLeave}
+          className="z-[100] rounded-md shadow-lg overflow-hidden"
+          data-testid={`${testId}-popover`}
+        >
+          <Chessboard
+            options={{
+              id: "minimap-board",
+              position: fen,
+              boardStyle: {
+                width: MINIMAP_BOARD_SIZE,
+                height: MINIMAP_BOARD_SIZE,
+              },
+              darkSquareStyle: { backgroundColor: BOARD_DARK_SQUARE },
+              lightSquareStyle: { backgroundColor: BOARD_LIGHT_SQUARE },
+            }}
+          />
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}
+
+export { MinimapPopover };

--- a/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+++ b/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
@@ -12,7 +12,7 @@ interface MostPlayedOpeningsTableProps {
   color: "white" | "black";
   testIdPrefix: string;
   /** Load PGN moves onto the board and navigate to games tab */
-  onOpenGames: (pgn: string) => void;
+  onOpenGames: (pgn: string, color: "white" | "black") => void;
 }
 
 /** Format opening name: split on ": " — line break only on mobile. */
@@ -37,7 +37,7 @@ function OpeningRow({ o, color, index, testIdPrefix, onOpenGames }: {
   color: "white" | "black";
   index: number;
   testIdPrefix: string;
-  onOpenGames: (pgn: string) => void;
+  onOpenGames: (pgn: string, color: "white" | "black") => void;
 }) {
   const isEvenRow = index % 2 === 0;
 
@@ -66,7 +66,7 @@ function OpeningRow({ o, color, index, testIdPrefix, onOpenGames }: {
         className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         aria-label={`View ${o.total} games for ${o.opening_name}`}
         data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
-        onClick={() => onOpenGames(o.pgn)}
+        onClick={() => onOpenGames(o.pgn, color)}
       >
         <span className="tabular-nums">{o.total}</span>
         <FolderOpen className="h-3.5 w-3.5" />

--- a/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+++ b/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
@@ -57,7 +57,7 @@ function OpeningRow({ o, color, index, testIdPrefix, onOpenGames }: {
             <span className="text-muted-foreground mr-1.5">{o.opening_eco}</span>
             {formatName(o.opening_name)}
           </div>
-          <div className="text-xs text-muted-foreground mt-0.5 truncate">{o.pgn}</div>
+          <div className="text-xs text-muted-foreground mt-0.5 break-words sm:truncate">{o.pgn}</div>
         </div>
       </MinimapPopover>
 

--- a/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+++ b/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useNavigate } from "react-router-dom"
-import { FolderOpen } from "lucide-react"
+import { FolderOpen, ChevronDown, ChevronUp } from "lucide-react"
 import type { OpeningWDL } from "@/types/stats"
 import { MinimapPopover } from "./MinimapPopover"
 import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
@@ -8,19 +8,25 @@ import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
 // Minimum percentage to show label text inside a WDL bar segment
 const MIN_PCT_FOR_LABEL = 15;
 
+// Number of openings to show before the "More" fold
+const INITIAL_VISIBLE_COUNT = 3;
+
 interface MostPlayedOpeningsTableProps {
   openings: OpeningWDL[];
+  color: "white" | "black";
   testIdPrefix: string;
 }
 
-/** Format opening name: split on ": " and insert line break if colon found. */
+/** Format opening name: split on ": " — line break only on mobile. */
 function formatName(name: string): React.ReactNode {
   const parts = name.split(": ");
   if (parts.length > 1) {
     return (
       <>
         <span className="font-medium">{parts[0]}:</span>
-        <br />
+        {/* Line break on mobile only, space on desktop */}
+        <br className="sm:hidden" />
+        <span className="hidden sm:inline"> </span>
         <span>{parts.slice(1).join(": ")}</span>
       </>
     );
@@ -68,45 +74,93 @@ function MiniWDLBar({ win_pct, draw_pct, loss_pct }: { win_pct: number; draw_pct
   );
 }
 
-export function MostPlayedOpeningsTable({ openings, testIdPrefix }: MostPlayedOpeningsTableProps) {
+function OpeningRow({ o, color, testIdPrefix }: { o: OpeningWDL; color: "white" | "black"; testIdPrefix: string }) {
   const navigate = useNavigate();
+
+  return (
+    <div
+      key={`${o.opening_eco}-${o.opening_name}`}
+      className="grid grid-cols-[1fr_auto_minmax(80px,140px)] sm:grid-cols-[minmax(0,1fr)_auto_minmax(120px,200px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors"
+      data-testid={`${testIdPrefix}-row-${o.opening_eco}`}
+    >
+      {/* Column 1: ECO + Name + PGN */}
+      <MinimapPopover
+        fen={o.fen}
+        boardOrientation={color}
+        testId={`${testIdPrefix}-minimap-${o.opening_eco}`}
+      >
+        <div className="min-w-0">
+          <div className="text-sm leading-tight">
+            <span className="text-muted-foreground mr-1.5">{o.opening_eco}</span>
+            {formatName(o.opening_name)}
+          </div>
+          <div className="text-xs text-muted-foreground mt-0.5 truncate">{o.pgn}</div>
+        </div>
+      </MinimapPopover>
+
+      {/* Column 2: Game count with link to games tab */}
+      <button
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        aria-label={`View ${o.total} games for ${o.opening_name}`}
+        data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
+        onClick={() => navigate('/openings/games')}
+      >
+        <span className="tabular-nums">{o.total}</span>
+        <FolderOpen className="h-3.5 w-3.5" />
+      </button>
+
+      {/* Column 3: Mini WDL bar */}
+      <MiniWDLBar win_pct={o.win_pct} draw_pct={o.draw_pct} loss_pct={o.loss_pct} />
+    </div>
+  );
+}
+
+export function MostPlayedOpeningsTable({ openings, color, testIdPrefix }: MostPlayedOpeningsTableProps) {
+  const [expanded, setExpanded] = React.useState(false);
 
   if (openings.length === 0) return null;
 
+  const visibleOpenings = expanded ? openings : openings.slice(0, INITIAL_VISIBLE_COUNT);
+  const hiddenCount = openings.length - INITIAL_VISIBLE_COUNT;
+  const hasMore = hiddenCount > 0;
+
   return (
-    <div className="space-y-1" data-testid={`${testIdPrefix}-table`}>
-      {openings.map((o) => (
-        <div
-          key={`${o.opening_eco}-${o.opening_name}`}
-          className="grid grid-cols-[1fr_auto_minmax(80px,120px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors"
-          data-testid={`${testIdPrefix}-row-${o.opening_eco}`}
+    <div data-testid={`${testIdPrefix}-table`}>
+      {/* Table header */}
+      <div className="grid grid-cols-[1fr_auto_minmax(80px,140px)] sm:grid-cols-[minmax(0,1fr)_auto_minmax(120px,200px)] gap-2 px-2 pb-1 text-xs text-muted-foreground border-b border-white/10 mb-1">
+        <span>Name</span>
+        <span>Games</span>
+        <span>Win / Draw / Loss</span>
+      </div>
+
+      {/* Rows */}
+      <div className="space-y-0.5">
+        {visibleOpenings.map((o) => (
+          <OpeningRow key={`${o.opening_eco}-${o.opening_name}`} o={o} color={color} testIdPrefix={testIdPrefix} />
+        ))}
+      </div>
+
+      {/* More/Less toggle */}
+      {hasMore && (
+        <button
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mt-2 px-2"
+          onClick={() => setExpanded(!expanded)}
+          data-testid={`${testIdPrefix}-btn-more`}
+          aria-label={expanded ? "Show fewer openings" : `Show ${hiddenCount} more openings`}
         >
-          {/* Column 1: ECO + Name + PGN */}
-          <MinimapPopover fen={o.fen} testId={`${testIdPrefix}-minimap-${o.opening_eco}`}>
-            <div className="min-w-0">
-              <div className="text-sm leading-tight">
-                <span className="text-muted-foreground mr-1.5">{o.opening_eco}</span>
-                {formatName(o.opening_name)}
-              </div>
-              <div className="text-xs text-muted-foreground mt-0.5 truncate">{o.pgn}</div>
-            </div>
-          </MinimapPopover>
-
-          {/* Column 2: Game count with link to games tab */}
-          <button
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            aria-label={`View ${o.total} games for ${o.opening_name}`}
-            data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
-            onClick={() => navigate('/openings/games')}
-          >
-            <span className="tabular-nums">{o.total}</span>
-            <FolderOpen className="h-3.5 w-3.5" />
-          </button>
-
-          {/* Column 3: Mini WDL bar */}
-          <MiniWDLBar win_pct={o.win_pct} draw_pct={o.draw_pct} loss_pct={o.loss_pct} />
-        </div>
-      ))}
+          {expanded ? (
+            <>
+              <ChevronUp className="h-4 w-4" />
+              Less
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-4 w-4" />
+              {hiddenCount} more
+            </>
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+++ b/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
@@ -1,0 +1,112 @@
+import * as React from "react"
+import { useNavigate } from "react-router-dom"
+import { FolderOpen } from "lucide-react"
+import type { OpeningWDL } from "@/types/stats"
+import { MinimapPopover } from "./MinimapPopover"
+import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
+
+// Minimum percentage to show label text inside a WDL bar segment
+const MIN_PCT_FOR_LABEL = 15;
+
+interface MostPlayedOpeningsTableProps {
+  openings: OpeningWDL[];
+  testIdPrefix: string;
+}
+
+/** Format opening name: split on ": " and insert line break if colon found. */
+function formatName(name: string): React.ReactNode {
+  const parts = name.split(": ");
+  if (parts.length > 1) {
+    return (
+      <>
+        <span className="font-medium">{parts[0]}:</span>
+        <br />
+        <span>{parts.slice(1).join(": ")}</span>
+      </>
+    );
+  }
+  return <span className="font-medium">{name}</span>;
+}
+
+function MiniWDLBar({ win_pct, draw_pct, loss_pct }: { win_pct: number; draw_pct: number; loss_pct: number }) {
+  return (
+    <div className="flex h-4 w-full min-w-[80px] overflow-hidden rounded-sm" data-testid="mini-wdl-bar">
+      {win_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {win_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(win_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {draw_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {draw_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(draw_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+      {loss_pct > 0 && (
+        <div
+          className="relative flex items-center justify-center text-[10px] font-medium"
+          style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
+        >
+          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
+          <span className="relative z-10 text-white drop-shadow-sm">
+            {loss_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(loss_pct)}%` : ""}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MostPlayedOpeningsTable({ openings, testIdPrefix }: MostPlayedOpeningsTableProps) {
+  const navigate = useNavigate();
+
+  if (openings.length === 0) return null;
+
+  return (
+    <div className="space-y-1" data-testid={`${testIdPrefix}-table`}>
+      {openings.map((o) => (
+        <div
+          key={`${o.opening_eco}-${o.opening_name}`}
+          className="grid grid-cols-[1fr_auto_minmax(80px,120px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors"
+          data-testid={`${testIdPrefix}-row-${o.opening_eco}`}
+        >
+          {/* Column 1: ECO + Name + PGN */}
+          <MinimapPopover fen={o.fen} testId={`${testIdPrefix}-minimap-${o.opening_eco}`}>
+            <div className="min-w-0">
+              <div className="text-sm leading-tight">
+                <span className="text-muted-foreground mr-1.5">{o.opening_eco}</span>
+                {formatName(o.opening_name)}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5 truncate">{o.pgn}</div>
+            </div>
+          </MinimapPopover>
+
+          {/* Column 2: Game count with link to games tab */}
+          <button
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={`View ${o.total} games for ${o.opening_name}`}
+            data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
+            onClick={() => navigate('/openings/games')}
+          >
+            <span className="tabular-nums">{o.total}</span>
+            <FolderOpen className="h-3.5 w-3.5" />
+          </button>
+
+          {/* Column 3: Mini WDL bar */}
+          <MiniWDLBar win_pct={o.win_pct} draw_pct={o.draw_pct} loss_pct={o.loss_pct} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
+++ b/frontend/src/components/stats/MostPlayedOpeningsTable.tsx
@@ -1,12 +1,8 @@
 import * as React from "react"
-import { useNavigate } from "react-router-dom"
 import { FolderOpen, ChevronDown, ChevronUp } from "lucide-react"
 import type { OpeningWDL } from "@/types/stats"
 import { MinimapPopover } from "./MinimapPopover"
-import { WDL_WIN, WDL_DRAW, WDL_LOSS, GLASS_OVERLAY } from "@/lib/theme"
-
-// Minimum percentage to show label text inside a WDL bar segment
-const MIN_PCT_FOR_LABEL = 15;
+import { MiniWDLBar } from "./MiniWDLBar"
 
 // Number of openings to show before the "More" fold
 const INITIAL_VISIBLE_COUNT = 3;
@@ -15,6 +11,8 @@ interface MostPlayedOpeningsTableProps {
   openings: OpeningWDL[];
   color: "white" | "black";
   testIdPrefix: string;
+  /** Load PGN moves onto the board and navigate to games tab */
+  onOpenGames: (pgn: string) => void;
 }
 
 /** Format opening name: split on ": " — line break only on mobile. */
@@ -34,53 +32,18 @@ function formatName(name: string): React.ReactNode {
   return <span className="font-medium">{name}</span>;
 }
 
-function MiniWDLBar({ win_pct, draw_pct, loss_pct }: { win_pct: number; draw_pct: number; loss_pct: number }) {
-  return (
-    <div className="flex h-4 w-full min-w-[80px] overflow-hidden rounded-sm" data-testid="mini-wdl-bar">
-      {win_pct > 0 && (
-        <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
-          style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
-        >
-          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
-          <span className="relative z-10 text-white drop-shadow-sm">
-            {win_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(win_pct)}%` : ""}
-          </span>
-        </div>
-      )}
-      {draw_pct > 0 && (
-        <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
-          style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
-        >
-          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
-          <span className="relative z-10 text-white drop-shadow-sm">
-            {draw_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(draw_pct)}%` : ""}
-          </span>
-        </div>
-      )}
-      {loss_pct > 0 && (
-        <div
-          className="relative flex items-center justify-center text-[10px] font-medium"
-          style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
-        >
-          <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
-          <span className="relative z-10 text-white drop-shadow-sm">
-            {loss_pct >= MIN_PCT_FOR_LABEL ? `${Math.round(loss_pct)}%` : ""}
-          </span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function OpeningRow({ o, color, testIdPrefix }: { o: OpeningWDL; color: "white" | "black"; testIdPrefix: string }) {
-  const navigate = useNavigate();
+function OpeningRow({ o, color, index, testIdPrefix, onOpenGames }: {
+  o: OpeningWDL;
+  color: "white" | "black";
+  index: number;
+  testIdPrefix: string;
+  onOpenGames: (pgn: string) => void;
+}) {
+  const isEvenRow = index % 2 === 0;
 
   return (
     <div
-      key={`${o.opening_eco}-${o.opening_name}`}
-      className="grid grid-cols-[1fr_auto_minmax(80px,140px)] sm:grid-cols-[minmax(0,1fr)_auto_minmax(120px,200px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors"
+      className={`grid grid-cols-[1fr_auto_minmax(80px,140px)] sm:grid-cols-[minmax(0,1fr)_auto_minmax(120px,200px)] gap-2 items-center rounded px-2 py-1.5 hover:bg-white/5 transition-colors ${isEvenRow ? 'bg-white/[0.02]' : ''}`}
       data-testid={`${testIdPrefix}-row-${o.opening_eco}`}
     >
       {/* Column 1: ECO + Name + PGN */}
@@ -103,7 +66,7 @@ function OpeningRow({ o, color, testIdPrefix }: { o: OpeningWDL; color: "white" 
         className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
         aria-label={`View ${o.total} games for ${o.opening_name}`}
         data-testid={`${testIdPrefix}-games-${o.opening_eco}`}
-        onClick={() => navigate('/openings/games')}
+        onClick={() => onOpenGames(o.pgn)}
       >
         <span className="tabular-nums">{o.total}</span>
         <FolderOpen className="h-3.5 w-3.5" />
@@ -115,7 +78,7 @@ function OpeningRow({ o, color, testIdPrefix }: { o: OpeningWDL; color: "white" 
   );
 }
 
-export function MostPlayedOpeningsTable({ openings, color, testIdPrefix }: MostPlayedOpeningsTableProps) {
+export function MostPlayedOpeningsTable({ openings, color, testIdPrefix, onOpenGames }: MostPlayedOpeningsTableProps) {
   const [expanded, setExpanded] = React.useState(false);
 
   if (openings.length === 0) return null;
@@ -134,9 +97,16 @@ export function MostPlayedOpeningsTable({ openings, color, testIdPrefix }: MostP
       </div>
 
       {/* Rows */}
-      <div className="space-y-0.5">
-        {visibleOpenings.map((o) => (
-          <OpeningRow key={`${o.opening_eco}-${o.opening_name}`} o={o} color={color} testIdPrefix={testIdPrefix} />
+      <div>
+        {visibleOpenings.map((o, i) => (
+          <OpeningRow
+            key={`${o.opening_eco}-${o.opening_name}`}
+            o={o}
+            color={color}
+            index={i}
+            testIdPrefix={testIdPrefix}
+            onOpenGames={onOpenGames}
+          />
         ))}
       </div>
 
@@ -164,3 +134,4 @@ export function MostPlayedOpeningsTable({ openings, color, testIdPrefix }: MostP
     </div>
   );
 }
+

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { statsApi } from '@/api/client';
-import type { Platform, Recency } from '@/types/api';
+import type { Platform, Recency, TimeControl, OpponentType } from '@/types/api';
 
 export function useRatingHistory(recency: Recency | null, platforms: Platform[] | null) {
   const normalizedRecency = recency === 'all' ? null : recency;
@@ -20,9 +20,27 @@ export function useGlobalStats(recency: Recency | null, platforms: Platform[] | 
   });
 }
 
-export function useMostPlayedOpenings() {
+export function useMostPlayedOpenings(filters?: {
+  recency: Recency | null;
+  timeControls: TimeControl[] | null;
+  platforms: Platform[] | null;
+  rated: boolean | null;
+  opponentType: OpponentType;
+}) {
+  const normalizedRecency = filters?.recency === 'all' ? null : (filters?.recency ?? null);
+  const timeControl = filters?.timeControls ?? null;
+  const platform = filters?.platforms ?? null;
+  const rated = filters?.rated ?? null;
+  const opponentType = filters?.opponentType ?? 'human';
+
   return useQuery({
-    queryKey: ['mostPlayedOpenings'],
-    queryFn: () => statsApi.getMostPlayedOpenings(),
+    queryKey: ['mostPlayedOpenings', normalizedRecency, timeControl, platform, rated, opponentType],
+    queryFn: () => statsApi.getMostPlayedOpenings({
+      recency: normalizedRecency,
+      time_control: timeControl,
+      platform: platform,
+      rated: rated,
+      opponent_type: opponentType,
+    }),
   });
 }

--- a/frontend/src/lib/pgn.ts
+++ b/frontend/src/lib/pgn.ts
@@ -1,0 +1,7 @@
+/** Parse PGN string like "1. e4 e5 2. Nf3" into SAN array ["e4", "e5", "Nf3"] */
+export function pgnToSanArray(pgn: string): string[] {
+  return pgn
+    .replace(/\d+\./g, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -532,10 +532,10 @@ export function OpeningsPage() {
               <InfoPopover ariaLabel="White openings info" testId="mpo-white-info" side="top">
                 <div className="space-y-2">
                   <p>
-                    Your most frequently played openings as White, based on how chess.com and lichess classified each game. Only openings where White made the last move are shown here.
+                    Your most frequently played openings as White, based on the lichess opening table. Only openings where White made the last move are shown here.
                   </p>
                   <p>
-                    The game count reflects how many of your games received this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                    The game count reflects how many of your games ended up with this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
                   </p>
                 </div>
               </InfoPopover>
@@ -559,10 +559,10 @@ export function OpeningsPage() {
               <InfoPopover ariaLabel="Black openings info" testId="mpo-black-info" side="top">
                 <div className="space-y-2">
                   <p>
-                    Your most frequently played openings as Black, based on how chess.com and lichess classified each game. Only openings where Black made the last move are shown here.
+                    Your most frequently played openings as Black, based on the lichess opening table. Only openings where Black made the last move are shown here.
                   </p>
                   <p>
-                    The game count reflects how many of your games received this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                    The game count reflects how many of your games ended up with this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
                   </p>
                 </div>
               </InfoPopover>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -41,6 +41,7 @@ import { GameCardList } from '@/components/results/GameCardList';
 import { getArrowColor } from '@/lib/arrowColor';
 import { WDLChartRow } from '@/components/charts/WDLChartRow';
 import { MostPlayedOpeningsTable } from '@/components/stats/MostPlayedOpeningsTable';
+import { pgnToSanArray } from '@/lib/pgn';
 import { WinRateChart } from '@/components/charts/WinRateChart';
 import { apiClient } from '@/api/client';
 import type { FilterState } from '@/components/filters/FilterPanel';
@@ -229,6 +230,12 @@ export function OpeningsPage() {
       toast.error('Failed to save bookmark');
     }
   }, [chess, filters, boardFlipped, bookmarkLabel, createBookmark]);
+
+  /** Load opening PGN onto the board and navigate to the games subtab */
+  const handleOpenGames = useCallback((pgn: string) => {
+    chess.loadMoves(pgnToSanArray(pgn));
+    navigate('/openings/games');
+  }, [chess, navigate]);
 
   const handleLoadBookmark = useCallback((bkm: PositionBookmarkResponse) => {
     chess.loadMoves(bkm.moves);
@@ -524,6 +531,7 @@ export function OpeningsPage() {
             openings={mostPlayedData.white}
             color="white"
             testIdPrefix="mpo-white"
+            onOpenGames={handleOpenGames}
           />
         </div>
       )}
@@ -538,6 +546,7 @@ export function OpeningsPage() {
             openings={mostPlayedData.black}
             color="black"
             testIdPrefix="mpo-black"
+            onOpenGames={handleOpenGames}
           />
         </div>
       )}

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -231,9 +231,11 @@ export function OpeningsPage() {
     }
   }, [chess, filters, boardFlipped, bookmarkLabel, createBookmark]);
 
-  /** Load opening PGN onto the board and navigate to the games subtab */
-  const handleOpenGames = useCallback((pgn: string) => {
+  /** Load opening PGN onto the board, set color/flip/filters, and navigate to games subtab */
+  const handleOpenGames = useCallback((pgn: string, color: "white" | "black") => {
     chess.loadMoves(pgnToSanArray(pgn));
+    setBoardFlipped(color === 'black');
+    setFilters(prev => ({ ...prev, color, matchSide: 'both' as MatchSide }));
     navigate('/openings/games');
   }, [chess, navigate]);
 

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -513,41 +513,32 @@ export function OpeningsPage() {
 
   const statisticsContent = (
     <div className="flex flex-col gap-4">
-      {mostPlayedData && (mostPlayedData.white.length > 0 || mostPlayedData.black.length > 0) && (
-        <div className="charcoal-texture rounded-md p-4" data-testid="most-played-openings">
-          <h2 className="text-lg font-medium mb-3">Most Played Openings</h2>
-          <div className="space-y-6">
-            {/* White section */}
-            <div data-testid="mpo-white-section">
-              <h3 className="text-base font-medium mb-2 flex items-center gap-1.5">
-                <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white" />
-                White
-              </h3>
-              {mostPlayedData.white.length === 0 ? (
-                <p className="text-sm text-muted-foreground">Not enough games with White to show top openings (minimum 10 games per opening).</p>
-              ) : (
-                <MostPlayedOpeningsTable
-                  openings={mostPlayedData.white}
-                  testIdPrefix="mpo-white"
-                />
-              )}
-            </div>
-            {/* Black section */}
-            <div data-testid="mpo-black-section">
-              <h3 className="text-base font-medium mb-2 flex items-center gap-1.5">
-                <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900" />
-                Black
-              </h3>
-              {mostPlayedData.black.length === 0 ? (
-                <p className="text-sm text-muted-foreground">Not enough games with Black to show top openings (minimum 10 games per opening).</p>
-              ) : (
-                <MostPlayedOpeningsTable
-                  openings={mostPlayedData.black}
-                  testIdPrefix="mpo-black"
-                />
-              )}
-            </div>
-          </div>
+      {/* White openings */}
+      {mostPlayedData && mostPlayedData.white.length > 0 && (
+        <div className="charcoal-texture rounded-md p-4" data-testid="mpo-white-section">
+          <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
+            <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-white" />
+            White: Most Played Openings
+          </h2>
+          <MostPlayedOpeningsTable
+            openings={mostPlayedData.white}
+            color="white"
+            testIdPrefix="mpo-white"
+          />
+        </div>
+      )}
+      {/* Black openings */}
+      {mostPlayedData && mostPlayedData.black.length > 0 && (
+        <div className="charcoal-texture rounded-md p-4" data-testid="mpo-black-section">
+          <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
+            <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-zinc-900" />
+            Black: Most Played Openings
+          </h2>
+          <MostPlayedOpeningsTable
+            openings={mostPlayedData.black}
+            color="black"
+            testIdPrefix="mpo-black"
+          />
         </div>
       )}
       {bookmarks.length === 0 ? (

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -40,6 +40,7 @@ import { SuggestionsModal } from '@/components/position-bookmarks/SuggestionsMod
 import { GameCardList } from '@/components/results/GameCardList';
 import { getArrowColor } from '@/lib/arrowColor';
 import { WDLChartRow } from '@/components/charts/WDLChartRow';
+import { MostPlayedOpeningsTable } from '@/components/stats/MostPlayedOpeningsTable';
 import { WinRateChart } from '@/components/charts/WinRateChart';
 import { apiClient } from '@/api/client';
 import type { FilterState } from '@/components/filters/FilterPanel';
@@ -167,8 +168,14 @@ export function OpeningsPage() {
 
   const { data: tsData } = useTimeSeries(timeSeriesRequest);
 
-  // Most played openings — all-time, no filter params (shows top 5 per color across all games)
-  const { data: mostPlayedData } = useMostPlayedOpenings();
+  // Most played openings — filter params applied to show top openings per color
+  const { data: mostPlayedData } = useMostPlayedOpenings({
+    recency: debouncedFilters.recency,
+    timeControls: debouncedFilters.timeControls,
+    platforms: debouncedFilters.platforms,
+    rated: debouncedFilters.rated,
+    opponentType: debouncedFilters.opponentType,
+  });
 
   // Derive WDL stats per bookmark using aggregate fields (not rolling sub-counts)
   const wdlStatsMap = useMemo(() => {
@@ -504,13 +511,6 @@ export function OpeningsPage() {
     </div>
   );
 
-  const maxTotalWhite = mostPlayedData?.white.length
-    ? Math.max(...mostPlayedData.white.map(x => x.total))
-    : 0;
-  const maxTotalBlack = mostPlayedData?.black.length
-    ? Math.max(...mostPlayedData.black.map(x => x.total))
-    : 0;
-
   const statisticsContent = (
     <div className="flex flex-col gap-4">
       {mostPlayedData && (mostPlayedData.white.length > 0 || mostPlayedData.black.length > 0) && (
@@ -526,17 +526,10 @@ export function OpeningsPage() {
               {mostPlayedData.white.length === 0 ? (
                 <p className="text-sm text-muted-foreground">Not enough games with White to show top openings (minimum 10 games per opening).</p>
               ) : (
-                <div className="space-y-2">
-                  {mostPlayedData.white.map((o) => (
-                    <WDLChartRow
-                      key={`${o.opening_eco}-white`}
-                      data={o}
-                      label={o.label}
-                      maxTotal={maxTotalWhite}
-                      testId={`mpo-white-${o.opening_eco}`}
-                    />
-                  ))}
-                </div>
+                <MostPlayedOpeningsTable
+                  openings={mostPlayedData.white}
+                  testIdPrefix="mpo-white"
+                />
               )}
             </div>
             {/* Black section */}
@@ -548,17 +541,10 @@ export function OpeningsPage() {
               {mostPlayedData.black.length === 0 ? (
                 <p className="text-sm text-muted-foreground">Not enough games with Black to show top openings (minimum 10 games per opening).</p>
               ) : (
-                <div className="space-y-2">
-                  {mostPlayedData.black.map((o) => (
-                    <WDLChartRow
-                      key={`${o.opening_eco}-black`}
-                      data={o}
-                      label={o.label}
-                      maxTotal={maxTotalBlack}
-                      testId={`mpo-black-${o.opening_eco}`}
-                    />
-                  ))}
-                </div>
+                <MostPlayedOpeningsTable
+                  openings={mostPlayedData.black}
+                  testIdPrefix="mpo-black"
+                />
               )}
             </div>
           </div>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -527,7 +527,19 @@ export function OpeningsPage() {
         <div className="charcoal-texture rounded-md p-4" data-testid="mpo-white-section">
           <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
             <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-white" />
-            White: Most Played Openings
+            <span className="inline-flex items-center gap-1">
+              White: Most Played Openings
+              <InfoPopover ariaLabel="White openings info" testId="mpo-white-info" side="top">
+                <div className="space-y-2">
+                  <p>
+                    Your most frequently played openings as White, based on how chess.com and lichess classified each game. Only openings where White made the last move are shown here.
+                  </p>
+                  <p>
+                    The game count reflects how many of your games received this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                  </p>
+                </div>
+              </InfoPopover>
+            </span>
           </h2>
           <MostPlayedOpeningsTable
             openings={mostPlayedData.white}
@@ -542,7 +554,19 @@ export function OpeningsPage() {
         <div className="charcoal-texture rounded-md p-4" data-testid="mpo-black-section">
           <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
             <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-zinc-900" />
-            Black: Most Played Openings
+            <span className="inline-flex items-center gap-1">
+              Black: Most Played Openings
+              <InfoPopover ariaLabel="Black openings info" testId="mpo-black-info" side="top">
+                <div className="space-y-2">
+                  <p>
+                    Your most frequently played openings as Black, based on how chess.com and lichess classified each game. Only openings where Black made the last move are shown here.
+                  </p>
+                  <p>
+                    The game count reflects how many of your games received this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                  </p>
+                </div>
+              </InfoPopover>
+            </span>
           </h2>
           <MostPlayedOpeningsTable
             openings={mostPlayedData.black}

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -29,6 +29,8 @@ export interface OpeningWDL {
   opening_eco: string;
   opening_name: string;
   label: string;
+  pgn: string;
+  fen: string;
   wins: number;
   draws: number;
   losses: number;

--- a/scripts/seed_openings.py
+++ b/scripts/seed_openings.py
@@ -1,0 +1,85 @@
+"""Idempotent seed script: populate openings table from app/data/openings.tsv.
+
+Uses board.board_fen() (not board.fen()) per project convention.
+Uses INSERT ... ON CONFLICT DO NOTHING for idempotency.
+Run with: uv run python -m scripts.seed_openings
+"""
+import asyncio
+import csv
+import io
+import logging
+from pathlib import Path
+
+import chess
+import chess.pgn
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+TSV_PATH = Path(__file__).resolve().parent.parent / "app" / "data" / "openings.tsv"
+
+
+def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
+    """Compute piece-placement FEN and ply count from a PGN move sequence.
+
+    Uses board.board_fen() (not board.fen()) per project convention.
+    """
+    game = chess.pgn.read_game(io.StringIO(pgn_str))
+    if game is None:
+        raise ValueError(f"Failed to parse PGN: {pgn_str!r}")
+    board = game.board()
+    for move in game.mainline_moves():
+        board.push(move)
+    return board.board_fen(), board.ply()
+
+
+async def seed_openings() -> int:
+    """Read TSV and insert rows into openings table. Returns count of inserted rows."""
+    engine = create_async_engine(settings.DATABASE_URL)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    inserted = 0
+    skipped = 0
+    errors = 0
+
+    async with async_session() as session:
+        with open(TSV_PATH, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter="\t")
+            for row_num, row in enumerate(reader, start=2):
+                eco = row["eco"]
+                name = row["name"]
+                pgn_str = row["pgn"]
+                try:
+                    fen, ply_count = pgn_to_fen_and_ply(pgn_str)
+                except Exception:
+                    logger.warning("Row %d: failed to parse PGN %r — skipping", row_num, pgn_str)
+                    errors += 1
+                    continue
+
+                result = await session.execute(
+                    text(
+                        "INSERT INTO openings (eco, name, pgn, ply_count, fen) "
+                        "VALUES (:eco, :name, :pgn, :ply_count, :fen) "
+                        "ON CONFLICT ON CONSTRAINT uq_openings_eco_name_pgn DO NOTHING"
+                    ),
+                    {"eco": eco, "name": name, "pgn": pgn_str, "ply_count": ply_count, "fen": fen},
+                )
+                if result.rowcount > 0:
+                    inserted += 1
+                else:
+                    skipped += 1
+
+        await session.commit()
+
+    await engine.dispose()
+    logger.info("Seed complete: %d inserted, %d skipped (already exist), %d errors", inserted, skipped, errors)
+    return inserted
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_openings())

--- a/tests/test_seed_openings.py
+++ b/tests/test_seed_openings.py
@@ -1,0 +1,126 @@
+"""Tests for the openings seed script and dedup view.
+
+Coverage:
+- pgn_to_fen_and_ply: correct FEN and ply for known openings
+- seed_openings: inserts rows from TSV
+- seed_openings: idempotent (running twice does not duplicate rows)
+- openings_dedup: returns one row per (eco, name) pair
+"""
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.opening import Opening
+from scripts.seed_openings import pgn_to_fen_and_ply, seed_openings
+
+
+@pytest.fixture(scope="session", autouse=True)
+def seed_openings_for_tests(test_engine):
+    """Seed the openings table in the test DB once per session.
+
+    The migration (run by test_engine fixture) creates the schema; this fixture
+    populates the data. Running seed_openings is idempotent so it is safe to
+    call even if the table already has rows.
+    """
+    import asyncio
+
+    # Run the seed against the test DB (settings.DATABASE_URL already patched to
+    # TEST_DATABASE_URL by the conftest test_engine fixture).
+    asyncio.run(seed_openings())
+
+
+class TestPgnToFenAndPly:
+    """Unit tests for pgn_to_fen_and_ply helper."""
+
+    def test_single_move_opening(self) -> None:
+        """1. e4 should produce ply_count=1 and correct FEN."""
+        fen, ply = pgn_to_fen_and_ply("1. e4")
+        assert ply == 1
+        # After 1. e4, the board should have the pawn on e4
+        assert "4P3" in fen  # e4 pawn in rank 4
+
+    def test_two_move_opening(self) -> None:
+        """1. e4 e5 should produce ply_count=2."""
+        fen, ply = pgn_to_fen_and_ply("1. e4 e5")
+        assert ply == 2
+
+    def test_uses_board_fen_not_full_fen(self) -> None:
+        """FEN must be piece-placement only (no castling/en passant/move counters)."""
+        fen, _ = pgn_to_fen_and_ply("1. e4 e5")
+        # board_fen() has exactly 7 slashes (8 ranks separated by /)
+        assert fen.count("/") == 7
+        # board_fen() does NOT contain spaces (full FEN has spaces for castling etc.)
+        assert " " not in fen
+
+    def test_invalid_pgn_raises(self) -> None:
+        """Invalid PGN should raise ValueError."""
+        with pytest.raises(ValueError, match="Failed to parse PGN"):
+            pgn_to_fen_and_ply("")
+
+
+@pytest.mark.asyncio(loop_scope="session")
+class TestSeedOpeningsIntegration:
+    """Integration tests verifying seed data exists in openings table.
+
+    These tests rely on the seed script having been run during test setup
+    (the migration + seed populate the openings table). They verify the
+    data is correct, not the seed script execution itself.
+    """
+
+    async def test_openings_table_has_expected_row_count(self, db_session: AsyncSession) -> None:
+        """openings table should have ~3641 rows from TSV."""
+        result = await db_session.execute(select(func.count()).select_from(Opening))
+        count = result.scalar_one()
+        # Allow small tolerance for TSV updates, but should be close to 3641
+        assert count >= 3600, f"Expected ~3641 rows, got {count}"
+
+    async def test_opening_row_has_valid_fen_and_ply(self, db_session: AsyncSession) -> None:
+        """Spot-check: a known opening has correct fen and ply_count."""
+        result = await db_session.execute(
+            select(Opening).where(Opening.eco == "B00", Opening.name == "King's Pawn Game")
+        )
+        opening = result.scalars().first()
+        assert opening is not None
+        assert opening.ply_count == 1  # 1. e4
+        assert "4P3" in opening.fen  # pawn on e4
+
+    async def test_seed_idempotent_no_duplicates(self, db_session: AsyncSession) -> None:
+        """UniqueConstraint prevents duplicate (eco, name, pgn) rows."""
+        # Count before — already seeded
+        result = await db_session.execute(select(func.count()).select_from(Opening))
+        count_before = result.scalar_one()
+        assert count_before >= 3600
+
+        # The UniqueConstraint ensures ON CONFLICT DO NOTHING works.
+        # We verify by checking there are no duplicate (eco, name, pgn) triples.
+        dup_result = await db_session.execute(
+            text(
+                "SELECT eco, name, pgn, COUNT(*) "
+                "FROM openings GROUP BY eco, name, pgn HAVING COUNT(*) > 1"
+            )
+        )
+        duplicates = dup_result.fetchall()
+        assert len(duplicates) == 0, f"Found duplicate rows: {duplicates}"
+
+    async def test_dedup_view_returns_fewer_rows(self, db_session: AsyncSession) -> None:
+        """openings_dedup should have fewer rows than openings (collapses duplicate eco+name)."""
+        total_result = await db_session.execute(select(func.count()).select_from(Opening))
+        total = total_result.scalar_one()
+
+        dedup_result = await db_session.execute(text("SELECT COUNT(*) FROM openings_dedup"))
+        dedup_count = dedup_result.scalar_one()
+
+        assert dedup_count < total, f"Dedup ({dedup_count}) should be < total ({total})"
+        assert dedup_count >= 3200, f"Expected ~3301 dedup rows, got {dedup_count}"
+
+    async def test_dedup_view_has_one_row_per_eco_name(self, db_session: AsyncSession) -> None:
+        """Each (eco, name) pair appears exactly once in the dedup view."""
+        result = await db_session.execute(
+            text(
+                "SELECT eco, name, COUNT(*) "
+                "FROM openings_dedup GROUP BY eco, name HAVING COUNT(*) > 1"
+            )
+        )
+        duplicates = result.fetchall()
+        assert len(duplicates) == 0, f"Dedup view has duplicate (eco, name): {duplicates}"

--- a/tests/test_stats_repository.py
+++ b/tests/test_stats_repository.py
@@ -7,10 +7,10 @@ Coverage:
 - query_rating_history: returns per-platform per-game rating data points
 - query_rating_history: filters by recency_cutoff
 - query_rating_history: excludes games with NULL user_rating
-- query_results_by_time_control: returns (bucket, result, user_color) tuples
+- query_results_by_time_control: returns SQL-aggregated (bucket, total, wins, draws, losses) tuples
 - query_results_by_time_control: filters by recency_cutoff
 - query_results_by_time_control: excludes games with NULL time_control_bucket
-- query_results_by_color: returns (user_color, result) tuples
+- query_results_by_color: returns SQL-aggregated (user_color, total, wins, draws, losses) tuples
 - query_results_by_color: filters by recency_cutoff
 """
 
@@ -26,7 +26,6 @@ from app.repositories.stats_repository import (
     query_rating_history,
     query_results_by_color,
     query_results_by_time_control,
-    query_top_openings_by_color,
     query_top_openings_sql_wdl,
 )
 
@@ -203,24 +202,27 @@ class TestQueryRatingHistory:
 
 
 class TestQueryResultsByTimeControl:
-    """Tests for query_results_by_time_control repository function."""
+    """Tests for query_results_by_time_control — SQL-aggregated WDL per bucket."""
 
     @pytest.mark.asyncio
-    async def test_returns_tuple_with_bucket_result_color(self, db_session: AsyncSession) -> None:
-        """Each row should be a (time_control_bucket, result, user_color) tuple."""
-        await _seed_game(
-            db_session, time_control_bucket="blitz", result="1-0", user_color="white"
-        )
+    async def test_returns_aggregated_wdl(self, db_session: AsyncSession) -> None:
+        """Should return (bucket, total, wins, draws, losses) aggregated in SQL."""
+        # 2 wins + 1 draw as white in blitz
+        await _seed_game(db_session, time_control_bucket="blitz", result="1-0", user_color="white")
+        await _seed_game(db_session, time_control_bucket="blitz", result="1-0", user_color="white")
+        await _seed_game(db_session, time_control_bucket="blitz", result="1/2-1/2", user_color="white")
 
         rows = await query_results_by_time_control(
             db_session, user_id=99999, recency_cutoff=None
         )
 
         assert len(rows) == 1
-        bucket, result, color = rows[0]
+        bucket, total, wins, draws, losses = rows[0]
         assert bucket == "blitz"
-        assert result == "1-0"
-        assert color == "white"
+        assert total == 3
+        assert wins == 2
+        assert draws == 1
+        assert losses == 0
 
     @pytest.mark.asyncio
     async def test_excludes_null_time_control_bucket(self, db_session: AsyncSession) -> None:
@@ -235,10 +237,10 @@ class TestQueryResultsByTimeControl:
 
     @pytest.mark.asyncio
     async def test_multiple_buckets(self, db_session: AsyncSession) -> None:
-        """Returns games from multiple time control buckets."""
-        await _seed_game(db_session, time_control_bucket="bullet", result="0-1")
-        await _seed_game(db_session, time_control_bucket="blitz", result="1-0")
-        await _seed_game(db_session, time_control_bucket="rapid", result="1/2-1/2")
+        """Returns one aggregated row per time control bucket."""
+        await _seed_game(db_session, time_control_bucket="bullet", result="0-1", user_color="white")
+        await _seed_game(db_session, time_control_bucket="blitz", result="1-0", user_color="white")
+        await _seed_game(db_session, time_control_bucket="rapid", result="1/2-1/2", user_color="white")
 
         rows = await query_results_by_time_control(
             db_session, user_id=99999, recency_cutoff=None
@@ -305,6 +307,24 @@ class TestQueryResultsByTimeControl:
         buckets = {r[0] for r in rows}
         assert buckets == {"blitz", "rapid"}
 
+    @pytest.mark.asyncio
+    async def test_wdl_counts_black_perspective(self, db_session: AsyncSession) -> None:
+        """Wins/losses should be computed from the user's perspective (black)."""
+        # Black wins when result is "0-1", loses when "1-0"
+        await _seed_game(db_session, time_control_bucket="blitz", result="0-1", user_color="black")
+        await _seed_game(db_session, time_control_bucket="blitz", result="1-0", user_color="black")
+
+        rows = await query_results_by_time_control(
+            db_session, user_id=99999, recency_cutoff=None
+        )
+
+        assert len(rows) == 1
+        _, total, wins, draws, losses = rows[0]
+        assert total == 2
+        assert wins == 1
+        assert losses == 1
+        assert draws == 0
+
 
 # ---------------------------------------------------------------------------
 # TestQueryResultsByColor
@@ -312,23 +332,29 @@ class TestQueryResultsByTimeControl:
 
 
 class TestQueryResultsByColor:
-    """Tests for query_results_by_color repository function."""
+    """Tests for query_results_by_color — SQL-aggregated WDL per color."""
 
     @pytest.mark.asyncio
-    async def test_returns_tuple_with_color_and_result(self, db_session: AsyncSession) -> None:
-        """Each row should be a (user_color, result) tuple."""
+    async def test_returns_aggregated_wdl(self, db_session: AsyncSession) -> None:
+        """Should return (color, total, wins, draws, losses) aggregated in SQL."""
+        # 2 wins + 1 loss as white
         await _seed_game(db_session, user_color="white", result="1-0")
+        await _seed_game(db_session, user_color="white", result="1-0")
+        await _seed_game(db_session, user_color="white", result="0-1")
 
         rows = await query_results_by_color(db_session, user_id=99999, recency_cutoff=None)
 
         assert len(rows) == 1
-        color, result = rows[0]
+        color, total, wins, draws, losses = rows[0]
         assert color == "white"
-        assert result == "1-0"
+        assert total == 3
+        assert wins == 2
+        assert draws == 0
+        assert losses == 1
 
     @pytest.mark.asyncio
     async def test_both_colors_returned(self, db_session: AsyncSession) -> None:
-        """Returns games with both white and black user colors."""
+        """Returns one aggregated row per color."""
         await _seed_game(db_session, user_color="white", result="1-0")
         await _seed_game(db_session, user_color="black", result="0-1")
 
@@ -387,87 +413,21 @@ class TestQueryResultsByColor:
         colors = {r[0] for r in rows}
         assert colors == {"white", "black"}
 
-
-# ---------------------------------------------------------------------------
-# TestQueryTopOpeningsByColor
-# ---------------------------------------------------------------------------
-
-
-class TestQueryTopOpeningsByColor:
-    """Tests for query_top_openings_by_color repository function."""
-
     @pytest.mark.asyncio
-    async def test_top_openings_returns_top_n_by_game_count(self, db_session: AsyncSession) -> None:
-        """Returns top-N openings by game count; opening below min_games is excluded."""
-        # Opening A: 8 games, Opening B: 6 games, Opening C: 3 games (below min_games=5)
-        for _ in range(8):
-            await _seed_game(db_session, user_color="white", opening_eco="A01", opening_name="Opening A")
-        for _ in range(6):
-            await _seed_game(db_session, user_color="white", opening_eco="B01", opening_name="Opening B")
-        for _ in range(3):
-            await _seed_game(db_session, user_color="white", opening_eco="C01", opening_name="Opening C")
+    async def test_wdl_counts_black_wins(self, db_session: AsyncSession) -> None:
+        """Black wins (result 0-1) should be counted as wins for the black row."""
+        await _seed_game(db_session, user_color="black", result="0-1")
+        await _seed_game(db_session, user_color="black", result="1-0")
+        await _seed_game(db_session, user_color="black", result="1/2-1/2")
 
-        rows = await query_top_openings_by_color(
-            db_session, user_id=99999, color="white", min_games=5, limit=2
-        )
+        rows = await query_results_by_color(db_session, user_id=99999, recency_cutoff=None)
 
-        # C excluded by min_games; A+B included (8+6=14 rows)
-        assert len(rows) == 14
-        ecos = {r[0] for r in rows}
-        assert ecos == {"A01", "B01"}
-        assert "C01" not in ecos
-
-    @pytest.mark.asyncio
-    async def test_top_openings_excludes_below_min_games(self, db_session: AsyncSession) -> None:
-        """Openings with fewer than min_games games are not returned."""
-        for _ in range(4):
-            await _seed_game(db_session, user_color="white", opening_eco="A01", opening_name="Opening A")
-
-        rows = await query_top_openings_by_color(
-            db_session, user_id=99999, color="white", min_games=5, limit=5
-        )
-
-        assert rows == []
-
-    @pytest.mark.asyncio
-    async def test_top_openings_excludes_null_eco_name(self, db_session: AsyncSession) -> None:
-        """Games with NULL opening_eco or NULL opening_name are excluded."""
-        # Games with valid eco/name
-        for _ in range(10):
-            await _seed_game(db_session, user_color="white", opening_eco="A01", opening_name="Valid Opening")
-        # Games with NULL eco
-        for _ in range(5):
-            await _seed_game(db_session, user_color="white", opening_eco=None, opening_name="Has Name")
-        # Games with NULL name
-        for _ in range(5):
-            await _seed_game(db_session, user_color="white", opening_eco="B01", opening_name=None)
-
-        rows = await query_top_openings_by_color(
-            db_session, user_id=99999, color="white", min_games=5, limit=5
-        )
-
-        # Only the valid opening should appear
-        assert len(rows) == 10
-        for opening_eco, opening_name, result, user_color in rows:
-            assert opening_eco is not None
-            assert opening_name is not None
-
-    @pytest.mark.asyncio
-    async def test_top_openings_filters_by_color(self, db_session: AsyncSession) -> None:
-        """Only games for the requested color are returned."""
-        for _ in range(10):
-            await _seed_game(db_session, user_color="white", opening_eco="A01", opening_name="White Opening")
-        for _ in range(10):
-            await _seed_game(db_session, user_color="black", opening_eco="B01", opening_name="Black Opening")
-
-        rows = await query_top_openings_by_color(
-            db_session, user_id=99999, color="white", min_games=5, limit=5
-        )
-
-        assert len(rows) == 10
-        for opening_eco, opening_name, result, user_color in rows:
-            assert user_color == "white"
-            assert opening_eco == "A01"
+        assert len(rows) == 1
+        _, total, wins, draws, losses = rows[0]
+        assert total == 3
+        assert wins == 1
+        assert draws == 1
+        assert losses == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stats_repository.py
+++ b/tests/test_stats_repository.py
@@ -27,6 +27,7 @@ from app.repositories.stats_repository import (
     query_results_by_color,
     query_results_by_time_control,
     query_top_openings_by_color,
+    query_top_openings_sql_wdl,
 )
 
 
@@ -467,3 +468,81 @@ class TestQueryTopOpeningsByColor:
         for opening_eco, opening_name, result, user_color in rows:
             assert user_color == "white"
             assert opening_eco == "A01"
+
+
+# ---------------------------------------------------------------------------
+# TestQueryTopOpeningsSqlWDL
+# ---------------------------------------------------------------------------
+
+
+class TestQueryTopOpeningsSqlWDL:
+    """Tests for the SQL-side WDL aggregation query (Phase 37)."""
+
+    @pytest.mark.asyncio
+    async def test_sql_wdl_returns_correct_counts(self, db_session: AsyncSession) -> None:
+        """SQL WDL should compute wins/draws/losses in SQL, not Python."""
+        # Seed 3 wins + 2 draws for King's Pawn Game as white.
+        # "King's Pawn Game" (B00, ply_count=1) exists in openings_dedup.
+        for _ in range(3):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+        for _ in range(2):
+            await _seed_game(db_session, user_id=99999, result="1/2-1/2", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=1)
+        assert len(rows) >= 1
+        # Find the King's Pawn Game row
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 1
+        eco, name, pgn, fen, total, wins, draws, losses = kpg[0]
+        assert wins == 3
+        assert draws == 2
+        assert losses == 0
+        assert total == 5
+        assert pgn  # non-empty PGN from openings_dedup
+        assert fen  # non-empty FEN from openings_dedup
+        assert "/" in fen  # FEN has rank separators
+
+    @pytest.mark.asyncio
+    async def test_sql_wdl_excludes_below_min_games(self, db_session: AsyncSession) -> None:
+        """Openings below min_games threshold should not appear."""
+        await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                         opening_eco="B00", opening_name="King's Pawn Game")
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=100, limit=10, min_ply=1)
+        assert len(rows) == 0
+
+    @pytest.mark.asyncio
+    async def test_sql_wdl_filters_by_time_control(self, db_session: AsyncSession) -> None:
+        """time_control filter should restrict results."""
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game",
+                             time_control_bucket="blitz")
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game",
+                             time_control_bucket="rapid")
+
+        # Filter to blitz only
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=1,
+            time_control=["blitz"])
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 1
+        assert kpg[0][4] == 10  # total = 10 blitz games only
+
+    @pytest.mark.asyncio
+    async def test_sql_wdl_ply_threshold_excludes_short_openings(self, db_session: AsyncSession) -> None:
+        """min_ply filter should exclude openings with ply_count below threshold."""
+        # King's Pawn Game has ply_count=1 (1. e4)
+        for _ in range(10):
+            await _seed_game(db_session, user_id=99999, result="1-0", user_color="white",
+                             opening_eco="B00", opening_name="King's Pawn Game")
+        # With min_ply=5, King's Pawn Game (ply=1) should be excluded
+        rows = await query_top_openings_sql_wdl(
+            db_session, user_id=99999, color="white", min_games=1, limit=10, min_ply=5)
+        kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
+        assert len(kpg) == 0

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -289,3 +289,49 @@ class TestGetMostPlayedOpenings:
         assert "black" in data
         assert isinstance(data["white"], list)
         assert isinstance(data["black"], list)
+
+    @pytest.mark.asyncio
+    async def test_most_played_openings_includes_pgn_fen(self, auth_headers: dict[str, str]) -> None:
+        """Response openings should include pgn and fen fields per ORT-03."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get("/api/stats/most-played-openings", headers=auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # If there are openings, they must have pgn and fen fields
+        for opening in data.get("white", []) + data.get("black", []):
+            assert "pgn" in opening
+            assert "fen" in opening
+
+    @pytest.mark.asyncio
+    async def test_most_played_openings_accepts_filters(self, auth_headers: dict[str, str]) -> None:
+        """Endpoint should accept filter params without error."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/stats/most-played-openings",
+                params={"recency": "month", "time_control": "blitz", "rated": "true"},
+                headers=auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "white" in data
+        assert "black" in data
+
+    @pytest.mark.asyncio
+    async def test_most_played_openings_accepts_opponent_type(self, auth_headers: dict[str, str]) -> None:
+        """Endpoint should accept opponent_type param without error."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.get(
+                "/api/stats/most-played-openings",
+                params={"opponent_type": "human"},
+                headers=auth_headers,
+            )
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- **Openings reference table**: SQLAlchemy model, Alembic migration with `openings_dedup` view, idempotent seed script (3,641 openings)
- **Backend redesign**: SQL-side WDL aggregation via `func.count().filter()`, JOIN to `openings_dedup` for PGN/FEN, filter support (recency, time control, platform, rated, opponent type), odd/even ply filtering for white/black
- **Frontend redesign**: Dedicated table with ECO/name/PGN columns, MiniWDLBar with inline percentages, cursor-following minimap popover, zebra rows, collapsible "More" section (3 shown, expand for rest), separate charcoal containers per color
- **SQL efficiency refactor**: Moved global stats WDL aggregation from Python-side row counting to SQL GROUP BY, removed dead `query_top_openings_by_color`
- **Shared MiniWDLBar component**: Extracted and reused in both openings table and move explorer (replaced plain bars + hover popover with inline percentage labels)
- **WDLChartRow inline labels**: Added percentage + game count labels inside bar segments, removed redundant legend row below

## Test plan
- [x] 471 backend tests passing (pytest)
- [x] 38 frontend tests passing (vitest)
- [x] TypeScript compiles clean
- [x] ESLint clean
- [ ] Visual verification: openings table layout on desktop and mobile
- [ ] Visual verification: minimap follows cursor, flipped for black
- [ ] Games navigation: folder icon loads PGN, sets color/flip/filters, navigates to games tab
- [ ] MiniWDLBar in move explorer shows inline percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)