### PR TITLE
Phase 38: Opening Statistics & Bookmark Suggestions Rework

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -78,7 +78,7 @@ Users can determine their success rate for any opening position they specify, fi
 
 ## Current State
 
-v1.5 shipped 2026-03-28. Phase 36 (Most Played Openings) complete — GET /stats/most-played-openings endpoint returning top 5 openings per color with WDL stats, rendered in Opening Statistics subtab with WDLChartRow components. v1.6 UI Polish milestone in progress.
+v1.5 shipped 2026-03-28. Phase 38 (Opening Statistics & Bookmark Suggestions Rework) complete — Statistics tab reordered (Results by Opening → Win Rate Over Time → Most Played), default chart data from top 3 most-played openings when no bookmarks, bookmark suggestions derived client-side from most-played data, chart-enable toggle on bookmark cards, position-based game counts and WDL in Most Played Openings, Zobrist hashes stored in openings table. v1.6 UI Polish milestone in progress.
 
 ## Context
 
@@ -124,4 +124,4 @@ v1.5 shipped 2026-03-28. Phase 36 (Most Played Openings) complete — GET /stats
 | Backend expose-only (no ports) | Caddy is sole internet-facing entry point | ✓ Good |
 
 ---
-*Last updated: 2026-03-28 after Phase 36 completion*
+*Last updated: 2026-03-29 after Phase 38 completion*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -39,8 +39,8 @@ Requirements for v1.6 — UI Polish & Improvements.
 
 ### Opening Statistics & Bookmark Suggestions Rework
 
-- [ ] **STAT-01**: Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played Openings as White, Most Played Openings as Black
-- [ ] **STAT-02**: When no bookmarks exist, Results by Opening and Win Rate Over Time charts show data from top 3 most-played openings per color (white with played-as-white filter, black with played-as-black filter)
+- [x] **STAT-01**: Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played Openings as White, Most Played Openings as Black
+- [x] **STAT-02**: When no bookmarks exist, Results by Opening and Win Rate Over Time charts show data from top 3 most-played openings per color (white with played-as-white filter, black with played-as-black filter)
 - [ ] **STAT-03**: Bookmark suggestions derive from most-played openings data (no backend suggestions API call), skip already-bookmarked positions, show fallback message when all are bookmarked
 - [ ] **STAT-04**: Each bookmark card has a chart-enable toggle (default: enabled, persisted in localStorage) controlling inclusion in Results by Opening and Win Rate Over Time charts
 - [ ] **STAT-05**: Bookmark card layout: bigger minimap (~72px), button row below piece filter with chart toggle (left), load (middle), delete (right)

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -41,10 +41,10 @@ Requirements for v1.6 — UI Polish & Improvements.
 
 - [x] **STAT-01**: Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played Openings as White, Most Played Openings as Black
 - [x] **STAT-02**: When no bookmarks exist, Results by Opening and Win Rate Over Time charts show data from top 3 most-played openings per color (white with played-as-white filter, black with played-as-black filter)
-- [ ] **STAT-03**: Bookmark suggestions derive from most-played openings data (no backend suggestions API call), skip already-bookmarked positions, show fallback message when all are bookmarked
-- [ ] **STAT-04**: Each bookmark card has a chart-enable toggle (default: enabled, persisted in localStorage) controlling inclusion in Results by Opening and Win Rate Over Time charts
-- [ ] **STAT-05**: Bookmark card layout: bigger minimap (~72px), button row below piece filter with chart toggle (left), load (middle), delete (right)
-- [ ] **STAT-06**: Position Bookmarks popover explains Piece filter and chart-enable toggle functionality
+- [x] **STAT-03**: Bookmark suggestions derive from most-played openings data (no backend suggestions API call), skip already-bookmarked positions, show fallback message when all are bookmarked
+- [x] **STAT-04**: Each bookmark card has a chart-enable toggle (default: enabled, persisted in localStorage) controlling inclusion in Results by Opening and Win Rate Over Time charts
+- [x] **STAT-05**: Bookmark card layout: bigger minimap (~72px), button row below piece filter with chart toggle (left), load (middle), delete (right)
+- [x] **STAT-06**: Position Bookmarks popover explains Piece filter and chart-enable toggle functionality
 
 ## Future Requirements
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -37,6 +37,15 @@ Requirements for v1.6 — UI Polish & Improvements.
 - [x] **ORT-04**: Frontend renders a dedicated table with ECO/name/PGN, game count link, and mini WDL bar per row
 - [x] **ORT-05**: Hovering/tapping a row shows a minimap popover of the opening position
 
+### Opening Statistics & Bookmark Suggestions Rework
+
+- [ ] **STAT-01**: Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played Openings as White, Most Played Openings as Black
+- [ ] **STAT-02**: When no bookmarks exist, Results by Opening and Win Rate Over Time charts show data from top 3 most-played openings per color (white with played-as-white filter, black with played-as-black filter)
+- [ ] **STAT-03**: Bookmark suggestions derive from most-played openings data (no backend suggestions API call), skip already-bookmarked positions, show fallback message when all are bookmarked
+- [ ] **STAT-04**: Each bookmark card has a chart-enable toggle (default: enabled, persisted in localStorage) controlling inclusion in Results by Opening and Win Rate Over Time charts
+- [ ] **STAT-05**: Bookmark card layout: bigger minimap (~72px), button row below piece filter with chart toggle (left), load (middle), delete (right)
+- [ ] **STAT-06**: Position Bookmarks popover explains Piece filter and chart-enable toggle functionality
+
 ## Future Requirements
 
 ### Pawn Structure Analysis
@@ -78,17 +87,23 @@ Which phases cover which requirements. Updated during roadmap creation.
 | MPO-02 | Phase 36 | Complete |
 | MPO-03 | Phase 36 | Complete |
 | MPO-04 | Phase 36 | Complete |
-| ORT-01 | Phase 37 | Not started |
-| ORT-02 | Phase 37 | Not started |
+| ORT-01 | Phase 37 | Complete |
+| ORT-02 | Phase 37 | Complete |
 | ORT-03 | Phase 37 | Not started |
-| ORT-04 | Phase 37 | Not started |
-| ORT-05 | Phase 37 | Not started |
+| ORT-04 | Phase 37 | Complete |
+| ORT-05 | Phase 37 | Complete |
+| STAT-01 | Phase 38 | Not started |
+| STAT-02 | Phase 38 | Not started |
+| STAT-03 | Phase 38 | Not started |
+| STAT-04 | Phase 38 | Not started |
+| STAT-05 | Phase 38 | Not started |
+| STAT-06 | Phase 38 | Not started |
 
 **Coverage:**
-- v1.6 requirements: 18 total
-- Mapped to phases: 18
+- v1.6 requirements: 24 total
+- Mapped to phases: 24
 - Unmapped: 0
 
 ---
 *Requirements defined: 2026-03-28*
-*Last updated: 2026-03-28 after Phase 37 planning*
+*Last updated: 2026-03-29 after Phase 38 planning*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -87,7 +87,7 @@
 - [x] **Phase 35: WDL Chart Refactoring** — Create shared WDL chart component based on endgame charts, replace all inconsistent WDL charts (custom and Recharts), clean up unused code (completed 2026-03-28)
 - [x] **Phase 36: Most Played Openings** — Add "Most Played Openings" sections (White/Black) to Opening Statistics subtab with top 5 openings as WDL charts, ECO codes, minimum 10 games threshold (completed 2026-03-28)
 - [x] **Phase 37: Openings Reference Table & Most Played Openings Redesign** — Create openings DB table from TSV dataset with PGN/FEN/ply_count, redesign most played openings with filter support, dedicated table UI, minimap popover, SQL-side WDL aggregation, top 10 (completed 2026-03-28)
-- [ ] **Phase 38: Opening Statistics & Bookmark Suggestions Rework** — Reorder stats sections, use most-played openings as default chart data, rework bookmark suggestions, add chart-enable toggle, redesign bookmark card layout
+- [x] **Phase 38: Opening Statistics & Bookmark Suggestions Rework** — Reorder stats sections, use most-played openings as default chart data, rework bookmark suggestions, add chart-enable toggle, redesign bookmark card layout (completed 2026-03-29)
 
 ## Phase Details
 
@@ -106,8 +106,8 @@
 **UI hint**: yes
 
 Plans:
-- [ ] 38-01-PLAN.md — Backend full_hash addition, section reordering, default chart data from most-played openings
-- [ ] 38-02-PLAN.md — Suggestions rework, chart-enable toggle, bookmark card redesign, dead code cleanup, visual verification
+- [x] 38-01-PLAN.md — Backend full_hash addition, section reordering, default chart data from most-played openings
+- [x] 38-02-PLAN.md — Suggestions rework, chart-enable toggle, bookmark card redesign, dead code cleanup, visual verification
 
 ### Phase 37: Openings Reference Table & Most Played Openings Redesign
 **Goal**: Create an openings reference table from the TSV dataset, then redesign the Most Played Openings feature with filter support, dedicated table UI, opening PGN/FEN display, minimap popover, and SQL-side WDL aggregation
@@ -215,7 +215,7 @@ Plans:
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
 | 37. Openings Reference Table & Redesign | v1.6 | 3/3 | Complete   | 2026-03-28 |
-| 38. Opening Statistics & Bookmark Rework | v1.6 | 0/2 | Planned    |  |
+| 38. Opening Statistics & Bookmark Rework | v1.6 | 2/2 | Complete   | 2026-03-29 |
 
 ## Backlog
 
@@ -223,7 +223,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 0/2 plans executed
+**Plans:** 2/2 plans complete
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -215,7 +215,7 @@ Plans:
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
 | 37. Openings Reference Table & Redesign | v1.6 | 3/3 | Complete   | 2026-03-28 |
-| 38. Opening Statistics & Bookmark Rework | v1.6 | 0/2 | In Progress | — |
+| 38. Opening Statistics & Bookmark Rework | v1.6 | 0/2 | Planned    |  |
 
 ## Backlog
 
@@ -223,7 +223,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 3/3 plans complete
+**Plans:** 0/2 plans executed
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,7 +8,7 @@
 - ✅ **v1.3 Project Launch** — Phases 20-23 (shipped 2026-03-22)
 - ✅ **v1.4 Improvements** — Phase 24 (shipped 2026-03-22)
 - ✅ **v1.5 Game Statistics & Endgame Analysis** — Phases 26-33 (shipped 2026-03-28)
-- 🚧 **v1.6 UI Polish & Improvements** — Phases 34-37 (in progress)
+- 🚧 **v1.6 UI Polish & Improvements** — Phases 34-38 (in progress)
 
 ## Phases
 
@@ -87,8 +87,27 @@
 - [x] **Phase 35: WDL Chart Refactoring** — Create shared WDL chart component based on endgame charts, replace all inconsistent WDL charts (custom and Recharts), clean up unused code (completed 2026-03-28)
 - [x] **Phase 36: Most Played Openings** — Add "Most Played Openings" sections (White/Black) to Opening Statistics subtab with top 5 openings as WDL charts, ECO codes, minimum 10 games threshold (completed 2026-03-28)
 - [x] **Phase 37: Openings Reference Table & Most Played Openings Redesign** — Create openings DB table from TSV dataset with PGN/FEN/ply_count, redesign most played openings with filter support, dedicated table UI, minimap popover, SQL-side WDL aggregation, top 10 (completed 2026-03-28)
+- [ ] **Phase 38: Opening Statistics & Bookmark Suggestions Rework** — Reorder stats sections, use most-played openings as default chart data, rework bookmark suggestions, add chart-enable toggle, redesign bookmark card layout
 
 ## Phase Details
+
+### Phase 38: Opening Statistics & Bookmark Suggestions Rework
+**Goal**: Reorder Opening Statistics sections, use top most-played openings as default chart data when no bookmarks exist, rework bookmark suggestion system using most-played openings data, add chart-enable toggle to bookmarks, redesign bookmark card layout
+**Depends on**: Phase 37
+**Requirements**: STAT-01, STAT-02, STAT-03, STAT-04, STAT-05, STAT-06
+**Success Criteria** (what must be TRUE):
+  1. Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played White, Most Played Black
+  2. When no bookmarks exist, charts show data from top 3 most-played openings per color
+  3. Bookmark suggestions derive from most-played openings, skip already-bookmarked positions
+  4. Each bookmark card has a chart-enable toggle (localStorage-persisted) controlling chart inclusion
+  5. Bookmark card layout: bigger minimap (72px), button row (toggle, load, delete) below piece filter
+  6. Position Bookmarks popover explains Piece filter and chart-enable toggle
+**Plans**: 2 plans
+**UI hint**: yes
+
+Plans:
+- [ ] 38-01-PLAN.md — Backend full_hash addition, section reordering, default chart data from most-played openings
+- [ ] 38-02-PLAN.md — Suggestions rework, chart-enable toggle, bookmark card redesign, dead code cleanup, visual verification
 
 ### Phase 37: Openings Reference Table & Most Played Openings Redesign
 **Goal**: Create an openings reference table from the TSV dataset, then redesign the Most Played Openings feature with filter support, dedicated table UI, opening PGN/FEN display, minimap popover, and SQL-side WDL aggregation
@@ -196,6 +215,7 @@ Plans:
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
 | 37. Openings Reference Table & Redesign | v1.6 | 3/3 | Complete   | 2026-03-28 |
+| 38. Opening Statistics & Bookmark Rework | v1.6 | 0/2 | In Progress | — |
 
 ## Backlog
 
@@ -234,4 +254,3 @@ Plans:
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)
-

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -215,7 +215,7 @@ Plans:
 | 35. WDL Chart Refactoring | v1.6 | 2/2 | Complete   | 2026-03-28 |
 | 36. Most Played Openings | v1.6 | 1/1 | Complete    | 2026-03-28 |
 | 37. Openings Reference Table & Redesign | v1.6 | 3/3 | Complete   | 2026-03-28 |
-| 38. Opening Statistics & Bookmark Rework | v1.6 | 2/2 | Complete   | 2026-03-29 |
+| 38. Opening Statistics & Bookmark Rework | v1.6 | 2/2 | Complete    | 2026-03-29 |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,7 +3,7 @@ gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
 status: verifying
-last_updated: "2026-03-29T09:41:11.100Z"
+last_updated: "2026-03-29T11:56:09.323Z"
 last_activity: 2026-03-29
 progress:
   total_phases: 9
@@ -16,8 +16,8 @@ progress:
 
 ## Current Position
 
-Phase: 38 (opening-statistics-bookmark-suggestions-rework) — EXECUTING
-Plan: 2 of 2
+Phase: 999.1
+Plan: Not started
 Status: Phase complete — ready for verification
 Last activity: 2026-03-29
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: executing
-last_updated: "2026-03-29T09:31:25.729Z"
+status: verifying
+last_updated: "2026-03-29T09:41:11.100Z"
 last_activity: 2026-03-29
 progress:
   total_phases: 9
-  completed_phases: 4
+  completed_phases: 5
   total_plans: 10
-  completed_plans: 8
+  completed_plans: 10
 ---
 
 # Project State: FlawChess
@@ -18,7 +18,7 @@ progress:
 
 Phase: 38 (opening-statistics-bookmark-suggestions-rework) — EXECUTING
 Plan: 2 of 2
-Status: Ready to execute
+Status: Phase complete — ready for verification
 Last activity: 2026-03-29
 
 ## Project Reference
@@ -89,6 +89,8 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 38-01]: full_hash computed server-side from FEN using python-chess Board + compute_hashes — avoids duplicate Zobrist logic on frontend
 - [Phase 38-01]: DEFAULT_CHART_LIMIT = 3 openings per color as default chart data when no bookmarks
 - [Phase 38-01]: Synthetic bookmark IDs use negative integers to avoid collision with real bookmark IDs
+- [Phase 38]: SuggestionsModal uses mostPlayedData prop directly — no backend suggestions endpoint call
+- [Phase 38]: chartToggleVersion state counter forces chartEnabledMap useMemo recompute without storing toggle state in React state
 
 ### Critical v1.5 Constraints
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.6
 milestone_name: UI Polish & Improvements
-status: verifying
-last_updated: "2026-03-28T19:59:11.755Z"
-last_activity: 2026-03-28
+status: executing
+last_updated: "2026-03-29T09:31:25.729Z"
+last_activity: 2026-03-29
 progress:
-  total_phases: 6
+  total_phases: 9
   completed_phases: 4
-  total_plans: 8
+  total_plans: 10
   completed_plans: 8
 ---
 
@@ -16,10 +16,10 @@ progress:
 
 ## Current Position
 
-Phase: 999.1
-Plan: Not started
-Status: Phase complete — ready for verification
-Last activity: 2026-03-28
+Phase: 38 (opening-statistics-bookmark-suggestions-rework) — EXECUTING
+Plan: 2 of 2
+Status: Ready to execute
+Last activity: 2026-03-29
 
 ## Project Reference
 
@@ -86,6 +86,9 @@ Current focus: v1.6 UI Polish & Improvements
 - [Phase 37-02]: TOP_OPENINGS_LIMIT raised from 5 to 10; MIN_PLY_WHITE=1, MIN_PLY_BLACK=2
 - [Phase 37-03]: arePiecesDraggable not a valid prop in react-chessboard v5 — static minimap board achieved by omitting onPieceDrop/onSquareClick handlers
 - [Phase 37-03]: MostPlayedOpeningsTable replaces WDLChartRow in statisticsContent; filters from debouncedFilters now passed to useMostPlayedOpenings so Statistics tab openings react to filter changes
+- [Phase 38-01]: full_hash computed server-side from FEN using python-chess Board + compute_hashes — avoids duplicate Zobrist logic on frontend
+- [Phase 38-01]: DEFAULT_CHART_LIMIT = 3 openings per color as default chart data when no bookmarks
+- [Phase 38-01]: Synthetic bookmark IDs use negative integers to avoid collision with real bookmark IDs
 
 ### Critical v1.5 Constraints
 
@@ -111,6 +114,7 @@ Current focus: v1.6 UI Polish & Improvements
 - Phase 35 added: WDL Chart Refactoring — shared WDL chart component, replace all inconsistent implementations
 - Phase 36 added: Most Played Openings — top 5 openings by color as WDL charts in Opening Statistics subtab
 - Phase 37 added: Openings Reference Table & Most Played Openings Redesign — openings DB table from TSV, SQL-side WDL, filters, dedicated table UI, minimap popover
+- Phase 38 added: Opening Statistics & Bookmark Suggestions Rework — reorder stats sections, most-played openings as default chart data, rework bookmark suggestions, chart-enable toggle, bookmark card layout redesign
 
 ### Blockers/Concerns
 

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-PLAN.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-PLAN.md
@@ -1,0 +1,336 @@
+---
+phase: 38-opening-statistics-bookmark-suggestions-rework
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - app/schemas/stats.py
+  - app/services/stats_service.py
+  - frontend/src/types/stats.ts
+  - frontend/src/pages/Openings.tsx
+  - tests/test_stats_router.py
+autonomous: true
+requirements: [STAT-01, STAT-02]
+must_haves:
+  truths:
+    - "OpeningWDL backend response includes full_hash field"
+    - "Statistics tab shows Results by Opening first, then Win Rate Over Time, then Most Played White, then Most Played Black"
+    - "When user has no bookmarks, Results by Opening and Win Rate Over Time show data from top 3 most-played openings per color"
+    - "When user has bookmarks, Results by Opening and Win Rate Over Time show only bookmark data (no most-played defaults)"
+  artifacts:
+    - path: "app/schemas/stats.py"
+      provides: "full_hash field on OpeningWDL"
+      contains: "full_hash: str"
+    - path: "app/services/stats_service.py"
+      provides: "full_hash computation in rows_to_openings"
+      contains: "compute_hashes"
+    - path: "frontend/src/types/stats.ts"
+      provides: "full_hash field on OpeningWDL TS interface"
+      contains: "full_hash: string"
+    - path: "frontend/src/pages/Openings.tsx"
+      provides: "Reordered statisticsContent + default chart data logic"
+      contains: "DEFAULT_CHART_LIMIT"
+  key_links:
+    - from: "app/services/stats_service.py"
+      to: "app/services/zobrist.py"
+      via: "compute_hashes import"
+      pattern: "from app\\.services\\.zobrist import compute_hashes"
+    - from: "frontend/src/pages/Openings.tsx"
+      to: "frontend/src/types/stats.ts"
+      via: "OpeningWDL.full_hash for synthetic bookmarks"
+      pattern: "full_hash"
+---
+
+<objective>
+Add `full_hash` to the most-played openings backend response, reorder the Statistics tab sections, and implement default chart data from most-played openings when no bookmarks exist.
+
+Purpose: Enables the Statistics tab to show meaningful WDL and time-series charts even without bookmarks, using the user's most-played openings as default data. The `full_hash` field is the critical backend addition that makes synthetic bookmark construction possible.
+
+Output: Backend returns `full_hash` in `OpeningWDL`, Statistics tab sections reordered, charts populated from most-played data when no bookmarks.
+</objective>
+
+<execution_context>
+@/home/aimfeld/.claude/get-shit-done/workflows/execute-plan.md
+@/home/aimfeld/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-CONTEXT.md
+@.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-RESEARCH.md
+
+<interfaces>
+<!-- Key types and contracts the executor needs -->
+
+From app/schemas/stats.py (current — full_hash must be ADDED):
+```python
+class OpeningWDL(BaseModel):
+    opening_eco: str
+    opening_name: str
+    label: str
+    pgn: str
+    fen: str
+    wins: int
+    draws: int
+    losses: int
+    total: int
+    win_pct: float
+    draw_pct: float
+    loss_pct: float
+```
+
+From app/services/stats_service.py (rows_to_openings, line 212):
+```python
+def rows_to_openings(rows: list[tuple]) -> list[OpeningWDL]:
+    openings = []
+    for eco, name, pgn, fen, total, wins, draws, losses in rows:
+        # ... builds OpeningWDL from tuple
+```
+
+From app/services/zobrist.py:
+```python
+def compute_hashes(board: chess.Board) -> tuple[int, int, int]:
+    # Returns (white_hash, black_hash, full_hash)
+```
+
+From frontend/src/types/stats.ts (current):
+```typescript
+export interface OpeningWDL {
+  opening_eco: string; opening_name: string; label: string;
+  pgn: string; fen: string;
+  wins: number; draws: number; losses: number; total: number;
+  win_pct: number; draw_pct: number; loss_pct: number;
+}
+export interface MostPlayedOpeningsResponse {
+  white: OpeningWDL[]; black: OpeningWDL[];
+}
+```
+
+From frontend/src/types/position_bookmarks.ts:
+```typescript
+export interface TimeSeriesBookmarkParam {
+  bookmark_id: number;
+  target_hash: string;
+  match_side: 'white' | 'black' | 'full';
+  color: 'white' | 'black' | null;
+}
+export interface TimeSeriesRequest {
+  bookmarks: TimeSeriesBookmarkParam[];
+  time_control?: ('bullet' | 'blitz' | 'rapid' | 'classical')[] | null;
+  platform?: ('chess.com' | 'lichess')[] | null;
+  rated?: boolean | null;
+  opponent_type?: 'human' | 'bot' | 'both';
+  recency?: 'week' | 'month' | '3months' | '6months' | 'year' | 'all' | null;
+}
+```
+
+From frontend/src/types/position_bookmarks.ts:
+```typescript
+export interface PositionBookmarkResponse {
+  id: number; label: string; target_hash: string; fen: string;
+  moves: string[]; color: 'white' | 'black' | null;
+  match_side: MatchSide; is_flipped: boolean; sort_order: number;
+}
+```
+
+From frontend/src/components/charts/WinRateChart.tsx:
+```typescript
+interface WinRateChartProps {
+  bookmarks: PositionBookmarkResponse[];
+  series: BookmarkTimeSeries[];
+}
+```
+
+statisticsContent current order (Openings.tsx lines 523-652):
+1. White: Most Played Openings
+2. Black: Most Played Openings
+3. [empty state OR Results by Opening + Win Rate Over Time]
+
+Target order:
+1. Results by Opening
+2. Win Rate Over Time
+3. Most Played Openings as White
+4. Most Played Openings as Black
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add full_hash to OpeningWDL backend response</name>
+  <files>app/schemas/stats.py, app/services/stats_service.py, frontend/src/types/stats.ts, tests/test_stats_router.py</files>
+  <read_first>
+    - app/schemas/stats.py
+    - app/services/stats_service.py (lines 190-242)
+    - app/services/zobrist.py (line 58, compute_hashes signature)
+    - frontend/src/types/stats.ts
+    - tests/test_stats_router.py (lines 261-340, most_played tests)
+  </read_first>
+  <action>
+    **Backend schema** (`app/schemas/stats.py`):
+    Add `full_hash: str` field to `OpeningWDL` class, after the `fen` field. The field holds the string representation of the 64-bit Zobrist full hash for the opening position.
+
+    **Backend service** (`app/services/stats_service.py`):
+    1. Add import at top: `import chess as chess_lib` and `from app.services.zobrist import compute_hashes`
+    2. In `rows_to_openings()`, after unpacking each tuple row, compute the full hash:
+       ```python
+       board = chess_lib.Board(fen)
+       _, _, full_hash = compute_hashes(board)
+       ```
+    3. Pass `full_hash=str(full_hash)` to the `OpeningWDL(...)` constructor.
+
+    **Frontend type** (`frontend/src/types/stats.ts`):
+    Add `full_hash: string;` to the `OpeningWDL` interface, after the `fen` field.
+
+    **Test** (`tests/test_stats_router.py`):
+    In the `test_most_played_openings_includes_pgn_fen` test method (around line 294), add an assertion that each opening in the response has a `full_hash` key that is a non-empty string:
+    ```python
+    assert "full_hash" in opening
+    assert isinstance(opening["full_hash"], str)
+    assert len(opening["full_hash"]) > 0
+    ```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run pytest tests/test_stats_router.py -x -k most_played</automated>
+  </verify>
+  <acceptance_criteria>
+    - app/schemas/stats.py contains `full_hash: str`
+    - app/services/stats_service.py contains `from app.services.zobrist import compute_hashes`
+    - app/services/stats_service.py contains `full_hash=str(full_hash)` in OpeningWDL constructor
+    - frontend/src/types/stats.ts OpeningWDL interface contains `full_hash: string`
+    - tests/test_stats_router.py contains assertion for `full_hash` in most_played test
+    - `uv run pytest tests/test_stats_router.py -x -k most_played` passes
+  </acceptance_criteria>
+  <done>OpeningWDL response includes full_hash field computed server-side, verified by passing test</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Reorder Statistics sections and implement default chart data from most-played openings</name>
+  <files>frontend/src/pages/Openings.tsx</files>
+  <read_first>
+    - frontend/src/pages/Openings.tsx (full file — contains statisticsContent, timeSeriesRequest, wdlStatsMap)
+    - frontend/src/types/stats.ts (OpeningWDL with new full_hash)
+    - frontend/src/types/position_bookmarks.ts (TimeSeriesRequest, TimeSeriesBookmarkParam, PositionBookmarkResponse)
+    - frontend/src/components/charts/WinRateChart.tsx (props: bookmarks + series)
+    - frontend/src/types/api.ts (resolveMatchSide, MatchSide, Color)
+  </read_first>
+  <action>
+    This task modifies `frontend/src/pages/Openings.tsx` to:
+
+    **A. Add DEFAULT_CHART_LIMIT constant** at the top of the file (after `PAGE_SIZE`):
+    ```typescript
+    const DEFAULT_CHART_LIMIT = 3;
+    ```
+
+    **B. Create synthetic bookmark entries from mostPlayedData** (inside the component, after `mostPlayedData` fetch):
+    ```typescript
+    // When no bookmarks exist, derive synthetic entries from most-played openings
+    const defaultChartEntries: PositionBookmarkResponse[] = useMemo(() => {
+      if (bookmarks.length > 0 || !mostPlayedData) return [];
+      const white = mostPlayedData.white.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+        id: -(i + 1),
+        label: o.label,
+        target_hash: o.full_hash,
+        fen: o.fen,
+        moves: [],
+        color: 'white' as const,
+        match_side: 'both' as MatchSide,
+        is_flipped: false,
+        sort_order: i,
+      }));
+      const black = mostPlayedData.black.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+        id: -(DEFAULT_CHART_LIMIT + i + 1),
+        label: o.label,
+        target_hash: o.full_hash,
+        fen: o.fen,
+        moves: [],
+        color: 'black' as const,
+        match_side: 'both' as MatchSide,
+        is_flipped: false,
+        sort_order: DEFAULT_CHART_LIMIT + i,
+      }));
+      return [...white, ...black];
+    }, [bookmarks, mostPlayedData]);
+    ```
+
+    **C. Compute chartBookmarks** — the entries used for charts (real bookmarks if any, else defaults):
+    ```typescript
+    const chartBookmarks = bookmarks.length > 0 ? bookmarks : defaultChartEntries;
+    ```
+
+    **D. Update timeSeriesRequest** to use `chartBookmarks` instead of `bookmarks`:
+    Change the useMemo for `timeSeriesRequest` from:
+    ```typescript
+    if (bookmarks.length === 0) return null;
+    ```
+    to:
+    ```typescript
+    if (chartBookmarks.length === 0) return null;
+    ```
+    And replace `bookmarks.map(...)` with `chartBookmarks.map(...)` in the request builder. For default entries (color is white/black), use `resolveMatchSide('both', (b.color ?? 'white') as Color)` — same as existing logic.
+
+    Add `chartBookmarks` to the useMemo dependency array.
+
+    **E. Update wdlStatsMap** — no changes needed, it already keys by `s.bookmark_id` from tsData.
+
+    **F. Reorder statisticsContent** — restructure the `statisticsContent` const to this order:
+
+    1. **Results by Opening** (charcoal container) — render when `chartBookmarks.length > 0 && tsData`:
+       - Use `chartBookmarks` instead of `bookmarks` for the rows
+       - Filter/map logic stays the same, just replace `bookmarks` with `chartBookmarks`
+       - Show loading state ("Loading chart data...") when `chartBookmarks.length > 0 && !tsData`
+
+    2. **Win Rate Over Time** (charcoal container) — render when `tsData`:
+       - Pass `chartBookmarks` instead of `bookmarks` to `WinRateChart`
+       - `<WinRateChart bookmarks={chartBookmarks} series={tsData.series} />`
+
+    3. **Most Played Openings as White** — rename the h2 heading from "White: Most Played Openings" to "Most Played Openings as White". Keep the white color circle. Keep InfoPopover and MostPlayedOpeningsTable unchanged.
+
+    4. **Most Played Openings as Black** — rename the h2 heading from "Black: Most Played Openings" to "Most Played Openings as Black". Keep the black color circle.
+
+    **G. Remove the old empty state** — delete the `bookmarks.length === 0 ? (... "No bookmarks yet" ...)` block entirely. The charts now always show data (from bookmarks or defaults).
+
+    **H. Handle loading state** — when `chartBookmarks.length > 0` but `tsData` is still undefined (loading), show "Loading chart data..." placeholder instead of nothing. This handles the race condition where mostPlayedData is loaded but time-series is still fetching.
+
+    **I. Verify statisticsContent is used in both desktop and mobile layouts** — `statisticsContent` is a single `const` used in both the desktop `<TabsContent value="compare">` and the mobile layout's same `<TabsContent>`. A single edit covers both layouts (per CLAUDE.md mobile variant rule).
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build</automated>
+  </verify>
+  <acceptance_criteria>
+    - Openings.tsx contains `const DEFAULT_CHART_LIMIT = 3`
+    - Openings.tsx contains `defaultChartEntries` useMemo that slices mostPlayedData
+    - Openings.tsx contains `chartBookmarks` derived from bookmarks or defaultChartEntries
+    - Openings.tsx timeSeriesRequest uses `chartBookmarks` not raw `bookmarks`
+    - statisticsContent renders Results by Opening BEFORE Most Played sections
+    - statisticsContent renders Win Rate Over Time BEFORE Most Played sections
+    - h2 heading contains "Most Played Openings as White" (not "White: Most Played Openings")
+    - h2 heading contains "Most Played Openings as Black" (not "Black: Most Played Openings")
+    - No "No bookmarks yet" empty state in statisticsContent
+    - `npm run build` succeeds with no TypeScript errors
+  </acceptance_criteria>
+  <done>Statistics tab sections reordered per spec, charts show most-played opening data when no bookmarks exist, loading states handled</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run pytest tests/test_stats_router.py -x -k most_played` — full_hash in response
+- `cd frontend && npm run build` — no TS errors
+- `uv run pytest -x` — full backend suite passes
+</verification>
+
+<success_criteria>
+1. Backend most-played openings endpoint returns `full_hash` field in each `OpeningWDL` entry
+2. Statistics tab sections appear in order: Results by Opening, Win Rate Over Time, Most Played White, Most Played Black
+3. When user has no bookmarks, charts are populated from top 3 white + top 3 black most-played openings
+4. When user has bookmarks, charts use only bookmark data (existing behavior preserved)
+5. Both frontend build and backend tests pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-SUMMARY.md`
+</output>

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-SUMMARY.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 38-opening-statistics-bookmark-suggestions-rework
+plan: 01
+subsystem: ui, api
+tags: [react, fastapi, zobrist, typescript, pydantic, chess]
+
+# Dependency graph
+requires:
+  - phase: 37-openings-reference-table-redesign
+    provides: MostPlayedOpeningsTable component, most-played openings endpoint, SQL-side WDL
+  - phase: 36-most-played-openings
+    provides: GET /stats/most-played-openings endpoint, useMostPlayedOpenings hook
+provides:
+  - full_hash field on OpeningWDL backend response (enables synthetic bookmark construction)
+  - Statistics tab sections reordered: Results by Opening, Win Rate Over Time, Most Played White, Most Played Black
+  - Default chart data from top 3 most-played openings per color when user has no bookmarks
+affects: 38-02
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - Synthetic PositionBookmarkResponse entries from OpeningWDL for chart reuse without real bookmarks
+    - chartBookmarks pattern: real bookmarks or most-played defaults depending on bookmark count
+
+key-files:
+  created: []
+  modified:
+    - app/schemas/stats.py
+    - app/services/stats_service.py
+    - frontend/src/types/stats.ts
+    - frontend/src/pages/Openings.tsx
+    - tests/test_stats_router.py
+
+key-decisions:
+  - "full_hash computed server-side from FEN using python-chess Board + compute_hashes — avoids duplicate Zobrist logic on frontend"
+  - "DEFAULT_CHART_LIMIT = 3 openings per color as default chart data — balances chart readability and data richness"
+  - "chartBookmarks = bookmarks.length > 0 ? bookmarks : defaultChartEntries — clean fallback with no empty state message"
+  - "Synthetic bookmark IDs use negative integers (-(i+1)) to avoid collision with real bookmark IDs"
+
+patterns-established:
+  - "Pattern: synthetic PositionBookmarkResponse from OpeningWDL — construct entries with negative IDs, full_hash as target_hash, match_side='both'"
+
+requirements-completed: [STAT-01, STAT-02]
+
+# Metrics
+duration: 12min
+completed: 2026-03-29
+---
+
+# Phase 38 Plan 01: Opening Statistics & Bookmark Suggestions Rework Summary
+
+**`full_hash` added to OpeningWDL backend response; Statistics tab reordered with charts populated from top 3 most-played openings per color when no bookmarks exist**
+
+## Performance
+
+- **Duration:** 12 min
+- **Started:** 2026-03-29T09:30:00Z
+- **Completed:** 2026-03-29T09:42:00Z
+- **Tasks:** 2
+- **Files modified:** 5
+
+## Accomplishments
+- Backend `OpeningWDL` Pydantic schema and TypeScript interface both include `full_hash: str` field computed from the FEN via `compute_hashes`
+- Statistics tab sections reordered to: Results by Opening, Win Rate Over Time, Most Played as White, Most Played as Black
+- When user has no bookmarks, top 3 white + top 3 black most-played openings become synthetic `PositionBookmarkResponse` entries driving both the WDL bar chart and Win Rate Over Time chart
+- "No bookmarks yet" empty state removed — charts now always show data (from bookmarks or defaults)
+- All 471 backend tests pass, TypeScript build succeeds
+
+## Task Commits
+
+1. **Task 1: Add full_hash to OpeningWDL backend response** - `dced612` (feat)
+2. **Task 2: Reorder Statistics sections and implement default chart data** - `00d09f5` (feat)
+
+## Files Created/Modified
+- `app/schemas/stats.py` - Added `full_hash: str` field to `OpeningWDL` Pydantic model
+- `app/services/stats_service.py` - Added `chess_lib` and `compute_hashes` imports; computes full_hash from FEN in `rows_to_openings()`
+- `frontend/src/types/stats.ts` - Added `full_hash: string` to `OpeningWDL` TypeScript interface
+- `frontend/src/pages/Openings.tsx` - Added `DEFAULT_CHART_LIMIT`, `defaultChartEntries`, `chartBookmarks`; updated `timeSeriesRequest`; reordered `statisticsContent`; renamed section headings
+- `tests/test_stats_router.py` - Added `full_hash` field assertions to `test_most_played_openings_includes_pgn_fen`
+
+## Decisions Made
+- `full_hash` computed server-side from FEN using `chess.Board(fen)` + `compute_hashes()` — avoids any Zobrist logic duplication on the frontend
+- `DEFAULT_CHART_LIMIT = 3` openings per color as default chart data — balances readability with coverage
+- Synthetic bookmark IDs use negative integers `-(i+1)` to avoid collision with real bookmark IDs from the database
+- `chartBookmarks` pattern: clean conditional with no empty state — charts always render something meaningful
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- `full_hash` on `OpeningWDL` is now available for Plan 02 (bookmark suggestions rework), which uses it to construct suggestion entries
+- Statistics tab section order and default chart data behavior are in place
+
+---
+*Phase: 38-opening-statistics-bookmark-suggestions-rework*
+*Completed: 2026-03-29*

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-PLAN.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-PLAN.md
@@ -1,0 +1,438 @@
+---
+phase: 38-opening-statistics-bookmark-suggestions-rework
+plan: 02
+type: execute
+wave: 2
+depends_on: ["38-01"]
+files_modified:
+  - frontend/src/components/position-bookmarks/SuggestionsModal.tsx
+  - frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+  - frontend/src/hooks/usePositionBookmarks.ts
+  - frontend/src/api/client.ts
+  - frontend/src/types/position_bookmarks.ts
+  - frontend/src/pages/Openings.tsx
+autonomous: false
+requirements: [STAT-03, STAT-04, STAT-05, STAT-06]
+must_haves:
+  truths:
+    - "Bookmark suggestions are derived from most-played openings data, not from backend suggestions endpoint"
+    - "Already-bookmarked openings are skipped in suggestions, showing the next most-played opening"
+    - "Each bookmark card has a chart-enable toggle that persists across page reload via localStorage"
+    - "Bookmark card layout has a bigger minimap and buttons in a new row below the piece filter"
+    - "Position Bookmarks popover explains the Piece filter and chart-enable toggle"
+    - "Results by Opening and Win Rate Over Time charts respect the chart-enable toggle"
+  artifacts:
+    - path: "frontend/src/components/position-bookmarks/SuggestionsModal.tsx"
+      provides: "Reworked SuggestionsModal using mostPlayedData prop"
+      contains: "mostPlayedData"
+    - path: "frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx"
+      provides: "Chart-enable toggle + redesigned layout"
+      contains: "bookmark-chart-toggle"
+    - path: "frontend/src/pages/Openings.tsx"
+      provides: "Chart-enable filtering + updated popover text"
+      contains: "chartEnabledMap"
+  key_links:
+    - from: "frontend/src/pages/Openings.tsx"
+      to: "frontend/src/components/position-bookmarks/SuggestionsModal.tsx"
+      via: "mostPlayedData and bookmarks props"
+      pattern: "mostPlayedData.*bookmarks"
+    - from: "frontend/src/pages/Openings.tsx"
+      to: "frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx"
+      via: "onChartEnabledChange callback"
+      pattern: "chartEnabled|onChartEnabledChange"
+---
+
+<objective>
+Rework bookmark suggestions to use most-played openings data, add chart-enable toggle to bookmark cards, redesign bookmark card layout, and update popover text.
+
+Purpose: Replaces the complex backend-driven suggestion system with a simpler client-side approach using already-fetched most-played data. Gives users control over which bookmarks appear in charts. Improves bookmark card UX with better layout.
+
+Output: Reworked SuggestionsModal, redesigned PositionBookmarkCard with toggle, cleaned up dead suggestion code, updated popover.
+</objective>
+
+<execution_context>
+@/home/aimfeld/.claude/get-shit-done/workflows/execute-plan.md
+@/home/aimfeld/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-CONTEXT.md
+@.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-RESEARCH.md
+@.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-01-SUMMARY.md
+
+<interfaces>
+<!-- Contracts from Plan 38-01 that this plan depends on -->
+
+From frontend/src/types/stats.ts (updated in 38-01):
+```typescript
+export interface OpeningWDL {
+  opening_eco: string; opening_name: string; label: string;
+  pgn: string; fen: string; full_hash: string;
+  wins: number; draws: number; losses: number; total: number;
+  win_pct: number; draw_pct: number; loss_pct: number;
+}
+export interface MostPlayedOpeningsResponse {
+  white: OpeningWDL[]; black: OpeningWDL[];
+}
+```
+
+From frontend/src/pages/Openings.tsx (updated in 38-01):
+- `mostPlayedData` is fetched via `useMostPlayedOpenings` hook
+- `chartBookmarks` is the array used for chart rendering
+- `defaultChartEntries` is derived from mostPlayedData when no bookmarks
+- `timeSeriesRequest` uses `chartBookmarks`
+
+From frontend/src/types/position_bookmarks.ts:
+```typescript
+export interface PositionBookmarkResponse {
+  id: number; label: string; target_hash: string; fen: string;
+  moves: string[]; color: 'white' | 'black' | null;
+  match_side: MatchSide; is_flipped: boolean; sort_order: number;
+}
+export interface PositionBookmarkCreate {
+  label: string; target_hash: string; fen: string; moves: string[];
+  color: 'white' | 'black' | null;
+  match_side: 'mine' | 'opponent' | 'both'; is_flipped: boolean;
+}
+```
+
+From frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx (current):
+- Layout: [drag handle] [mini-board 60px] [label + piece filter] [load + delete stacked]
+- Props: `{ bookmark: PositionBookmarkResponse; onLoad: (bookmark) => void }`
+
+From frontend/src/components/position-bookmarks/SuggestionsModal.tsx (current):
+- Uses `usePositionSuggestions()` hook to fetch from backend API
+- Props: `{ open: boolean; onOpenChange: (open: boolean) => void }`
+
+From frontend/src/hooks/usePositionBookmarks.ts:
+```typescript
+export function usePositionSuggestions() { /* queries backend */ }
+export function useDeletePositionBookmark() {
+  // onMutate optimistically removes from cache
+  // onSettled invalidates ['position-bookmarks']
+}
+```
+
+From frontend/src/api/client.ts:
+```typescript
+positionBookmarksApi = {
+  // ...
+  getSuggestions: () => apiClient.get<SuggestionsResponse>('/position-bookmarks/suggestions').then(r => r.data),
+};
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rework SuggestionsModal, add chart-enable toggle to bookmark cards, redesign card layout</name>
+  <files>
+    frontend/src/components/position-bookmarks/SuggestionsModal.tsx,
+    frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx,
+    frontend/src/components/position-bookmarks/PositionBookmarkList.tsx,
+    frontend/src/pages/Openings.tsx
+  </files>
+  <read_first>
+    - frontend/src/components/position-bookmarks/SuggestionsModal.tsx (full file — being rewritten)
+    - frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx (full file — being redesigned)
+    - frontend/src/components/position-bookmarks/PositionBookmarkList.tsx (passes props to cards)
+    - frontend/src/pages/Openings.tsx (full file — passes props to SuggestionsModal, has popover text, has chartBookmarks logic)
+    - frontend/src/types/stats.ts (OpeningWDL with full_hash)
+    - frontend/src/types/position_bookmarks.ts (PositionBookmarkResponse, PositionBookmarkCreate)
+    - frontend/src/hooks/usePositionBookmarks.ts (useDeletePositionBookmark for cleanup)
+    - frontend/src/api/client.ts (positionBookmarksApi.create)
+    - frontend/src/lib/theme.ts (check for existing toggle/switch color constants)
+    - frontend/src/components/ui/switch.tsx (if it exists, otherwise check for toggle components)
+  </read_first>
+  <action>
+    This task makes four coordinated changes:
+
+    **A. Rework SuggestionsModal** (`SuggestionsModal.tsx`):
+
+    1. Change the props interface to:
+       ```typescript
+       interface SuggestionsModalProps {
+         open: boolean;
+         onOpenChange: (open: boolean) => void;
+         mostPlayedData: MostPlayedOpeningsResponse | undefined;
+         bookmarks: PositionBookmarkResponse[];
+       }
+       ```
+    2. Remove the `usePositionSuggestions()` hook import and usage entirely.
+    3. Remove the `useEffect` that calls `refetch()` on open.
+    4. Derive suggestions from `mostPlayedData` prop:
+       - For each color (white, black), take up to 10 entries from `mostPlayedData.white` / `mostPlayedData.black`
+       - Filter out entries where `opening.full_hash` matches any bookmark's `target_hash` (where `bookmark.match_side === 'both'`)
+       - Take the first 5 remaining entries per color
+       - If all 10 per color are already bookmarked, show fallback message: "All your most-played openings are already bookmarked. Try creating custom bookmarks on the board and experimenting with the Piece filter."
+    5. Each suggestion card renders similarly to current but uses `OpeningWDL` data:
+       - `MiniBoard` with `fen=opening.fen`, `flipped=(color === 'black')`, `size={100}`
+       - Label: `opening.label` (which is "Name (ECO)")
+       - Badge: `opening.total` games count
+    6. On save, create bookmark via `positionBookmarksApi.create()`:
+       ```typescript
+       await positionBookmarksApi.create({
+         label: opening.label,
+         target_hash: opening.full_hash,
+         fen: opening.fen,
+         moves: [],  // opening moves not needed for hash-based matching
+         color: color,  // 'white' or 'black'
+         match_side: 'both',
+         is_flipped: color === 'black',
+       });
+       ```
+    7. Show loading state when `mostPlayedData` is undefined: "Loading suggestions..."
+    8. Keep the existing checkbox-based multi-select save UX pattern.
+    9. Keep all existing `data-testid` attributes: `suggestions-modal`, `suggestion-card-*`, `suggestion-checkbox-*`, `btn-save-suggestions`.
+
+    **B. Redesign PositionBookmarkCard** (`PositionBookmarkCard.tsx`):
+
+    1. Add new props to the `Props` interface:
+       ```typescript
+       interface Props {
+         bookmark: PositionBookmarkResponse;
+         onLoad: (bookmark: PositionBookmarkResponse) => void;
+         chartEnabled: boolean;
+         onChartEnabledChange: (id: number, enabled: boolean) => void;
+       }
+       ```
+    2. Increase MiniBoard size from `size={60}` to `size={72}`.
+    3. Restructure the layout — keep the same outer flex container but reorganize:
+       - Remove the stacked load/delete column on the right
+       - Add a new button row below the piece filter toggle, inside the `flex-1 flex-col` container:
+         ```tsx
+         <div className="flex items-center justify-between mt-1">
+           {/* Chart toggle on left */}
+           <button
+             role="switch"
+             aria-checked={chartEnabled}
+             aria-label="Include in charts"
+             onClick={() => onChartEnabledChange(bookmark.id, !chartEnabled)}
+             className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${chartEnabled ? 'bg-primary' : 'bg-muted'}`}
+             data-testid={`bookmark-chart-toggle-${bookmark.id}`}
+           >
+             <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${chartEnabled ? 'translate-x-4' : 'translate-x-0.5'}`} />
+           </button>
+           {/* Load button in middle */}
+           <Button variant="ghost" size="icon" className="h-7 w-7"
+             onMouseDown={() => { isDirtyRef.current = true; }}
+             onClick={handleLoad}
+             data-testid={`bookmark-btn-load-${bookmark.id}`}
+             aria-label="Load bookmark">
+             <Upload size={15} />
+           </Button>
+           {/* Delete button on right */}
+           <Button variant="ghost" size="icon"
+             className="h-7 w-7 text-muted-foreground hover:text-destructive"
+             onMouseDown={() => { isDirtyRef.current = true; }}
+             onClick={handleDelete}
+             disabled={deleteBookmark.isPending}
+             data-testid={`bookmark-btn-delete-${bookmark.id}`}
+             aria-label={`Delete bookmark: ${bookmark.label}`}>
+             <Trash2 size={15} />
+           </Button>
+         </div>
+         ```
+       Note: Use a custom toggle button (role="switch") rather than importing a Switch component (which doesn't exist in the project). The toggle uses `bg-primary` when enabled and `bg-muted` when disabled — these are Tailwind theme variables, no hardcoded colors.
+
+    **C. Wire chart-enable toggle in Openings.tsx**:
+
+    1. Add localStorage helper functions at the top of the file (after imports):
+       ```typescript
+       function getChartEnabled(bookmarkId: number): boolean {
+         const stored = localStorage.getItem(`bookmark-chart-enabled-${bookmarkId}`);
+         return stored === null ? true : stored === 'true';  // default: enabled
+       }
+       function setChartEnabledStorage(bookmarkId: number, enabled: boolean): void {
+         localStorage.setItem(`bookmark-chart-enabled-${bookmarkId}`, String(enabled));
+       }
+       ```
+
+    2. Add state to force re-render when toggle changes:
+       ```typescript
+       const [chartToggleVersion, setChartToggleVersion] = useState(0);
+       ```
+
+    3. Add `chartEnabledMap` useMemo:
+       ```typescript
+       const chartEnabledMap = useMemo(() => {
+         const map: Record<number, boolean> = {};
+         for (const b of bookmarks) {
+           map[b.id] = getChartEnabled(b.id);
+         }
+         return map;
+         // eslint-disable-next-line react-hooks/exhaustive-deps
+       }, [bookmarks, chartToggleVersion]);
+       ```
+
+    4. Add toggle handler:
+       ```typescript
+       const handleChartEnabledChange = useCallback((id: number, enabled: boolean) => {
+         setChartEnabledStorage(id, enabled);
+         setChartToggleVersion(v => v + 1);
+       }, []);
+       ```
+
+    5. Update `chartBookmarks` to filter by chart-enabled (only when real bookmarks exist):
+       ```typescript
+       const chartBookmarks = bookmarks.length > 0
+         ? bookmarks.filter(b => chartEnabledMap[b.id] !== false)
+         : defaultChartEntries;
+       ```
+
+    6. Clean up localStorage on bookmark delete — in `useDeletePositionBookmark` hook in `usePositionBookmarks.ts`, add to `onMutate`:
+       ```typescript
+       localStorage.removeItem(`bookmark-chart-enabled-${id}`);
+       ```
+
+    7. Pass `mostPlayedData` and `bookmarks` to `SuggestionsModal`:
+       ```tsx
+       <SuggestionsModal
+         open={suggestionsOpen}
+         onOpenChange={setSuggestionsOpen}
+         mostPlayedData={mostPlayedData}
+         bookmarks={bookmarks}
+       />
+       ```
+
+    8. Pass `chartEnabled` and `onChartEnabledChange` through `PositionBookmarkList` to each `PositionBookmarkCard`. Update `PositionBookmarkList` props to accept `chartEnabledMap` and `onChartEnabledChange`, and pass them to each card.
+
+    **D. Update Position Bookmarks popover text** in `Openings.tsx`:
+
+    Find the InfoPopover next to "Position bookmarks" (around line 379) and update its content to:
+    ```tsx
+    <InfoPopover ariaLabel="Position bookmarks info" testId="position-bookmarks-info" side="top">
+      <div className="space-y-2">
+        <p>
+          Save positions as bookmarks to track your openings. Bookmarks appear as entries in the Statistics tab charts, showing your win/draw/loss breakdown and win rate over time for each saved position.
+        </p>
+        <p>
+          Each bookmark has a Piece filter setting (Mine/Opponent/Both) that controls how positions are matched. You can change the Piece filter directly on each bookmark card.
+        </p>
+        <p>
+          Use the chart toggle on each bookmark to include or exclude it from the Results by Opening and Win Rate Over Time charts.
+        </p>
+      </div>
+    </InfoPopover>
+    ```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build</automated>
+  </verify>
+  <acceptance_criteria>
+    - SuggestionsModal.tsx imports MostPlayedOpeningsResponse and PositionBookmarkResponse types
+    - SuggestionsModal.tsx does NOT import usePositionSuggestions
+    - SuggestionsModal.tsx props include `mostPlayedData` and `bookmarks`
+    - SuggestionsModal.tsx filters suggestions by comparing `full_hash` against bookmark `target_hash`
+    - SuggestionsModal.tsx contains fallback message "All your most-played openings are already bookmarked"
+    - PositionBookmarkCard.tsx contains `data-testid={`bookmark-chart-toggle-${bookmark.id}`}`
+    - PositionBookmarkCard.tsx MiniBoard has `size={72}` (not 60)
+    - PositionBookmarkCard.tsx has `chartEnabled` and `onChartEnabledChange` in props
+    - PositionBookmarkCard.tsx button row has chart toggle, load, and delete in a flex justify-between container
+    - Openings.tsx contains `getChartEnabled` and `setChartEnabledStorage` localStorage helpers
+    - Openings.tsx contains `chartEnabledMap` useMemo
+    - Openings.tsx `chartBookmarks` filters by `chartEnabledMap` when bookmarks exist
+    - Openings.tsx SuggestionsModal receives `mostPlayedData` and `bookmarks` props
+    - Openings.tsx Position Bookmarks popover mentions "Piece filter" and "chart toggle"
+    - usePositionBookmarks.ts `useDeletePositionBookmark` onMutate removes localStorage key
+    - `npm run build` succeeds
+  </acceptance_criteria>
+  <done>SuggestionsModal reworked to use mostPlayedData, bookmark cards have chart-enable toggle and redesigned layout, popover updated, dead code removed from hooks</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Remove dead suggestion code from frontend</name>
+  <files>
+    frontend/src/hooks/usePositionBookmarks.ts,
+    frontend/src/api/client.ts,
+    frontend/src/types/position_bookmarks.ts
+  </files>
+  <read_first>
+    - frontend/src/hooks/usePositionBookmarks.ts (usePositionSuggestions function)
+    - frontend/src/api/client.ts (getSuggestions in positionBookmarksApi)
+    - frontend/src/types/position_bookmarks.ts (PositionSuggestion, SuggestionsResponse)
+  </read_first>
+  <action>
+    Remove all dead frontend code related to the old backend suggestions system:
+
+    1. **`frontend/src/hooks/usePositionBookmarks.ts`**: Remove the `usePositionSuggestions` function (lines 93-100). Remove any now-unused imports.
+
+    2. **`frontend/src/api/client.ts`**: Remove `getSuggestions` from `positionBookmarksApi` object. Remove `SuggestionsResponse` from the import statement at the top of the file (it imports from `@/types/position_bookmarks`).
+
+    3. **`frontend/src/types/position_bookmarks.ts`**: Remove the `PositionSuggestion` interface (lines 3-13) and the `SuggestionsResponse` interface (lines 15-17). These types are no longer used anywhere.
+
+    The backend `/position-bookmarks/suggestions` endpoint can remain in place — removing backend code is NOT required for this phase. Only clean up the frontend dead code.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npm run build && npm run lint</automated>
+  </verify>
+  <acceptance_criteria>
+    - usePositionBookmarks.ts does NOT contain `usePositionSuggestions`
+    - client.ts positionBookmarksApi does NOT contain `getSuggestions`
+    - position_bookmarks.ts does NOT contain `PositionSuggestion` interface
+    - position_bookmarks.ts does NOT contain `SuggestionsResponse` interface
+    - `npm run build` succeeds with no errors
+    - `npm run lint` passes
+  </acceptance_criteria>
+  <done>All dead frontend suggestion code removed, no unused imports remain, build and lint pass</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <files>N/A</files>
+  <name>Task 3: Visual verification of all changes</name>
+  <what-built>
+    1. Bookmark suggestions now derive from most-played openings (no backend call)
+    2. Bookmark cards have chart-enable toggle, bigger minimap (72px), and button row below piece filter
+    3. Chart-enable toggle excludes/includes bookmarks from Results by Opening and Win Rate Over Time
+    4. Position Bookmarks popover updated with Piece filter and chart toggle explanations
+    5. Dead suggestion code removed
+  </what-built>
+  <how-to-verify>
+    1. Go to Openings > Statistics tab
+    2. Open Position Bookmarks collapsible in sidebar
+    3. Click "Suggest" — verify suggestions appear from most-played openings, no loading delay from backend call
+    4. If you have bookmarks, verify already-bookmarked openings are skipped in suggestions
+    5. Save a suggested bookmark — verify it appears in the bookmark list
+    6. On each bookmark card, verify: minimap is slightly larger, chart toggle appears on left, load button in middle, delete on right (all in a row below the piece filter)
+    7. Toggle chart-enable off for one bookmark — verify it disappears from Results by Opening and Win Rate Over Time charts
+    8. Toggle it back on — verify it reappears
+    9. Reload the page — verify the toggle state persists
+    10. Read the Position Bookmarks info popover — verify it mentions Piece filter and chart toggle
+    11. Delete a bookmark — verify its toggle state is cleaned up (re-create with same position, toggle should default to on)
+    12. Check on mobile viewport — verify bookmark card layout works on small screens
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe issues to fix</resume-signal>
+  <action>Human visual verification — no automated action needed.</action>
+  <verify>User approves all 12 verification steps above.</verify>
+  <done>User confirms: suggestions work from mostPlayedData, chart toggle functions correctly, bookmark card layout matches spec, popover text is updated.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `cd frontend && npm run build` — no TS errors
+- `cd frontend && npm run lint` — no lint warnings
+- `uv run pytest -x` — backend tests still pass
+- Manual: SuggestionsModal shows most-played-based suggestions
+- Manual: Chart-enable toggle works and persists
+- Manual: Bookmark card layout matches spec
+</verification>
+
+<success_criteria>
+1. SuggestionsModal derives suggestions from mostPlayedData prop, no backend API call
+2. Already-bookmarked openings are filtered out of suggestions
+3. Chart-enable toggle on each bookmark card controls inclusion in Results by Opening and Win Rate Over Time
+4. Toggle state persists via localStorage across page reloads
+5. Bookmark card has bigger minimap (72px) and button row (toggle, load, delete) below piece filter
+6. Position Bookmarks popover explains Piece filter and chart toggle
+7. Dead suggestion code removed from frontend (usePositionSuggestions, getSuggestions, PositionSuggestion type)
+8. Build and lint pass clean
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-SUMMARY.md`
+</output>

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-SUMMARY.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-SUMMARY.md
@@ -1,0 +1,125 @@
+---
+phase: 38-opening-statistics-bookmark-suggestions-rework
+plan: 02
+subsystem: ui
+tags: [react, typescript, localStorage, position-bookmarks, chess]
+
+# Dependency graph
+requires:
+  - phase: 38-01
+    provides: full_hash on OpeningWDL, mostPlayedData in Openings.tsx, defaultChartEntries pattern
+provides:
+  - SuggestionsModal derives suggestions client-side from mostPlayedData (no backend call)
+  - PositionBookmarkCard with chart-enable toggle, 72px minimap, button row below piece filter
+  - chartEnabledMap persisted in localStorage, filters chartBookmarks in Statistics tab
+  - Position Bookmarks popover updated with Piece filter and chart toggle explanations
+  - Dead frontend suggestion code removed (usePositionSuggestions, getSuggestions, PositionSuggestion type)
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - localStorage per-bookmark toggle with version counter to trigger useMemo recompute
+    - Client-side suggestion filtering by comparing full_hash against existing bookmark target_hash
+
+key-files:
+  created: []
+  modified:
+    - frontend/src/components/position-bookmarks/SuggestionsModal.tsx
+    - frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+    - frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
+    - frontend/src/pages/Openings.tsx
+    - frontend/src/pages/Dashboard.tsx
+    - frontend/src/hooks/usePositionBookmarks.ts
+    - frontend/src/api/client.ts
+    - frontend/src/types/position_bookmarks.ts
+
+key-decisions:
+  - "SuggestionsModal uses mostPlayedData prop directly — no backend suggestions endpoint call"
+  - "chartToggleVersion state counter forces chartEnabledMap useMemo recompute without storing toggle state in React state"
+  - "Dashboard.tsx wired with same chart toggle pattern (Rule 3 fix) to satisfy PositionBookmarkList prop contract"
+
+patterns-established:
+  - "Pattern: localStorage version counter — increment counter state to re-trigger useMemo that reads localStorage values"
+
+requirements-completed: [STAT-03, STAT-04, STAT-05, STAT-06]
+
+# Metrics
+duration: 25min
+completed: 2026-03-29
+---
+
+# Phase 38 Plan 02: Opening Statistics & Bookmark Suggestions Rework Summary
+
+**SuggestionsModal reworked to use mostPlayedData client-side; bookmark cards redesigned with chart-enable toggle (72px minimap, button row), toggle state persisted in localStorage**
+
+## Performance
+
+- **Duration:** 25 min
+- **Started:** 2026-03-29T10:00:00Z
+- **Completed:** 2026-03-29T10:25:00Z
+- **Tasks:** 2 completed (Task 3 awaiting human verification)
+- **Files modified:** 8
+
+## Accomplishments
+- SuggestionsModal now derives suggestions from `mostPlayedData` prop, filtering already-bookmarked positions by `full_hash` — no backend API call on open
+- PositionBookmarkCard redesigned: MiniBoard enlarged from 60px to 72px, stacked load/delete removed, new button row (chart toggle, load, delete) added below piece filter
+- Chart-enable toggle persists per bookmark in localStorage; `chartBookmarks` in Openings.tsx filters by `chartEnabledMap` when real bookmarks exist
+- `useDeletePositionBookmark` cleans up localStorage on delete so re-created bookmarks default to enabled
+- Dead frontend suggestion code removed: `usePositionSuggestions`, `getSuggestions`, `PositionSuggestion`, `SuggestionsResponse`
+- Build and lint pass cleanly
+
+## Task Commits
+
+1. **Task 1: Rework SuggestionsModal, add chart-enable toggle to bookmark cards, redesign card layout** - `fe486b9` (feat)
+2. **Task 2: Remove dead suggestion code from frontend** - `41e8823` (feat)
+3. **Task 3: Visual verification of all changes** — checkpoint: awaiting human verification
+
+## Files Created/Modified
+- `frontend/src/components/position-bookmarks/SuggestionsModal.tsx` - Rewritten to accept `mostPlayedData` and `bookmarks` props; derives suggestions client-side; filters already-bookmarked openings
+- `frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx` - Added `chartEnabled`/`onChartEnabledChange` props; MiniBoard 72px; button row with chart toggle, load, delete
+- `frontend/src/components/position-bookmarks/PositionBookmarkList.tsx` - Added `chartEnabledMap` and `onChartEnabledChange` props; passes them to each card
+- `frontend/src/pages/Openings.tsx` - Added localStorage helpers, `chartToggleVersion`, `chartEnabledMap`, `handleChartEnabledChange`; updated `chartBookmarks` filter; updated SuggestionsModal and PositionBookmarkList props; updated both desktop and mobile popover text
+- `frontend/src/pages/Dashboard.tsx` - Wired `chartEnabledMap` and `handleChartEnabledChange` to satisfy PositionBookmarkList props (Rule 3 fix)
+- `frontend/src/hooks/usePositionBookmarks.ts` - Added localStorage.removeItem in useDeletePositionBookmark; removed usePositionSuggestions
+- `frontend/src/api/client.ts` - Removed getSuggestions from positionBookmarksApi; removed SuggestionsResponse import
+- `frontend/src/types/position_bookmarks.ts` - Removed PositionSuggestion and SuggestionsResponse interfaces
+
+## Decisions Made
+- Suggestions derived client-side from `mostPlayedData` prop — avoids backend round-trip; data is already fetched for Statistics tab
+- `chartToggleVersion` counter triggers `useMemo` recompute without duplicating toggle state in React state
+- Dashboard.tsx needed the same chart toggle wiring to compile — kept implementation minimal (Rule 3 fix, no feature scope added)
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Wired chartEnabledMap in Dashboard.tsx**
+- **Found during:** Task 1 (build verification)
+- **Issue:** `PositionBookmarkList` is also used in `Dashboard.tsx` (not in plan's files list). The new required props `chartEnabledMap` and `onChartEnabledChange` caused a TypeScript build error.
+- **Fix:** Added the same `getChartEnabled`/`setChartEnabledStorage` helpers, `chartToggleVersion` state, `chartEnabledMap` useMemo, and `handleChartEnabledChange` callback to Dashboard.tsx; passed props to PositionBookmarkList.
+- **Files modified:** `frontend/src/pages/Dashboard.tsx`
+- **Verification:** `npm run build` succeeded after fix
+- **Committed in:** `fe486b9` (Task 1 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Necessary fix for build correctness. No scope creep — same pattern as Openings.tsx, no extra features.
+
+## Issues Encountered
+- Worktree was missing 38-01 commits at start. Resolved by merging the `gsd/phase-38-opening-statistics-bookmark-suggestions-rework` branch into the worktree branch before proceeding.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- All STAT-03 through STAT-06 requirements implemented
+- Task 3 (visual verification) is a checkpoint awaiting human approval
+- Once approved, Phase 38 is complete
+
+---
+*Phase: 38-opening-statistics-bookmark-suggestions-rework*
+*Completed: 2026-03-29*

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-SUMMARY.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-02-SUMMARY.md
@@ -123,3 +123,12 @@ None - no external service configuration required.
 ---
 *Phase: 38-opening-statistics-bookmark-suggestions-rework*
 *Completed: 2026-03-29*
+
+## Self-Check: PASSED
+
+- FOUND: frontend/src/components/position-bookmarks/SuggestionsModal.tsx
+- FOUND: frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+- FOUND: frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
+- FOUND: frontend/src/pages/Openings.tsx
+- FOUND commit fe486b9 (Task 1)
+- FOUND commit 41e8823 (Task 2)

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-CONTEXT.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-CONTEXT.md
@@ -1,0 +1,106 @@
+# Phase 38: Opening Statistics & Bookmark Suggestions Rework - Context
+
+**Gathered:** 2026-03-29
+**Status:** Ready for planning
+**Source:** User requirements (conversation)
+
+<domain>
+## Phase Boundary
+
+This phase reworks the Opening Statistics subtab when there are no bookmarks, refactors bookmark suggestions to use most-played openings data from Phase 37, and redesigns the bookmark card layout. No backend schema changes expected — leverages existing most-played openings endpoint.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Section Reordering
+- Reorder the Opening Statistics sections to:
+  1. Results by Opening
+  2. Win Rate Over Time
+  3. Most Played Openings as White (renamed from "White: Most Played Openings", with white color circle)
+  4. Most Played Openings as Black (renamed from "Black: Most Played Openings", with black color circle)
+
+### Default Chart Data (No Bookmarks)
+- If the user has NO position bookmarks, use the top 3 white and top 3 black most-played openings as data for "Results by Opening" and "Win Rate Over Time" charts
+- Each opening uses its corresponding "Played as" filter (white openings use played-as-white, black openings use played-as-black) with "Piece filter: Both" and all default "more filters" settings
+- Since most-played openings data is already fetched, do NOT create extra API requests — reuse the existing fetched data
+- Most Played Openings data must be fetched BEFORE rendering "Results by Opening" and "Win Rate Over Time" charts (since those charts depend on it when no bookmarks exist)
+- If the user has at least one position bookmark, use ONLY bookmarks for "Results by Opening" and "Win Rate Over Time" charts
+
+### Bookmark Suggestions Rework
+- Fetch top 10 most-played openings for white and black for bookmark suggestions
+- Suggest only the top 5 for each color
+- If a most-played opening is already bookmarked, skip it and suggest the next one from the list
+- If all 10 most-played positions (for a color) are already bookmarked, display a message suggesting the user create custom position bookmarks on the board and experiment with the Piece filter
+- Remove ALL obsolete bookmark suggestion code
+
+### Bookmark Card: Chart Enable Toggle
+- Add a toggle to each bookmark card to enable/disable including that bookmark in "Results by Opening" and "Win Rate Over Time" charts
+- Default: enabled
+
+### Bookmark Card Layout Redesign
+- Make the minimap slightly bigger
+- Move load and delete buttons to a new row below the Piece filter (gains horizontal space)
+- New button row layout: chart-enable toggle on left, load button in middle, delete button on right
+
+### Position Bookmarks Popover
+- Update the explanation text in the Position Bookmarks popover
+- Add explanation of the Piece filter (not what it does functionally, just that its state can be updated here)
+- Add explanation of the chart-enable toggle
+
+### Claude's Discretion
+- How to implement the chart-enable toggle state (localStorage, API field, or bookmark model extension)
+- Exact sizing of the bigger minimap
+- Transition/animation details for toggle
+- Loading state handling while most-played openings fetch is in progress
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Opening Statistics Components
+- `frontend/src/pages/Openings/Statistics/` — Opening Statistics subtab components
+- `frontend/src/pages/Openings/Statistics/MostPlayedOpenings.tsx` — Most Played Openings component (Phase 37)
+- `frontend/src/pages/Openings/Statistics/ResultsByOpening.tsx` — Results by Opening chart
+- `frontend/src/pages/Openings/Statistics/WinRateOverTime.tsx` — Win Rate Over Time chart
+
+### Bookmark Components
+- `frontend/src/pages/Openings/Bookmarks/` — Bookmark-related components
+- `frontend/src/components/` — Shared components
+
+### API / Hooks
+- `frontend/src/api/` — API client and hooks
+- `app/routers/` — Backend routers
+- `app/services/` — Backend services
+- `app/repositories/` — Backend repositories
+
+### Theme
+- `frontend/src/lib/theme.ts` — Theme constants
+
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+
+- The "Played as" filter context for default chart openings: white openings get played-as-white, black openings get played-as-black
+- Piece filter for default chart openings: "Both"
+- More filters for default chart openings: default settings
+- Bookmark suggestion fallback message should mention creating custom bookmarks on the board and experimenting with the Piece filter
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — requirements cover phase scope
+
+</deferred>
+
+---
+
+*Phase: 38-opening-statistics-bookmark-suggestions-rework*
+*Context gathered: 2026-03-29 from user requirements*

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-HUMAN-UAT.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-HUMAN-UAT.md
@@ -1,0 +1,44 @@
+---
+status: partial
+phase: 38-opening-statistics-bookmark-suggestions-rework
+source: [38-VERIFICATION.md]
+started: 2026-03-29T12:30:00Z
+updated: 2026-03-29T12:30:00Z
+---
+
+## Current Test
+
+[awaiting human testing]
+
+## Tests
+
+### 1. Default charts without bookmarks
+expected: 3 white + 3 black most-played openings populate Results by Opening and Win Rate Over Time charts
+result: [pending]
+
+### 2. Suggestions from most-played
+expected: No backend delay when opening suggestions; already-bookmarked positions absent from list
+result: [pending]
+
+### 3. Toggle persistence
+expected: Chart-enable toggle state persists in localStorage across page reload
+result: [pending]
+
+### 4. Delete cleanup
+expected: Re-created bookmark defaults to chart-enabled after deleting and re-creating
+result: [pending]
+
+### 5. Mobile card layout
+expected: Minimap + button row (toggle, load, delete) render correctly at small viewport
+result: [pending]
+
+## Summary
+
+total: 5
+passed: 0
+issues: 0
+pending: 5
+skipped: 0
+blocked: 0
+
+## Gaps

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-RESEARCH.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-RESEARCH.md
@@ -1,0 +1,556 @@
+# Phase 38: Opening Statistics & Bookmark Suggestions Rework - Research
+
+**Researched:** 2026-03-29
+**Domain:** React/TypeScript frontend UI rework — Opening Statistics layout, bookmark suggestion logic, bookmark card redesign. No backend schema changes.
+**Confidence:** HIGH
+
+---
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Section Reordering**
+- Reorder the Opening Statistics sections to:
+  1. Results by Opening
+  2. Win Rate Over Time
+  3. Most Played Openings as White (renamed from "White: Most Played Openings", with white color circle)
+  4. Most Played Openings as Black (renamed from "Black: Most Played Openings", with black color circle)
+
+**Default Chart Data (No Bookmarks)**
+- If the user has NO position bookmarks, use the top 3 white and top 3 black most-played openings as data for "Results by Opening" and "Win Rate Over Time" charts
+- Each opening uses its corresponding "Played as" filter (white openings use played-as-white, black openings use played-as-black) with "Piece filter: Both" and all default "more filters" settings
+- Since most-played openings data is already fetched, do NOT create extra API requests — reuse the existing fetched data
+- Most Played Openings data must be fetched BEFORE rendering "Results by Opening" and "Win Rate Over Time" charts (since those charts depend on it when no bookmarks exist)
+- If the user has at least one position bookmark, use ONLY bookmarks for "Results by Opening" and "Win Rate Over Time" charts
+
+**Bookmark Suggestions Rework**
+- Fetch top 10 most-played openings for white and black for bookmark suggestions
+- Suggest only the top 5 for each color
+- If a most-played opening is already bookmarked, skip it and suggest the next one from the list
+- If all 10 most-played positions (for a color) are already bookmarked, display a message suggesting the user create custom position bookmarks on the board and experiment with the Piece filter
+- Remove ALL obsolete bookmark suggestion code
+
+**Bookmark Card: Chart Enable Toggle**
+- Add a toggle to each bookmark card to enable/disable including that bookmark in "Results by Opening" and "Win Rate Over Time" charts
+- Default: enabled
+
+**Bookmark Card Layout Redesign**
+- Make the minimap slightly bigger
+- Move load and delete buttons to a new row below the Piece filter (gains horizontal space)
+- New button row layout: chart-enable toggle on left, load button in middle, delete button on right
+
+**Position Bookmarks Popover**
+- Update the explanation text in the Position Bookmarks popover
+- Add explanation of the Piece filter (not what it does functionally, just that its state can be updated here)
+- Add explanation of the chart-enable toggle
+
+### Claude's Discretion
+- How to implement the chart-enable toggle state (localStorage, API field, or bookmark model extension)
+- Exact sizing of the bigger minimap
+- Transition/animation details for toggle
+- Loading state handling while most-played openings fetch is in progress
+
+### Deferred Ideas (OUT OF SCOPE)
+None — requirements cover phase scope
+</user_constraints>
+
+---
+
+## Summary
+
+Phase 38 is a frontend-only rework of the Opening Statistics tab and bookmark system. The key changes are:
+
+1. **Section reordering**: Move "Results by Opening" and "Win Rate Over Time" to the top of the Statistics tab, and rename the Most Played Openings sections.
+2. **Default chart data**: When no bookmarks exist, derive synthetic bookmark-like data from the top 3 most-played openings per color and feed it into the existing chart components.
+3. **Bookmark suggestions rework**: Replace the existing Zobrist-hash-based suggestion backend with a purely frontend logic that filters `mostPlayedData` against the current bookmarks list.
+4. **Chart-enable toggle on bookmark cards**: A per-bookmark toggle that controls whether the bookmark is included in "Results by Opening" and "Win Rate Over Time". State must be persisted across sessions.
+
+The most architecturally interesting decision is the chart-enable toggle storage. The most natural implementation that preserves the existing pattern is **localStorage** (purely frontend, no backend schema migration, no new API endpoint). Alternatively, adding a `chart_enabled` boolean column to the `position_bookmarks` DB table and API is robust but requires a migration. Given the scope, localStorage is the right call for this phase.
+
+**Primary recommendation:** Implement everything in the frontend. Use localStorage for chart-enable toggle state. Reuse `mostPlayedData` already fetched in `Openings.tsx` for both the default chart logic and the new SuggestionsModal — no new API calls needed.
+
+---
+
+## Standard Stack
+
+### Core (all already in the project)
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| React | 19 | UI framework | Project standard |
+| TypeScript | 5.x | Type safety | Project standard |
+| TanStack Query | 5.x | Server state | Already used for `useMostPlayedOpenings`, `usePositionBookmarks` |
+| Tailwind CSS | 3.x | Styling | Project standard |
+| lucide-react | — | Icon set | Already used (Upload, Trash2, Sparkles, ChevronUp, etc.) |
+| @dnd-kit/sortable | — | Drag-to-reorder | Already used in PositionBookmarkList |
+
+**Installation:** No new packages needed — this phase uses only what is already installed.
+
+---
+
+## Architecture Patterns
+
+### Existing statisticsContent Structure (current)
+
+```
+statisticsContent (in Openings.tsx, lines 523-652):
+  1. White: Most Played Openings  (mostPlayedData.white)
+  2. Black: Most Played Openings  (mostPlayedData.black)
+  3. [empty state OR bookmarks charts]
+     - Results by Opening          (tsData + bookmarks)
+     - Win Rate Over Time          (tsData + bookmarks)
+```
+
+### Target statisticsContent Structure (Phase 38)
+
+```
+statisticsContent:
+  1. Results by Opening            (bookmarks OR top-3 derived from mostPlayedData)
+  2. Win Rate Over Time            (bookmarks OR top-3 derived from mostPlayedData)
+  3. Most Played Openings as White (renamed, mostPlayedData.white)
+  4. Most Played Openings as Black (renamed, mostPlayedData.black)
+```
+
+### Pattern 1: Default Chart Data from Most-Played Openings
+
+The `OpeningWDL` type (from `frontend/src/types/stats.ts`) already has all fields needed to
+build a "synthetic bookmark" for the charts: `fen`, `opening_name`, `opening_eco`, WDL stats.
+
+The challenge is that `ResultsByOpening` and `WinRateChart` consume data keyed by `bookmark_id`.
+The clean approach is to derive a synthetic `PositionBookmark`-shaped array from `mostPlayedData`
+when `bookmarks.length === 0`, then feed it to the same chart rendering code.
+
+**Synthetic bookmark derivation** (when no bookmarks exist):
+```typescript
+// Top 3 white + top 3 black from mostPlayedData
+const DEFAULT_CHART_LIMIT = 3;
+
+const defaultChartBookmarks: PositionBookmarkResponse[] = useMemo(() => {
+  if (bookmarks.length > 0 || !mostPlayedData) return [];
+  const white = mostPlayedData.white.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+    id: -(i + 1),                    // negative ID to avoid collision with real bookmarks
+    label: o.label,
+    target_hash: '0',                // not used for chart lookup
+    fen: o.fen,
+    moves: [],
+    color: 'white' as const,
+    match_side: 'both' as const,
+    is_flipped: false,
+    sort_order: i,
+    chart_enabled: true,
+  }));
+  const black = mostPlayedData.black.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+    id: -(DEFAULT_CHART_LIMIT + i + 1),
+    label: o.label,
+    target_hash: '0',
+    fen: o.fen,
+    moves: [],
+    color: 'black' as const,
+    match_side: 'both' as const,
+    is_flipped: false,
+    sort_order: DEFAULT_CHART_LIMIT + i,
+    chart_enabled: true,
+  }));
+  return [...white, ...black];
+}, [bookmarks, mostPlayedData]);
+```
+
+However: `WinRateChart` needs a `BookmarkTimeSeries[]` response from the time-series API, which
+requires real bookmark IDs sent to the backend. Synthetic bookmarks (with negative IDs) cannot
+be fetched from the time-series endpoint.
+
+**Key insight on WinRateChart with default data**: The time-series endpoint (`/api/analysis/time-series`)
+receives `target_hash` and `match_side` per bookmark — not the ID. The backend joins on `target_hash`,
+not on `bookmark_id`. So synthetic bookmarks CAN be sent to the time-series API as long as we construct
+a valid `TimeSeriesRequest` using the real Zobrist hashes from the opening FEN.
+
+The FEN is available in `OpeningWDL.fen` (from the `openings_dedup` view, which stores the position FEN).
+The Zobrist hash must be computed from FEN. Since the frontend doesn't compute Zobrist hashes, we need
+a different approach:
+
+**Recommended approach for WinRateChart default data:**
+- Compute `target_hash` client-side using the `fen` from `OpeningWDL`. The Zobrist hash computation
+  is in `app/services/zobrist.py` on the backend. There is no existing frontend Zobrist utility.
+- **Alternative (simpler)**: Add a `full_hash` field to `OpeningWDL` in the backend response so the
+  frontend can use it directly. This avoids reimplementing Zobrist in TypeScript.
+- **Even simpler alternative**: Use the existing `/api/analysis/time-series` endpoint by passing
+  synthetic bookmark entries with `target_hash` derived from the backend-provided `OpeningWDL.fen`
+  ... but this requires the hash.
+
+**Recommended resolution**: Add `full_hash` (as a string) to `OpeningWDL` schema and the
+`query_top_openings_sql_wdl` SQL query. The `fen` is already available in `openings_dedup`;
+the full hash can be computed server-side via `compute_hashes(chess.Board(fen))[2]`.
+
+Wait — re-reading the requirements: *"Since most-played openings data is already fetched, do NOT
+create extra API requests — reuse the existing fetched data."* This constraint applies to NOT making
+additional API calls to fetch the data. It does not prevent adding a `full_hash` field to the
+existing response. A backend schema change to add `full_hash` to `OpeningWDL` response is minimal
+and aligns with "reuse existing fetched data."
+
+**Recommended for WinRateChart default data**: Add `full_hash: string` to `OpeningWDL` backend
+schema and compute it server-side. Frontend derives `TimeSeriesRequest` from `mostPlayedData`
+using the included hashes. No extra API calls.
+
+### Pattern 2: Chart-Enable Toggle — localStorage Implementation
+
+Since the bookmark model has no `chart_enabled` column, and the CONTEXT.md leaves the
+implementation to Claude's discretion, localStorage is the cleanest approach for this phase:
+
+```typescript
+// Key: `bookmark-chart-enabled-${bookmark.id}`
+// Value: "true" | "false" (default: "true" — enabled by default)
+
+function getChartEnabled(bookmarkId: number): boolean {
+  const stored = localStorage.getItem(`bookmark-chart-enabled-${bookmarkId}`);
+  return stored === null ? true : stored === 'true';
+}
+
+function setChartEnabled(bookmarkId: number, enabled: boolean): void {
+  localStorage.setItem(`bookmark-chart-enabled-${bookmarkId}`, String(enabled));
+}
+```
+
+A custom hook `useBookmarkChartEnabled(bookmarkId)` returning `[enabled, setEnabled]` makes
+this testable and reusable.
+
+**Why localStorage over DB field:**
+- No backend migration, no new API endpoint, no schema change
+- Correct behavior: toggle state is per-browser (not shared across devices), which is fine for
+  a display preference
+- Consistent with how similar display preferences are handled in most React apps
+- Drawback: state is lost when clearing localStorage or using a different browser — acceptable
+  for a display toggle
+
+**Filtering in the parent component**: `Openings.tsx` filters `bookmarks` through chart-enabled
+state before constructing `timeSeriesRequest` and the "Results by Opening" rows:
+
+```typescript
+const chartEnabledMap = useMemo(() => {
+  const map: Record<number, boolean> = {};
+  for (const b of bookmarks) {
+    map[b.id] = getChartEnabled(b.id);
+  }
+  return map;
+}, [bookmarks]);
+
+const chartBookmarks = useMemo(
+  () => bookmarks.filter(b => chartEnabledMap[b.id] !== false),
+  [bookmarks, chartEnabledMap]
+);
+```
+
+Then `timeSeriesRequest` uses `chartBookmarks` instead of `bookmarks`.
+
+### Pattern 3: Bookmark Suggestions Rework
+
+The existing `SuggestionsModal` calls `/api/position-bookmarks/suggestions` which runs the
+complex Zobrist-hash-based suggestion logic in the backend. The new approach replaces the
+backend call entirely with client-side filtering of `mostPlayedData`.
+
+**New flow:**
+1. Parent (`Openings.tsx`) passes `mostPlayedData` and `bookmarks` to `SuggestionsModal`
+2. `SuggestionsModal` filters `mostPlayedData.white/black` against existing bookmarks
+3. No call to `/api/position-bookmarks/suggestions`
+
+**Deduplication**: Matching against existing bookmarks requires comparing the position.
+`OpeningWDL` has `fen` — bookmarks also have `fen`. An exact FEN string match is the simplest
+deduplication. However, bookmark's `target_hash` is more reliable (handles different FEN
+representations of the same position). Since `OpeningWDL.fen` comes from `openings_dedup` and
+matches the FEN stored in the bookmark when using the same opening, FEN comparison is sufficient.
+
+If `full_hash` is added to `OpeningWDL` (per Pattern 1 recommendation), hash comparison is
+more robust. The SuggestionsModal can compare `opening.full_hash` against bookmark `target_hash`
+values where `match_side === 'both'`.
+
+**Fallback message** when all 10 most-played are already bookmarked:
+> "All your most-played openings are already bookmarked. Try creating custom bookmarks on the board and experimenting with the Piece filter."
+
+**Props for new SuggestionsModal:**
+```typescript
+interface SuggestionsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mostPlayedData: MostPlayedOpeningsResponse | undefined;
+  bookmarks: PositionBookmarkResponse[];
+}
+```
+
+**Saving**: When saving a selected suggestion, create a bookmark via the existing
+`positionBookmarksApi.create()` call. The `target_hash` for a "Both" bookmark is the
+`full_hash` of the opening's position (must come from `OpeningWDL.full_hash`).
+
+### Pattern 4: Bookmark Card Layout Redesign
+
+Current layout (3-column flex):
+```
+[drag handle] [mini-board 60px] [label + piece filter toggle] [load btn / delete btn (stacked)]
+```
+
+New layout (2-row within card):
+```
+Row 1: [drag handle] [mini-board ~72px] [label + piece filter toggle]
+Row 2 (button row below piece filter, spanning label column):
+        [chart-enable toggle | LEFT] [load btn | CENTER] [delete btn | RIGHT]
+```
+
+Mini-board size: increase from `size={60}` to `size={72}` (20% larger, still compact).
+
+The chart-enable toggle uses a Shadcn/ui `Switch` component (already in project for other uses,
+or use a `Button` with active styling). Prefer `Switch` for semantic correctness of an
+enable/disable toggle.
+
+### Anti-Patterns to Avoid
+
+- **Calling the suggestions API**: The new SuggestionsModal must NOT call
+  `/api/position-bookmarks/suggestions`. Remove `usePositionSuggestions` hook usage entirely.
+- **Creating a new `useMostPlayedOpenings` call in SuggestionsModal**: Pass `mostPlayedData`
+  as a prop from the parent — it is already fetched there. Do not duplicate the fetch.
+- **Blocking chart render waiting for time-series when using default data**: When
+  `bookmarks.length === 0`, we still need a `TimeSeriesRequest` built from the synthetic entries.
+  The render should show a loading state while this is in progress, not skip the charts.
+- **Hardcoding color values in new UI elements**: All toggle colors (active/inactive states)
+  that have semantic meaning must be routed through `theme.ts` per CLAUDE.md.
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Toggle on/off UI | Custom styled div | Shadcn `Switch` component | Accessible, keyboard-navigable, consistent with design system |
+| Drag sorting | Custom drag impl | @dnd-kit (already in use) | Already wired in PositionBookmarkList |
+| Persistent toggle state | Session state (lost on refresh) | localStorage | Survives page reload; appropriate for display preferences |
+| Opening hash computation in frontend | Reimplementing Zobrist in TypeScript | Add `full_hash` to `OpeningWDL` backend response | Single source of truth; avoids hash sync bugs |
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: WinRateChart with Default Data — Missing `full_hash`
+
+**What goes wrong:** `OpeningWDL` has `fen` but not `full_hash`. Building a `TimeSeriesRequest`
+for default chart data requires a Zobrist hash, which isn't available in the frontend.
+**Why it happens:** The existing `MostPlayedOpeningsResponse` was designed for display only
+(showing WDL stats), not for feeding the time-series endpoint.
+**How to avoid:** Add `full_hash: str` to `OpeningWDL` Pydantic schema and compute it server-side
+using `compute_hashes(chess.Board(fen))[2]` in `stats_service.py`.
+**Warning signs:** If you try to implement default WinRateChart data without a hash, you'll find
+there's no way to build the `target_hash` field for the `TimeSeriesRequest`.
+
+### Pitfall 2: Chart-Enable Toggle — Stale State After Bookmark Delete
+
+**What goes wrong:** When a bookmark is deleted, its localStorage key remains. If a new bookmark
+is later created that gets the same ID (PostgreSQL sequences do not reuse IDs in practice, but the
+risk exists), the old toggle state could be applied incorrectly.
+**Why it happens:** localStorage keys are keyed by bookmark ID (`bookmark-chart-enabled-${id}`).
+**How to avoid:** On bookmark delete, call `localStorage.removeItem('bookmark-chart-enabled-${id}')`.
+The `useDeletePositionBookmark` mutation's `onMutate` or `onSuccess` is the right place.
+
+### Pitfall 3: `usePositionSuggestions` Hook — Dead Code Risk
+
+**What goes wrong:** The old `usePositionSuggestions` hook in `usePositionBookmarks.ts` and the
+`getSuggestions` API call in `client.ts` become dead code after the rework. Leaving them creates
+confusion and the backend endpoint stays alive.
+**Why it happens:** Partial refactors that change the call site but not the definitions.
+**How to avoid:** Remove `usePositionSuggestions` from `usePositionBookmarks.ts`, remove
+`getSuggestions` from `client.ts`, remove `PositionSuggestion`/`SuggestionsResponse` from
+`types/position_bookmarks.ts`, and delete or simplify the backend `/position-bookmarks/suggestions`
+endpoint (or leave the backend endpoint in place since removing it is not required, but remove all
+frontend dead code).
+
+### Pitfall 4: Section Reorder — Mobile Layout Duplication
+
+**What goes wrong:** `Openings.tsx` has both a desktop and mobile layout. The `statisticsContent`
+variable is shared — but if the Statistics tab ever has mobile-specific markup, it must be updated
+in both places.
+**Why it happens:** CLAUDE.md requires checking both desktop and mobile variants.
+**How to avoid:** Verify that `statisticsContent` is shared between both layouts (it is, as a
+single `const statisticsContent = ...` used in both `<TabsContent value="compare">` blocks).
+A single reorder edit covers both layouts in this case.
+
+### Pitfall 5: Default Chart Data — Loading State Race Condition
+
+**What goes wrong:** `mostPlayedData` is loaded asynchronously. If `bookmarks.length === 0` and
+`mostPlayedData` is still `undefined` (loading), the charts must not render in a broken state.
+**Why it happens:** The dependency chain: charts depend on mostPlayedData when no bookmarks exist,
+but mostPlayedData fetches in parallel with the page load.
+**How to avoid:** Show a loading skeleton / spinner for the charts while `mostPlayedData` is
+`undefined` AND `bookmarks.length === 0`. Once `mostPlayedData` arrives, render the charts.
+
+### Pitfall 6: Bookmark Suggestion Matching — FEN vs Hash
+
+**What goes wrong:** Matching opening suggestions against existing bookmarks by FEN string may fail
+if the FEN in `OpeningWDL` differs from the FEN stored in the bookmark (e.g., en passant square
+or castling rights differ, though `board_fen()` vs `fen()` distinctions were already handled
+at import time via `compute_hashes`).
+**Why it happens:** `openings_dedup.fen` comes from the openings reference table (seeded from TSV,
+computed via python-chess's `board.fen()` which includes castling/en passant). Bookmark `fen` is
+stored from the board at bookmark creation time (also full FEN). For opening positions these should
+match, but subtle differences are possible.
+**How to avoid:** If `full_hash` is added to `OpeningWDL`, use hash comparison instead of FEN
+string comparison for deduplication in SuggestionsModal. This is more robust and is already the
+reason we recommend adding `full_hash`.
+
+---
+
+## Code Examples
+
+### Verified: Existing OpeningWDL response structure
+```typescript
+// Source: frontend/src/types/stats.ts
+export interface OpeningWDL {
+  opening_eco: string;
+  opening_name: string;
+  label: string;
+  pgn: string;
+  fen: string;
+  wins: number; draws: number; losses: number; total: number;
+  win_pct: number; draw_pct: number; loss_pct: number;
+}
+```
+
+Field `full_hash` does not exist yet — must be added in `app/schemas/stats.py` and
+`app/services/stats_service.py`.
+
+### Verified: Existing timeSeriesRequest construction (Openings.tsx lines 152-168)
+```typescript
+const timeSeriesRequest: TimeSeriesRequest | null = useMemo(() => {
+  if (bookmarks.length === 0) return null;
+  return {
+    bookmarks: bookmarks.map((b) => ({
+      bookmark_id: b.id,
+      target_hash: b.target_hash,
+      match_side: resolveMatchSide(b.match_side, (b.color ?? 'white') as Color),
+      color: b.color,
+    })),
+    // ...filters
+  };
+}, [bookmarks, debouncedFilters]);
+```
+
+For default chart data (no bookmarks), a parallel request is built from `mostPlayedData` slices
+using `full_hash` from `OpeningWDL`. The `bookmark_id` field in `TimeSeriesBookmarkParam` is a
+frontend label used to match series back to display labels — synthetic negative IDs work fine here
+since the backend only uses `target_hash` and `match_side` for the query.
+
+### Verified: Backend stats_service rows_to_openings (stats_service.py line 213)
+```python
+# Currently does NOT include full_hash — must be added
+for eco, name, pgn, fen, total, wins, draws, losses in rows:
+    # Add full_hash computation:
+    import chess as chess_lib
+    from app.services.zobrist import compute_hashes
+    board = chess_lib.Board(fen)
+    _, _, full_hash = compute_hashes(board)
+```
+
+And the SQL query in `stats_repository.py` does not need to change — `full_hash` is computed
+from the `fen` field that's already returned.
+
+### Verified: Bookmark card current DOM structure (PositionBookmarkCard.tsx lines 76-198)
+Current: `[drag handle] [mini-board 60px] [flex-col: label + piece-filter] [flex-col: load + delete]`
+
+New target:
+```tsx
+<div className="flex items-start gap-2 ...">
+  <span {...listeners}>☰</span>           {/* drag handle */}
+  <MiniBoard size={72} ... />              {/* larger minimap */}
+  <div className="flex-1 flex flex-col gap-1">
+    {/* label row */}
+    {/* piece filter toggle */}
+    {/* NEW: button row */}
+    <div className="flex items-center justify-between">
+      <Switch checked={chartEnabled} onCheckedChange={setChartEnabled}
+              aria-label="Include in charts" data-testid={`bookmark-chart-toggle-${id}`} />
+      <Button onClick={handleLoad} ...>Load</Button>
+      <Button onClick={handleDelete} ...>Delete</Button>
+    </div>
+  </div>
+</div>
+```
+
+---
+
+## Backend Changes Required
+
+This phase was stated as "No backend schema changes expected" in CONTEXT.md. However, research
+reveals one minimal backend addition is needed:
+
+**`full_hash` field on `OpeningWDL`**: Required to enable the SuggestionsModal to save bookmarks
+with correct `target_hash`, and to enable WinRateChart default data without a new API call.
+
+| Change | File | Impact |
+|--------|------|--------|
+| Add `full_hash: str` to `OpeningWDL` Pydantic schema | `app/schemas/stats.py` | Non-breaking (additive) |
+| Compute and include `full_hash` in `rows_to_openings()` | `app/services/stats_service.py` | Non-breaking |
+| Add `full_hash: string` to `OpeningWDL` TypeScript interface | `frontend/src/types/stats.ts` | Non-breaking |
+
+No DB migration needed. No new endpoints. No schema changes to `position_bookmarks` table.
+
+---
+
+## Validation Architecture
+
+nyquist_validation is enabled per config.json.
+
+### Test Framework
+
+| Property | Value |
+|----------|-------|
+| Framework | pytest (backend), Vitest (frontend) |
+| Config file | `pyproject.toml` (backend), `vite.config.ts` (frontend) |
+| Quick run command | `uv run pytest tests/test_bookmark_repository.py tests/test_stats_router.py -x` |
+| Full suite command | `uv run pytest && npm test` |
+
+### Phase Requirements → Test Map
+
+| Behavior | Test Type | Automated Command | File Exists? |
+|----------|-----------|-------------------|-------------|
+| `full_hash` included in MostPlayedOpenings response | integration | `uv run pytest tests/test_stats_router.py -x -k most_played` | Exists (test_stats_router.py) |
+| Default chart bookmarks derived from mostPlayedData when no bookmarks | unit/manual | Manual verification in browser | N/A (UI logic) |
+| Suggestion filtering skips already-bookmarked openings | unit | Frontend test or manual | N/A (no frontend unit test yet) |
+| Chart-enable toggle persists across page reload | manual | Manual browser verification | N/A |
+| Bookmark card layout: buttons in new row | visual | Browser + screenshot | N/A |
+
+### Sampling Rate
+- **Per task commit:** `uv run pytest tests/test_stats_router.py -x`
+- **Per wave merge:** `uv run pytest`
+- **Phase gate:** Full suite green before `/gsd:verify-work`
+
+### Wave 0 Gaps
+- No new test files required — the single backend change (`full_hash` in response) is covered by
+  the existing `test_stats_router.py` (add one assertion for the new field).
+
+---
+
+## Environment Availability
+
+Step 2.6: SKIPPED — this phase is primarily frontend code changes with one minimal backend schema
+addition. No new external tools, CLIs, or services are required beyond the existing stack.
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- Direct codebase inspection — all source file reads above
+
+### Secondary (MEDIUM confidence)
+- CONTEXT.md decisions (Phase 38, gathered 2026-03-29)
+- STATE.md accumulated decisions for Phases 36-37
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — all existing; no new dependencies
+- Architecture: HIGH — codebase thoroughly read; patterns are clear
+- Pitfalls: HIGH — identified from direct code analysis, not speculation
+- Backend `full_hash` addition: HIGH — straightforward addition to existing service
+
+**Research date:** 2026-03-29
+**Valid until:** Indefinite for stable internal codebase; refresh if Phase 37 implementation
+details change before this phase executes.

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-VALIDATION.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-VALIDATION.md
@@ -1,0 +1,73 @@
+---
+phase: 38
+slug: opening-statistics-bookmark-suggestions-rework
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-03-29
+---
+
+# Phase 38 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | vitest (frontend), pytest (backend) |
+| **Config file** | `frontend/vitest.config.ts`, `pyproject.toml` |
+| **Quick run command** | `cd frontend && npm test` / `uv run pytest tests/ -x` |
+| **Full suite command** | `cd frontend && npm test && cd .. && uv run pytest` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run quick test command for affected area
+- **After every plan wave:** Run full suite command
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| TBD | TBD | TBD | TBD | TBD | TBD | TBD | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+*Existing infrastructure covers all phase requirements.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| Section reorder renders correctly | Phase goal | Visual layout verification | Open Opening Statistics tab, verify section order matches spec |
+| Bookmark card layout redesign | Phase goal | Visual layout verification | Check bookmark cards show bigger minimap, new button row layout |
+| Chart-enable toggle UX | Phase goal | Interactive behavior | Toggle chart-enable on/off, verify charts update accordingly |
+| Default openings in charts (no bookmarks) | Phase goal | Requires empty bookmark state | Delete all bookmarks, verify top 3 white/black openings appear in charts |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending

--- a/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-VERIFICATION.md
+++ b/.planning/phases/38-opening-statistics-bookmark-suggestions-rework/38-VERIFICATION.md
@@ -1,0 +1,156 @@
+---
+phase: 38-opening-statistics-bookmark-suggestions-rework
+verified: 2026-03-29T11:00:00Z
+status: human_needed
+score: 6/6 must-haves verified
+human_verification:
+  - test: "Open Statistics tab without bookmarks — verify charts show most-played openings data"
+    expected: "Results by Opening and Win Rate Over Time show up to 3 white + 3 black most-played openings with real WDL data, no empty state"
+    why_human: "Requires a logged-in user with game imports; chart rendering not testable statically"
+  - test: "Open Position Bookmarks > Suggest — verify suggestions come from most-played openings without any backend loading delay"
+    expected: "Modal populates immediately from already-fetched mostPlayedData; already-bookmarked positions are absent"
+    why_human: "Network timing and suggestion filtering require visual inspection"
+  - test: "Toggle chart-enable off on a bookmark, reload page — verify toggle state persists and chart excludes that bookmark"
+    expected: "Toggled-off bookmark disappears from Results by Opening and Win Rate Over Time after page reload"
+    why_human: "localStorage persistence and chart re-render require browser interaction"
+  - test: "Delete a bookmark that had chart-enable toggled off, re-create it — verify toggle defaults to enabled"
+    expected: "Newly created bookmark appears in charts (toggle defaults on)"
+    why_human: "localStorage cleanup on delete requires end-to-end browser flow"
+  - test: "Verify bookmark card layout on mobile viewport"
+    expected: "72-84px minimap visible, button row (toggle/load/delete) below piece filter, no overflow"
+    why_human: "Responsive layout correctness requires visual inspection at small viewport"
+---
+
+# Phase 38: Opening Statistics & Bookmark Suggestions Rework — Verification Report
+
+**Phase Goal:** Reorder Opening Statistics sections, use top most-played openings as default chart data when no bookmarks exist, rework bookmark suggestion system using most-played openings data, add chart-enable toggle to bookmarks, redesign bookmark card layout
+
+**Verified:** 2026-03-29T11:00:00Z
+**Status:** human_needed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | OpeningWDL backend response includes full_hash field | VERIFIED | `app/schemas/stats.py` line 49: `full_hash: str`; DB query at `stats_repository.py` line 220 selects `full_hash`; service at `stats_service.py` line 259 passes `full_hash=str(full_hash)` |
+| 2 | Statistics tab shows Results by Opening first, then Win Rate Over Time, then Most Played White, then Most Played Black | VERIFIED | `Openings.tsx` lines 623-729: `statisticsContent` renders in exact order: Results by Opening (623), Win Rate Over Time (691), Most Played as White (697), Most Played as Black (717) |
+| 3 | When user has no bookmarks, charts show data from top 3 most-played openings per color | VERIFIED | `Openings.tsx` lines 188-218: `defaultChartEntries` slices `mostPlayedData.white/black` to `DEFAULT_CHART_LIMIT=3`; `chartBookmarks` uses `defaultChartEntries` when `bookmarks.length === 0` |
+| 4 | When user has bookmarks, charts use only bookmark data filtered by chart-enable toggle | VERIFIED | `Openings.tsx` line 216-218: `chartBookmarks = bookmarks.filter(b => chartEnabledMap[b.id] !== false)` when bookmarks exist |
+| 5 | Bookmark suggestions derive from most-played openings, skip already-bookmarked positions, show fallback | VERIFIED | `SuggestionsModal.tsx` lines 40-63: derives from `mostPlayedData` prop, filters by `full_hash` vs `target_hash`, fallback message at line 191 |
+| 6 | Each bookmark card has chart-enable toggle persisted in localStorage | VERIFIED | `PositionBookmarkCard.tsx` lines 36-37, 206-212: props `chartEnabled`/`onChartEnabledChange`; `data-testid="bookmark-chart-toggle-{id}"`; `Openings.tsx` lines 4-8: `getChartEnabled`/`setChartEnabledStorage` localStorage helpers; `usePositionBookmarks.ts` line 42: `localStorage.removeItem` on delete |
+| 7 | Bookmark card layout has bigger minimap and button row below piece filter | VERIFIED | `PositionBookmarkCard.tsx` line 128: `size={84}` (up from 60px, exceeds 72px spec); button row at lines 204-232 with chart toggle (left), load (middle), delete (right) in `flex items-center justify-between` |
+| 8 | Position Bookmarks popover explains Piece filter and chart-enable toggle | VERIFIED | `Openings.tsx` desktop popover (lines 468-473) and mobile popover (lines 931-940) both contain "Piece filter" and "chart toggle" explanations |
+| 9 | Dead suggestion code removed (usePositionSuggestions, getSuggestions, PositionSuggestion, SuggestionsResponse) | VERIFIED | `grep` found zero occurrences in `usePositionBookmarks.ts`, `client.ts`, and `position_bookmarks.ts` |
+
+**Score:** 9/9 truths verified (exceeds the 6 required must-haves across both plans)
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `app/schemas/stats.py` | full_hash field on OpeningWDL | VERIFIED | Line 49: `full_hash: str` with comment |
+| `app/services/stats_service.py` | full_hash computation in rows_to_openings | VERIFIED | Line 240: unpacked from DB row; line 259: `full_hash=str(full_hash)` in constructor. Note: pulled from DB query (not recomputed via compute_hashes), which is correct — avoids redundant hashing |
+| `frontend/src/types/stats.ts` | full_hash field on OpeningWDL TS interface | VERIFIED | Line 34: `full_hash: string` |
+| `frontend/src/pages/Openings.tsx` | DEFAULT_CHART_LIMIT + default chart data logic + chartEnabledMap | VERIFIED | Lines 4-8 (localStorage helpers), 63 (DEFAULT_CHART_LIMIT=3), 115-125 (chartEnabledMap), 188-218 (defaultChartEntries, chartBookmarks) |
+| `frontend/src/components/position-bookmarks/SuggestionsModal.tsx` | Reworked SuggestionsModal using mostPlayedData prop | VERIFIED | Props include `mostPlayedData` and `bookmarks`; no `usePositionSuggestions` import; derives suggestions client-side |
+| `frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx` | Chart-enable toggle + redesigned layout | VERIFIED | `data-testid="bookmark-chart-toggle-{id}"`, `size={84}` MiniBoard, button row |
+| `frontend/src/hooks/usePositionBookmarks.ts` | localStorage cleanup on delete | VERIFIED | Line 42: `localStorage.removeItem` in `useDeletePositionBookmark` |
+| `frontend/src/api/client.ts` | getSuggestions removed | VERIFIED | Not present |
+| `frontend/src/types/position_bookmarks.ts` | PositionSuggestion/SuggestionsResponse removed | VERIFIED | Not present |
+| `frontend/src/pages/Dashboard.tsx` | Chart toggle wiring (auto-fixed) | VERIFIED | Lines 4-8 (helpers), 73-81 (chartEnabledMap/handleChartEnabledChange), 456-457 (passed to PositionBookmarkList) |
+| `tests/test_stats_router.py` | full_hash assertions in most_played tests | VERIFIED | Lines 307-309: asserts `full_hash` key exists, is a non-empty string |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `app/services/stats_service.py` | `app/repositories/stats_repository.py` | full_hash in DB rows | VERIFIED | Row tuple unpacked at line 240 includes full_hash from SQL query |
+| `frontend/src/pages/Openings.tsx` | `frontend/src/types/stats.ts` | OpeningWDL.full_hash for synthetic bookmarks | VERIFIED | `defaultChartEntries` uses `o.full_hash` as `target_hash` at lines 193, 203 |
+| `frontend/src/pages/Openings.tsx` | `frontend/src/components/position-bookmarks/SuggestionsModal.tsx` | mostPlayedData and bookmarks props | VERIFIED | Lines 1043-1048: `mostPlayedData={mostPlayedData}` and `bookmarks={bookmarks}` passed |
+| `frontend/src/pages/Openings.tsx` | `frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx` | chartEnabled/onChartEnabledChange via PositionBookmarkList | VERIFIED | PositionBookmarkList passes `chartEnabled={chartEnabledMap[b.id] !== false}` and `onChartEnabledChange` at lines 67-68 |
+| `frontend/src/pages/Openings.tsx` | `frontend/src/components/charts/WinRateChart.tsx` | chartBookmarks prop | VERIFIED | Line 694: `<WinRateChart bookmarks={chartBookmarks} series={tsData.series} />` |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|--------------------|--------|
+| `Openings.tsx` statisticsContent | `chartBookmarks` | `bookmarks` (from `usePositionBookmarks`) or `defaultChartEntries` (from `mostPlayedData`) | Yes — `mostPlayedData` comes from `useMostPlayedOpenings` hook which calls real API endpoint | FLOWING |
+| `SuggestionsModal.tsx` suggestion list | `whiteSuggestions`/`blackSuggestions` | `mostPlayedData` prop from parent | Yes — parent fetches via `useMostPlayedOpenings` | FLOWING |
+| `PositionBookmarkCard.tsx` chart toggle | `chartEnabled` prop | `chartEnabledMap` → localStorage → `chartToggleVersion` state | Yes — localStorage reads real stored values; defaults to `true` for new bookmarks | FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| Backend most_played tests pass with full_hash | `uv run pytest tests/test_stats_router.py -x -k most_played` | 5 passed, 0 failed | PASS |
+| Frontend TypeScript build succeeds | `npm run build` | Built in 4.62s, no errors | PASS |
+| Frontend lint passes | `npm run lint` | No warnings | PASS |
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|------------|-------------|--------|----------|
+| STAT-01 | 38-01 | Statistics tab sections in order: Results by Opening, Win Rate Over Time, Most Played White, Most Played Black | SATISFIED | `statisticsContent` renders in correct order at lines 623, 691, 697, 717 |
+| STAT-02 | 38-01 | No-bookmark default: charts show top 3 most-played per color | SATISFIED | `DEFAULT_CHART_LIMIT=3`, `defaultChartEntries` slices `mostPlayedData.white/black[:3]` |
+| STAT-03 | 38-02 | Bookmark suggestions from most-played data, skip bookmarked, fallback message | SATISFIED | SuggestionsModal derives client-side; filters by `full_hash`; fallback at line 191 |
+| STAT-04 | 38-02 | Chart-enable toggle per bookmark, localStorage persistence, controls chart inclusion | SATISFIED | Toggle in PositionBookmarkCard; `chartEnabledMap` filters `chartBookmarks` |
+| STAT-05 | 38-02 | Bigger minimap (~72px), button row (toggle/load/delete) below piece filter | SATISFIED | MiniBoard `size={84}` (exceeds ~72px target); button row confirmed |
+| STAT-06 | 38-02 | Position Bookmarks popover explains Piece filter and chart-enable toggle | SATISFIED | Both desktop (line 468-473) and mobile (line 936-939) popovers updated |
+
+No orphaned requirements — all 6 STAT-0x IDs claimed by plans and verified in code.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| `Openings.tsx` | 221 | `if (chartBookmarks.length === 0) return null` in `timeSeriesRequest` useMemo | Info | Intentional guard — no time-series request when no chart data. Correct behavior. |
+
+No stub patterns, no hardcoded empty returns that flow to user-visible output, no TODO/FIXME comments found in modified files.
+
+### Human Verification Required
+
+#### 1. Default chart data with no bookmarks
+
+**Test:** Log in as a user with game imports but no bookmarks. Navigate to Openings > Statistics tab.
+**Expected:** Results by Opening and Win Rate Over Time are populated with data from the top 3 most-played openings as white and top 3 as black (6 entries total). No "No bookmarks yet" empty state appears.
+**Why human:** Requires authenticated user session with real game data; chart rendering cannot be verified statically.
+
+#### 2. Bookmark suggestions from most-played data
+
+**Test:** Open Position Bookmarks collapsible in the sidebar, click "Suggest". If you have existing bookmarks, verify those openings are absent from the suggestions list.
+**Expected:** Modal populates immediately (no loading spinner from a backend call). Already-bookmarked positions are skipped. If all top 10 per color are bookmarked, fallback message appears.
+**Why human:** Network timing and client-side filtering logic require runtime verification.
+
+#### 3. Chart-enable toggle persistence
+
+**Test:** With at least one bookmark, toggle its chart-enable switch off. Verify the bookmark disappears from Results by Opening and Win Rate Over Time. Reload the page. Verify the toggle is still off and the bookmark is still excluded from charts.
+**Expected:** Toggle state survives page reload via localStorage. Charts update immediately on toggle.
+**Why human:** localStorage reads, React re-render on toggle change, and chart exclusion all require browser interaction.
+
+#### 4. localStorage cleanup on bookmark delete
+
+**Test:** Toggle a bookmark's chart-enable off, then delete that bookmark. Re-create a bookmark at the same position. Verify the new bookmark defaults to chart-enabled (toggle is on).
+**Expected:** Old localStorage key removed on delete; new bookmark starts with default-enabled state.
+**Why human:** End-to-end flow spanning delete mutation, localStorage cleanup, and re-creation.
+
+#### 5. Bookmark card layout on mobile viewport
+
+**Test:** Resize browser to a mobile viewport (375px width). Open Position Bookmarks. Verify each card shows: larger minimap (~84px), piece filter toggle row, then button row (chart toggle on left, load in middle, delete on right).
+**Expected:** All three sections visible, no horizontal overflow, buttons are tappable size.
+**Why human:** Responsive layout correctness requires visual inspection.
+
+### Gaps Summary
+
+No automated gaps found. All 6 requirements are satisfied and all 9 observable truths are verified by code inspection. The 5 human verification items above are standard UX behaviors that cannot be confirmed without a running browser session.
+
+**Implementation note on minimap size:** The plan specified `size={72}` and STAT-05 says "bigger minimap (~72px)". The implementation used `size={84}`, which exceeds the approximate target. This is not a gap — 84px is larger than the previous 60px and satisfies "bigger minimap".
+
+**Implementation note on full_hash computation:** Plan 38-01 described computing `full_hash` via `chess.Board(fen)` + `compute_hashes()` in the service. The actual implementation pulls `full_hash` directly from the database query result (already stored in `game_positions.full_hash`). This is semantically equivalent and architecturally superior — it avoids redundant hashing and uses the canonical stored hash. The test assertion (`full_hash` is non-empty string) passes, confirming the field flows correctly.
+
+---
+
+_Verified: 2026-03-29T11:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/alembic/versions/20260329_102659_b4ede5562e92_add_zobrist_hashes_to_openings_table.py
+++ b/alembic/versions/20260329_102659_b4ede5562e92_add_zobrist_hashes_to_openings_table.py
@@ -1,0 +1,50 @@
+"""add zobrist hashes to openings table
+
+Revision ID: b4ede5562e92
+Revises: 1b941ecba0a6
+Create Date: 2026-03-29 10:26:59.770809+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b4ede5562e92'
+down_revision: Union[str, Sequence[str], None] = '1b941ecba0a6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add Zobrist hash columns to openings table and rebuild the dedup view."""
+    op.add_column('openings', sa.Column('full_hash', sa.BigInteger(), nullable=True))
+    op.add_column('openings', sa.Column('white_hash', sa.BigInteger(), nullable=True))
+    op.add_column('openings', sa.Column('black_hash', sa.BigInteger(), nullable=True))
+
+    # Recreate view to include the new columns
+    op.execute("DROP VIEW IF EXISTS openings_dedup")
+    op.execute("""
+        CREATE VIEW openings_dedup AS
+        SELECT DISTINCT ON (eco, name)
+            id, eco, name, pgn, ply_count, fen, full_hash, white_hash, black_hash
+        FROM openings
+        ORDER BY eco, name, id
+    """)
+
+
+def downgrade() -> None:
+    """Remove Zobrist hash columns and restore original view."""
+    op.execute("DROP VIEW IF EXISTS openings_dedup")
+    op.execute("""
+        CREATE VIEW openings_dedup AS
+        SELECT DISTINCT ON (eco, name)
+            id, eco, name, pgn, ply_count, fen
+        FROM openings
+        ORDER BY eco, name, id
+    """)
+    op.drop_column('openings', 'black_hash')
+    op.drop_column('openings', 'white_hash')
+    op.drop_column('openings', 'full_hash')

--- a/app/models/opening.py
+++ b/app/models/opening.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Index, SmallInteger, String, Text, UniqueConstraint
+from sqlalchemy import BigInteger, Index, SmallInteger, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -17,3 +17,7 @@ class Opening(Base):
     pgn: Mapped[str] = mapped_column(Text, nullable=False)
     ply_count: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     fen: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Precomputed Zobrist hashes — avoids PGN replay at query time
+    full_hash: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    white_hash: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    black_hash: Mapped[int | None] = mapped_column(BigInteger, nullable=True)

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -257,7 +257,19 @@ async def query_top_openings_sql_wdl(
     return list(result.fetchall())
 
 
-async def query_position_game_counts(
+class PositionWDL:
+    """Position-based WDL stats for a single hash."""
+
+    __slots__ = ("total", "wins", "draws", "losses")
+
+    def __init__(self, total: int, wins: int, draws: int, losses: int):
+        self.total = total
+        self.wins = wins
+        self.draws = draws
+        self.losses = losses
+
+
+async def query_position_wdl_batch(
     session: AsyncSession,
     user_id: int,
     hashes: list[int],
@@ -267,30 +279,59 @@ async def query_position_game_counts(
     rated: bool | None = None,
     opponent_type: str = "human",
     recency_cutoff: datetime.datetime | None = None,
-) -> dict[int, int]:
-    """Return {full_hash: game_count} for games passing through each position.
+) -> dict[int, PositionWDL]:
+    """Return {full_hash: PositionWDL} for games passing through each position.
 
     Uses DISTINCT game_id per hash to avoid double-counting games where the
-    same position appears at multiple plies.
+    same position appears at multiple plies. WDL computed SQL-side using the
+    same conditions as query_top_openings_sql_wdl.
     """
     if not hashes:
         return {}
 
-    stmt = (
+    # Deduplicate game_id per hash first (subquery), then aggregate WDL
+    dedup = (
         select(
             GamePosition.full_hash,
-            func.count(func.distinct(GamePosition.game_id)).label("game_count"),
+            Game.id.label("game_id"),
+            Game.result,
+            Game.user_color,
         )
         .join(Game, GamePosition.game_id == Game.id)
         .where(
             GamePosition.user_id == user_id,
             GamePosition.full_hash.in_(hashes),
         )
-        .group_by(GamePosition.full_hash)
+        .distinct(GamePosition.full_hash, Game.id)
     )
     if color is not None:
-        stmt = stmt.where(Game.user_color == color)
-    stmt = _apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff)
+        dedup = dedup.where(Game.user_color == color)
+    dedup = _apply_game_filters(dedup, time_control, platform, rated, opponent_type, recency_cutoff)
+    dedup = dedup.subquery()
+
+    stmt = (
+        select(
+            dedup.c.full_hash,
+            func.count().label("total"),
+            func.count().filter(
+                or_(
+                    and_(dedup.c.result == "1-0", dedup.c.user_color == "white"),
+                    and_(dedup.c.result == "0-1", dedup.c.user_color == "black"),
+                )
+            ).label("wins"),
+            func.count().filter(dedup.c.result == "1/2-1/2").label("draws"),
+            func.count().filter(
+                or_(
+                    and_(dedup.c.result == "0-1", dedup.c.user_color == "white"),
+                    and_(dedup.c.result == "1-0", dedup.c.user_color == "black"),
+                )
+            ).label("losses"),
+        )
+        .group_by(dedup.c.full_hash)
+    )
 
     result = await session.execute(stmt)
-    return {row[0]: row[1] for row in result.fetchall()}
+    return {
+        row[0]: PositionWDL(total=row[1], wins=row[2], draws=row[3], losses=row[4])
+        for row in result.fetchall()
+    }

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -3,7 +3,7 @@
 import datetime
 from typing import Literal
 
-from sqlalchemy import Column, Date, MetaData, SmallInteger, String, Table, Text, and_, case, cast, func, or_, select
+from sqlalchemy import BigInteger, Column, Date, MetaData, SmallInteger, String, Table, Text, and_, case, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
@@ -18,6 +18,9 @@ _openings_dedup = Table(
     Column("pgn", Text),
     Column("ply_count", SmallInteger),
     Column("fen", String(100)),
+    Column("full_hash", BigInteger),
+    Column("white_hash", BigInteger),
+    Column("black_hash", BigInteger),
 )
 
 
@@ -213,6 +216,7 @@ async def query_top_openings_sql_wdl(
             Game.opening_name,
             _openings_dedup.c.pgn,
             _openings_dedup.c.fen,
+            _openings_dedup.c.full_hash,
             func.count().label("total"),
             func.count().filter(win_cond).label("wins"),
             func.count().filter(draw_cond).label("draws"),
@@ -239,6 +243,7 @@ async def query_top_openings_sql_wdl(
             Game.opening_name,
             _openings_dedup.c.pgn,
             _openings_dedup.c.fen,
+            _openings_dedup.c.full_hash,
         )
         .having(func.count() >= min_games)
         .order_by(func.count().desc())

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -7,6 +7,7 @@ from sqlalchemy import BigInteger, Column, Date, MetaData, SmallInteger, String,
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
+from app.models.game_position import GamePosition
 
 # Standalone MetaData (not Base.metadata) keeps the view invisible to Alembic autogenerate.
 _openings_dedup = Table(
@@ -254,3 +255,42 @@ async def query_top_openings_sql_wdl(
 
     result = await session.execute(stmt)
     return list(result.fetchall())
+
+
+async def query_position_game_counts(
+    session: AsyncSession,
+    user_id: int,
+    hashes: list[int],
+    color: Literal["white", "black"] | None = None,
+    time_control: list[str] | None = None,
+    platform: list[str] | None = None,
+    rated: bool | None = None,
+    opponent_type: str = "human",
+    recency_cutoff: datetime.datetime | None = None,
+) -> dict[int, int]:
+    """Return {full_hash: game_count} for games passing through each position.
+
+    Uses DISTINCT game_id per hash to avoid double-counting games where the
+    same position appears at multiple plies.
+    """
+    if not hashes:
+        return {}
+
+    stmt = (
+        select(
+            GamePosition.full_hash,
+            func.count(func.distinct(GamePosition.game_id)).label("game_count"),
+        )
+        .join(Game, GamePosition.game_id == Game.id)
+        .where(
+            GamePosition.user_id == user_id,
+            GamePosition.full_hash.in_(hashes),
+        )
+        .group_by(GamePosition.full_hash)
+    )
+    if color is not None:
+        stmt = stmt.where(Game.user_color == color)
+    stmt = _apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff)
+
+    result = await session.execute(stmt)
+    return {row[0]: row[1] for row in result.fetchall()}

--- a/app/schemas/stats.py
+++ b/app/schemas/stats.py
@@ -46,6 +46,7 @@ class OpeningWDL(BaseModel):
     label: str          # "Opening Name (ECO)" — precomputed for UI
     pgn: str            # PGN move sequence for display
     fen: str            # Piece-placement FEN for minimap popover
+    full_hash: str      # String representation of 64-bit Zobrist full hash for synthetic bookmark construction
     wins: int
     draws: int
     losses: int

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -3,6 +3,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
+    query_position_game_counts,
     query_rating_history,
     query_results_by_color,
     query_results_by_time_control,
@@ -175,10 +176,11 @@ async def get_most_played_openings(
     rated: bool | None = None,
     opponent_type: str = "human",
 ) -> MostPlayedOpeningsResponse:
-    """Return top 10 most played openings per color with SQL-side WDL stats.
+    """Return top 10 most played openings per color with position-based game counts.
 
-    JOINs to openings_dedup for pgn/fen. Filters by recency, time_control,
-    platform, rated, and opponent_type. Excludes openings below ply threshold.
+    Opening selection uses the games table (by opening_eco/name), but the
+    displayed game count comes from game_positions (games passing through
+    the position). This matches the count shown in "Results by Opening".
     """
     cutoff = recency_cutoff(recency)
 
@@ -209,9 +211,44 @@ async def get_most_played_openings(
         opponent_type=opponent_type,
     )
 
-    def rows_to_openings(rows: list[tuple]) -> list[OpeningWDL]:
+    # Collect all full_hashes to batch-query position-based game counts
+    all_hashes: list[int] = []
+    for rows in (white_rows, black_rows):
+        for row in rows:
+            full_hash = row[4]  # full_hash is at index 4
+            if full_hash is not None:
+                all_hashes.append(full_hash)
+
+    # Get position-based game counts — games passing through each position,
+    # which is typically higher than the opening-name count because many
+    # openings share early moves
+    filter_kwargs = dict(
+        time_control=time_control,
+        platform=platform,
+        rated=rated,
+        opponent_type=opponent_type,
+        recency_cutoff=cutoff,
+    )
+    white_position_counts = await query_position_game_counts(
+        session, user_id,
+        [row[4] for row in white_rows if row[4] is not None],
+        color="white", **filter_kwargs,
+    )
+    black_position_counts = await query_position_game_counts(
+        session, user_id,
+        [row[4] for row in black_rows if row[4] is not None],
+        color="black", **filter_kwargs,
+    )
+
+    def rows_to_openings(
+        rows: list[tuple],
+        position_counts: dict[int, int],
+    ) -> list[OpeningWDL]:
         openings = []
         for eco, name, pgn, fen, full_hash, total, wins, draws, losses in rows:
+            # Use position-based game count if available, falling back to
+            # opening-name count for openings without a hash
+            display_total = position_counts.get(full_hash, total) if full_hash else total
             if total > 0:
                 win_pct = round(wins / total * 100, 1)
                 draw_pct = round(draws / total * 100, 1)
@@ -229,7 +266,7 @@ async def get_most_played_openings(
                     wins=wins,
                     draws=draws,
                     losses=losses,
-                    total=total,
+                    total=display_total,
                     win_pct=win_pct,
                     draw_pct=draw_pct,
                     loss_pct=loss_pct,
@@ -238,6 +275,6 @@ async def get_most_played_openings(
         return openings
 
     return MostPlayedOpeningsResponse(
-        white=rows_to_openings(white_rows),
-        black=rows_to_openings(black_rows),
+        white=rows_to_openings(white_rows, white_position_counts),
+        black=rows_to_openings(black_rows, black_position_counts),
     )

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,9 +1,5 @@
 """Stats service: aggregation logic for rating history and global stats."""
 
-import io
-
-import chess as chess_lib
-import chess.pgn
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
@@ -21,7 +17,6 @@ from app.schemas.stats import (
     WDLByCategory,
 )
 from app.services.analysis_service import recency_cutoff
-from app.services.zobrist import compute_hashes
 
 # Minimum number of games required for an opening to appear in top openings.
 MIN_GAMES_FOR_OPENING = 1
@@ -216,21 +211,13 @@ async def get_most_played_openings(
 
     def rows_to_openings(rows: list[tuple]) -> list[OpeningWDL]:
         openings = []
-        for eco, name, pgn, fen, total, wins, draws, losses in rows:
+        for eco, name, pgn, fen, full_hash, total, wins, draws, losses in rows:
             if total > 0:
                 win_pct = round(wins / total * 100, 1)
                 draw_pct = round(draws / total * 100, 1)
                 loss_pct = round(losses / total * 100, 1)
             else:
                 win_pct = draw_pct = loss_pct = 0.0
-            # Replay PGN to get correct board state (castling, en passant, side to move)
-            # — board_fen() loses these, producing wrong polyglot Zobrist hashes
-            board = chess_lib.Board()
-            pgn_game = chess.pgn.read_game(io.StringIO(pgn))
-            if pgn_game:
-                for move in pgn_game.mainline_moves():
-                    board.push(move)
-            _, _, full_hash = compute_hashes(board)
             openings.append(
                 OpeningWDL(
                     opening_eco=eco,
@@ -238,7 +225,7 @@ async def get_most_played_openings(
                     label=f"{name} ({eco})",
                     pgn=pgn,
                     fen=fen,
-                    full_hash=str(full_hash),
+                    full_hash=str(full_hash) if full_hash is not None else "",
                     wins=wins,
                     draws=draws,
                     losses=losses,

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -3,7 +3,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
-    query_position_game_counts,
+    query_position_wdl_batch,
     query_rating_history,
     query_results_by_color,
     query_results_by_time_control,
@@ -211,17 +211,9 @@ async def get_most_played_openings(
         opponent_type=opponent_type,
     )
 
-    # Collect all full_hashes to batch-query position-based game counts
-    all_hashes: list[int] = []
-    for rows in (white_rows, black_rows):
-        for row in rows:
-            full_hash = row[4]  # full_hash is at index 4
-            if full_hash is not None:
-                all_hashes.append(full_hash)
-
-    # Get position-based game counts — games passing through each position,
+    # Batch-query position-based WDL — games passing through each position,
     # which is typically higher than the opening-name count because many
-    # openings share early moves
+    # openings share early moves. This matches "Results by Opening" counts.
     filter_kwargs = dict(
         time_control=time_control,
         platform=platform,
@@ -229,12 +221,12 @@ async def get_most_played_openings(
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
     )
-    white_position_counts = await query_position_game_counts(
+    white_position_wdl = await query_position_wdl_batch(
         session, user_id,
         [row[4] for row in white_rows if row[4] is not None],
         color="white", **filter_kwargs,
     )
-    black_position_counts = await query_position_game_counts(
+    black_position_wdl = await query_position_wdl_batch(
         session, user_id,
         [row[4] for row in black_rows if row[4] is not None],
         color="black", **filter_kwargs,
@@ -242,13 +234,15 @@ async def get_most_played_openings(
 
     def rows_to_openings(
         rows: list[tuple],
-        position_counts: dict[int, int],
+        position_wdl: dict,
     ) -> list[OpeningWDL]:
         openings = []
         for eco, name, pgn, fen, full_hash, total, wins, draws, losses in rows:
-            # Use position-based game count if available, falling back to
-            # opening-name count for openings without a hash
-            display_total = position_counts.get(full_hash, total) if full_hash else total
+            # Use position-based WDL if available, falling back to
+            # opening-name WDL for openings without a hash
+            pos = position_wdl.get(full_hash) if full_hash else None
+            if pos:
+                total, wins, draws, losses = pos.total, pos.wins, pos.draws, pos.losses
             if total > 0:
                 win_pct = round(wins / total * 100, 1)
                 draw_pct = round(draws / total * 100, 1)
@@ -266,7 +260,7 @@ async def get_most_played_openings(
                     wins=wins,
                     draws=draws,
                     losses=losses,
-                    total=display_total,
+                    total=total,
                     win_pct=win_pct,
                     draw_pct=draw_pct,
                     loss_pct=loss_pct,
@@ -278,6 +272,6 @@ async def get_most_played_openings(
         return openings
 
     return MostPlayedOpeningsResponse(
-        white=rows_to_openings(white_rows, white_position_counts),
-        black=rows_to_openings(black_rows, black_position_counts),
+        white=rows_to_openings(white_rows, white_position_wdl),
+        black=rows_to_openings(black_rows, black_position_wdl),
     )

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -272,6 +272,9 @@ async def get_most_played_openings(
                     loss_pct=loss_pct,
                 )
             )
+        # Sort by position-based game count descending (may differ from
+        # the opening-name-based order returned by the SQL query)
+        openings.sort(key=lambda o: o.total, reverse=True)
         return openings
 
     return MostPlayedOpeningsResponse(

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,6 +1,9 @@
 """Stats service: aggregation logic for rating history and global stats."""
 
+import io
+
 import chess as chess_lib
+import chess.pgn
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
@@ -220,7 +223,13 @@ async def get_most_played_openings(
                 loss_pct = round(losses / total * 100, 1)
             else:
                 win_pct = draw_pct = loss_pct = 0.0
-            board = chess_lib.Board(fen)
+            # Replay PGN to get correct board state (castling, en passant, side to move)
+            # — board_fen() loses these, producing wrong polyglot Zobrist hashes
+            board = chess_lib.Board()
+            pgn_game = chess.pgn.read_game(io.StringIO(pgn))
+            if pgn_game:
+                for move in pgn_game.mainline_moves():
+                    board.push(move)
             _, _, full_hash = compute_hashes(board)
             openings.append(
                 OpeningWDL(

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,5 +1,6 @@
 """Stats service: aggregation logic for rating history and global stats."""
 
+import chess as chess_lib
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.stats_repository import (
@@ -17,6 +18,7 @@ from app.schemas.stats import (
     WDLByCategory,
 )
 from app.services.analysis_service import recency_cutoff
+from app.services.zobrist import compute_hashes
 
 # Minimum number of games required for an opening to appear in top openings.
 MIN_GAMES_FOR_OPENING = 1
@@ -218,6 +220,8 @@ async def get_most_played_openings(
                 loss_pct = round(losses / total * 100, 1)
             else:
                 win_pct = draw_pct = loss_pct = 0.0
+            board = chess_lib.Board(fen)
+            _, _, full_hash = compute_hashes(board)
             openings.append(
                 OpeningWDL(
                     opening_eco=eco,
@@ -225,6 +229,7 @@ async def get_most_played_openings(
                     label=f"{name} ({eco})",
                     pgn=pgn,
                     fen=fen,
+                    full_hash=str(full_hash),
                     wins=wins,
                     draws=draws,
                     losses=losses,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,7 +3,7 @@ import { queryClient } from '@/lib/queryClient';
 import type {
   PositionBookmarkResponse, PositionBookmarkCreate, PositionBookmarkUpdate,
   PositionBookmarkReorderRequest, TimeSeriesRequest, TimeSeriesResponse,
-  MatchSideUpdateRequest, SuggestionsResponse
+  MatchSideUpdateRequest
 } from '@/types/position_bookmarks';
 import type { RatingHistoryResponse, GlobalStatsResponse, MostPlayedOpeningsResponse } from '@/types/stats';
 import type { EndgameStatsResponse, EndgameGamesResponse, EndgamePerformanceResponse, EndgameTimelineResponse, ConvRecovTimelineResponse } from '@/types/endgames';
@@ -76,8 +76,6 @@ export const positionBookmarksApi = {
     apiClient.put<PositionBookmarkResponse[]>('/position-bookmarks/reorder', req).then(r => r.data),
   updateMatchSide: (id: number, data: MatchSideUpdateRequest) =>
     apiClient.patch<PositionBookmarkResponse>(`/position-bookmarks/${id}/match-side`, data).then(r => r.data),
-  getSuggestions: () =>
-    apiClient.get<SuggestionsResponse>('/position-bookmarks/suggestions').then(r => r.data),
 };
 
 // ─── Time Series API ──────────────────────────────────────────────────────────

--- a/frontend/src/components/charts/WDLChartRow.tsx
+++ b/frontend/src/components/charts/WDLChartRow.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, FolderOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   WDL_WIN,
@@ -34,6 +34,11 @@ interface WDLChartRowProps {
   /** aria-label for the games link */
   gamesLinkAriaLabel?: string;
 
+  /** Optional button-based games action — renders a FolderOpen icon next to game count */
+  onOpenGames?: () => void;
+  /** data-testid for the open games button */
+  openGamesTestId?: string;
+
   /** When present, renders a grey-outlined proportional game count bar. Value = max total across all rows for proportional sizing. */
   maxTotal?: number;
 
@@ -58,6 +63,8 @@ export function WDLChartRow({
   onGamesLinkClick,
   gamesLinkTestId,
   gamesLinkAriaLabel,
+  onOpenGames,
+  openGamesTestId,
   maxTotal,
   minGamesForReliable = MIN_GAMES_FOR_RELIABLE_STATS,
   barHeight = 'h-5',
@@ -107,6 +114,16 @@ export function WDLChartRow({
               >
                 <ExternalLink className="h-3.5 w-3.5" />
               </Link>
+            )}
+            {onOpenGames !== undefined && (
+              <button
+                onClick={onOpenGames}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="View games for this opening"
+                data-testid={openGamesTestId}
+              >
+                <FolderOpen className="h-3.5 w-3.5" />
+              </button>
             )}
           </span>
         </div>

--- a/frontend/src/components/charts/WDLChartRow.tsx
+++ b/frontend/src/components/charts/WDLChartRow.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { ExternalLink, FolderOpen } from 'lucide-react';
+import { FolderOpen } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   WDL_WIN,
@@ -92,40 +92,42 @@ export function WDLChartRow({
             <span className="text-sm font-medium">{label}</span>
             {infoPopover}
           </span>
-          <span className="inline-flex items-center gap-1.5">
-            <span className="text-xs text-muted-foreground">
-              {data.total} games
-              {showLowWarning && isUnreliable && (
-                <span
-                  className="text-amber-500 ml-1"
-                  title="Small sample size — percentages may be unreliable"
-                >
-                  (low)
-                </span>
-              )}
+          {gamesLink !== undefined ? (
+            <Link
+              to={gamesLink}
+              onClick={onGamesLinkClick}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={gamesLinkAriaLabel}
+              data-testid={gamesLinkTestId}
+            >
+              <span>{data.total} games</span>
+              <FolderOpen className="h-3.5 w-3.5" />
+            </Link>
+          ) : onOpenGames !== undefined ? (
+            <button
+              onClick={onOpenGames}
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="View games for this opening"
+              data-testid={openGamesTestId}
+            >
+              <span>{data.total} games</span>
+              <FolderOpen className="h-3.5 w-3.5" />
+            </button>
+          ) : (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                {data.total} games
+              </span>
             </span>
-            {gamesLink !== undefined && (
-              <Link
-                to={gamesLink}
-                onClick={onGamesLinkClick}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-                aria-label={gamesLinkAriaLabel}
-                data-testid={gamesLinkTestId}
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-              </Link>
-            )}
-            {onOpenGames !== undefined && (
-              <button
-                onClick={onOpenGames}
-                className="text-muted-foreground hover:text-foreground transition-colors"
-                aria-label="View games for this opening"
-                data-testid={openGamesTestId}
-              >
-                <FolderOpen className="h-3.5 w-3.5" />
-              </button>
-            )}
-          </span>
+          )}
+          {showLowWarning && isUnreliable && (
+            <span
+              className="text-xs text-amber-500 ml-1"
+              title="Small sample size — percentages may be unreliable"
+            >
+              (low)
+            </span>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -134,7 +134,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                 className={cn(
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isTimeControlActive(tc)
-                    ? 'border-primary bg-primary text-primary-foreground'
+                    ? 'border-toggle-active bg-toggle-active text-toggle-active-foreground'
                     : 'border-border bg-inactive-bg text-muted-foreground hover:bg-inactive-bg-hover hover:text-foreground',
                 )}
               >
@@ -160,7 +160,7 @@ export function FilterPanel({ filters, onChange, visibleFilters = ALL_FILTERS }:
                 className={cn(
                   'rounded border h-11 sm:h-7 text-xs transition-colors',
                   isPlatformActive(p)
-                    ? 'border-primary bg-primary text-primary-foreground'
+                    ? 'border-toggle-active bg-toggle-active text-toggle-active-foreground'
                     : 'border-border bg-inactive-bg text-muted-foreground hover:bg-inactive-bg-hover hover:text-foreground',
                 )}
               >

--- a/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
@@ -9,6 +9,27 @@ import type { PositionBookmarkResponse } from '@/types/position_bookmarks';
 import type { MatchSide } from '@/types/api';
 import { MiniBoard } from './MiniBoard';
 
+// Max characters for displayed label before truncation (keeps ~2 lines in card)
+const MAX_DISPLAY_LABEL_LENGTH = 35;
+
+/** Truncate label while preserving the ECO code suffix e.g. "(B12)".
+ *  "Caro-Kann Defense: Advance Variation, Botvinnik-Carls Defense (B12)"
+ *  → "Caro-Kann Defense: Advance Va... (B12)" */
+function truncateLabel(label: string): string {
+  if (label.length <= MAX_DISPLAY_LABEL_LENGTH) return label;
+  // Extract trailing ECO suffix like " (B12)" or " (A00)"
+  const ecoMatch = label.match(/\s*\([A-E]\d{2}\)$/);
+  if (!ecoMatch) {
+    // No ECO suffix — simple truncation
+    return label.slice(0, MAX_DISPLAY_LABEL_LENGTH - 3).trimEnd() + '...';
+  }
+  const eco = ecoMatch[0]; // e.g. " (B12)"
+  const name = label.slice(0, label.length - eco.length);
+  const maxNameLen = MAX_DISPLAY_LABEL_LENGTH - eco.length - 3; // 3 for "..."
+  if (name.length <= maxNameLen) return label;
+  return name.slice(0, maxNameLen).trimEnd() + '...' + eco;
+}
+
 interface Props {
   bookmark: PositionBookmarkResponse;
   onLoad: (bookmark: PositionBookmarkResponse) => void;
@@ -135,7 +156,7 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
               data-testid={`bookmark-label-${bookmark.id}`}
               aria-label={`Edit bookmark label: ${bookmark.label}`}
             >
-              {bookmark.label}
+              {truncateLabel(bookmark.label)}
             </button>
           )}
         </div>

--- a/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
@@ -12,9 +12,11 @@ import { MiniBoard } from './MiniBoard';
 interface Props {
   bookmark: PositionBookmarkResponse;
   onLoad: (bookmark: PositionBookmarkResponse) => void;
+  chartEnabled: boolean;
+  onChartEnabledChange: (id: number, enabled: boolean) => void;
 }
 
-export function PositionBookmarkCard({ bookmark, onLoad }: Props) {
+export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEnabledChange }: Props) {
   const updateLabel = useUpdatePositionBookmarkLabel();
   const deleteBookmark = useDeletePositionBookmark();
   const updateMatchSide = useUpdateMatchSide();
@@ -89,16 +91,16 @@ export function PositionBookmarkCard({ bookmark, onLoad }: Props) {
         ☰
       </span>
 
-      {/* Mini board thumbnail — always visible; smaller on mobile */}
+      {/* Mini board thumbnail — always visible; slightly larger for better readability */}
       <div
         className="shrink-0"
         data-testid={`bookmark-mini-board-${bookmark.id}`}
         style={{ opacity: updateMatchSide.isPending ? 0.6 : 1, transition: 'opacity 0.15s' }}
       >
-        <MiniBoard fen={bookmark.fen} flipped={bookmark.is_flipped} size={60} />
+        <MiniBoard fen={bookmark.fen} flipped={bookmark.is_flipped} size={72} />
       </div>
 
-      {/* Label + piece filter stacked */}
+      {/* Label + piece filter + button row stacked */}
       <div className="flex-1 min-w-0 flex flex-col gap-1">
         {/* Editable label with color circle */}
         <div className="flex items-center gap-1.5">
@@ -167,33 +169,39 @@ export function PositionBookmarkCard({ bookmark, onLoad }: Props) {
             Both
           </ToggleGroupItem>
         </ToggleGroup>
-      </div>
 
-      {/* Load & Delete buttons stacked */}
-      <div className="flex flex-col justify-between self-stretch shrink-0">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          onMouseDown={() => { isDirtyRef.current = true; }}
-          onClick={handleLoad}
-          data-testid={`bookmark-btn-load-${bookmark.id}`}
-          aria-label="Load bookmark"
-        >
-          <Upload size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 text-muted-foreground hover:text-destructive"
-          onMouseDown={() => { isDirtyRef.current = true; }}
-          onClick={handleDelete}
-          disabled={deleteBookmark.isPending}
-          data-testid={`bookmark-btn-delete-${bookmark.id}`}
-          aria-label={`Delete bookmark: ${bookmark.label}`}
-        >
-          <Trash2 size={15} />
-        </Button>
+        {/* Button row: chart toggle, load, delete */}
+        <div className="flex items-center justify-between mt-1">
+          {/* Chart toggle on left */}
+          <button
+            role="switch"
+            aria-checked={chartEnabled}
+            aria-label="Include in charts"
+            onClick={() => onChartEnabledChange(bookmark.id, !chartEnabled)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${chartEnabled ? 'bg-primary' : 'bg-muted'}`}
+            data-testid={`bookmark-chart-toggle-${bookmark.id}`}
+          >
+            <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${chartEnabled ? 'translate-x-4' : 'translate-x-0.5'}`} />
+          </button>
+          {/* Load button in middle */}
+          <Button variant="ghost" size="icon" className="h-7 w-7"
+            onMouseDown={() => { isDirtyRef.current = true; }}
+            onClick={handleLoad}
+            data-testid={`bookmark-btn-load-${bookmark.id}`}
+            aria-label="Load bookmark">
+            <Upload size={15} />
+          </Button>
+          {/* Delete button on right */}
+          <Button variant="ghost" size="icon"
+            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+            onMouseDown={() => { isDirtyRef.current = true; }}
+            onClick={handleDelete}
+            disabled={deleteBookmark.isPending}
+            data-testid={`bookmark-btn-delete-${bookmark.id}`}
+            aria-label={`Delete bookmark: ${bookmark.label}`}>
+            <Trash2 size={15} />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
@@ -97,7 +97,7 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
         data-testid={`bookmark-mini-board-${bookmark.id}`}
         style={{ opacity: updateMatchSide.isPending ? 0.6 : 1, transition: 'opacity 0.15s' }}
       >
-        <MiniBoard fen={bookmark.fen} flipped={bookmark.is_flipped} size={72} />
+        <MiniBoard fen={bookmark.fen} flipped={bookmark.is_flipped} size={84} />
       </div>
 
       {/* Label + piece filter + button row stacked */}
@@ -178,7 +178,7 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
             aria-checked={chartEnabled}
             aria-label="Include in charts"
             onClick={() => onChartEnabledChange(bookmark.id, !chartEnabled)}
-            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${chartEnabled ? 'bg-primary' : 'bg-muted'}`}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${chartEnabled ? 'bg-toggle-active' : 'bg-muted'}`}
             data-testid={`bookmark-chart-toggle-${bookmark.id}`}
           >
             <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${chartEnabled ? 'translate-x-4' : 'translate-x-0.5'}`} />

--- a/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkCard.tsx
@@ -52,7 +52,14 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
 
   const handleLabelKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
-      e.currentTarget.blur();
+      // Save directly on Enter — don't rely on blur chain which can be
+      // interrupted by sortable container focus management
+      const trimmed = labelValue.trim();
+      if (trimmed && trimmed !== bookmark.label) {
+        updateLabel.mutate({ id: bookmark.id, data: { label: trimmed } });
+      }
+      isDirtyRef.current = true; // prevent double-save from subsequent blur
+      setIsEditing(false);
     } else if (e.key === 'Escape') {
       isDirtyRef.current = true;
       setLabelValue(bookmark.label);
@@ -141,14 +148,14 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
           variant="outline"
           size="sm"
           data-testid={`bookmark-match-side-${bookmark.id}`}
-          className="justify-start"
+          className="w-full"
           aria-label="Piece filter"
         >
           <ToggleGroupItem
             value="mine"
             data-testid={`bookmark-match-side-${bookmark.id}-mine`}
             aria-label="Match my pieces only"
-            className="text-xs h-6 px-2"
+            className="text-xs h-6 px-2 flex-1"
           >
             Mine
           </ToggleGroupItem>
@@ -156,7 +163,7 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
             value="opponent"
             data-testid={`bookmark-match-side-${bookmark.id}-opponent`}
             aria-label="Match opponent pieces only"
-            className="text-xs h-6 px-2"
+            className="text-xs h-6 px-2 flex-1"
           >
             Opponent
           </ToggleGroupItem>
@@ -164,7 +171,7 @@ export function PositionBookmarkCard({ bookmark, onLoad, chartEnabled, onChartEn
             value="both"
             data-testid={`bookmark-match-side-${bookmark.id}-both`}
             aria-label="Match both sides"
-            className="text-xs h-6 px-2"
+            className="text-xs h-6 px-2 flex-1"
           >
             Both
           </ToggleGroupItem>

--- a/frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
@@ -21,9 +21,11 @@ interface Props {
   bookmarks: PositionBookmarkResponse[];
   onReorder: (orderedIds: number[]) => void;
   onLoad: (bookmark: PositionBookmarkResponse) => void;
+  chartEnabledMap: Record<number, boolean>;
+  onChartEnabledChange: (id: number, enabled: boolean) => void;
 }
 
-export function PositionBookmarkList({ bookmarks, onReorder, onLoad }: Props) {
+export function PositionBookmarkList({ bookmarks, onReorder, onLoad, chartEnabledMap, onChartEnabledChange }: Props) {
   const [items, setItems] = useState(bookmarks);
 
   // Sync when server data refreshes (e.g., after delete or label edit)
@@ -58,7 +60,13 @@ export function PositionBookmarkList({ bookmarks, onReorder, onLoad }: Props) {
           <SortableContext items={items.map((b) => b.id)} strategy={verticalListSortingStrategy}>
             <div className="space-y-2">
               {items.map((b) => (
-                <PositionBookmarkCard key={b.id} bookmark={b} onLoad={onLoad} />
+                <PositionBookmarkCard
+                  key={b.id}
+                  bookmark={b}
+                  onLoad={onLoad}
+                  chartEnabled={chartEnabledMap[b.id] !== false}
+                  onChartEnabledChange={onChartEnabledChange}
+                />
               ))}
             </div>
           </SortableContext>

--- a/frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
+++ b/frontend/src/components/position-bookmarks/PositionBookmarkList.tsx
@@ -53,7 +53,7 @@ export function PositionBookmarkList({ bookmarks, onReorder, onLoad, chartEnable
     <>
       {items.length === 0 ? (
         <p className="px-2 text-xs text-muted-foreground break-words">
-          No position bookmarks yet. Use the &apos;Bookmark&apos; button to save positions, or use &apos;Suggest&apos; to auto-generate from your most-played openings.
+          No position bookmarks yet. Use the &apos;Save&apos; button to save positions, or use &apos;Suggest&apos; to auto-generate from your most-played openings.
         </p>
       ) : (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/frontend/src/components/position-bookmarks/SuggestionsModal.tsx
+++ b/frontend/src/components/position-bookmarks/SuggestionsModal.tsx
@@ -12,6 +12,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { MiniBoard } from './MiniBoard';
 import { positionBookmarksApi } from '@/api/client';
+import { pgnToSanArray } from '@/lib/pgn';
 import type { MostPlayedOpeningsResponse, OpeningWDL } from '@/types/stats';
 import type { PositionBookmarkResponse } from '@/types/position_bookmarks';
 
@@ -97,7 +98,7 @@ export function SuggestionsModal({ open, onOpenChange, mostPlayedData, bookmarks
         label: opening.label,
         target_hash: opening.full_hash,
         fen: opening.fen,
-        moves: [],  // opening moves not needed for hash-based matching
+        moves: pgnToSanArray(opening.pgn),
         color: color,
         match_side: 'both',
         is_flipped: color === 'black',

--- a/frontend/src/components/position-bookmarks/SuggestionsModal.tsx
+++ b/frontend/src/components/position-bookmarks/SuggestionsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   Dialog,
@@ -11,64 +11,79 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { MiniBoard } from './MiniBoard';
-import { usePositionSuggestions } from '@/hooks/usePositionBookmarks';
 import { positionBookmarksApi } from '@/api/client';
-import type { PositionSuggestion } from '@/types/position_bookmarks';
+import type { MostPlayedOpeningsResponse, OpeningWDL } from '@/types/stats';
+import type { PositionBookmarkResponse } from '@/types/position_bookmarks';
+
+// Maximum openings per color to consider before filtering already-bookmarked ones
+const SUGGESTIONS_POOL_SIZE = 10;
+// Maximum suggestions to show per color after filtering
+const SUGGESTIONS_PER_COLOR = 5;
 
 interface SuggestionsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  mostPlayedData: MostPlayedOpeningsResponse | undefined;
+  bookmarks: PositionBookmarkResponse[];
 }
 
-export function SuggestionsModal({ open, onOpenChange }: SuggestionsModalProps) {
+export function SuggestionsModal({ open, onOpenChange, mostPlayedData, bookmarks }: SuggestionsModalProps) {
   const qc = useQueryClient();
-  const { data, isFetching, refetch } = usePositionSuggestions();
-  const suggestions = data?.suggestions ?? [];
 
-  // Per-suggestion state: selected for saving
-  const [selected, setSelected] = useState<Set<number>>(new Set());
+  // Per-suggestion state: selected for saving (keyed by color+index string)
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const [saving, setSaving] = useState(false);
   const [saveProgress, setSaveProgress] = useState(0);
 
-  // Fetch on open
-  useEffect(() => {
-    if (open) {
-      refetch();
-    }
-  }, [open, refetch]);
+  // Derive suggestions from mostPlayedData, filtering out already-bookmarked positions
+  const bookmarkedHashes = new Set(
+    bookmarks.filter(b => b.match_side === 'both').map(b => b.target_hash)
+  );
 
-  // Reset selection when suggestions load
-  /* eslint-disable react-hooks/set-state-in-effect -- intentional: reset state on new data */
-  useEffect(() => {
-    if (suggestions.length > 0) {
-      setSelected(new Set());
-      setSaveProgress(0);
-    }
-  }, [suggestions]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  const whiteSuggestions: OpeningWDL[] = mostPlayedData
+    ? mostPlayedData.white
+        .slice(0, SUGGESTIONS_POOL_SIZE)
+        .filter(o => !bookmarkedHashes.has(o.full_hash))
+        .slice(0, SUGGESTIONS_PER_COLOR)
+    : [];
 
-  const whiteSuggestions = suggestions.filter(s => s.color === 'white');
-  const blackSuggestions = suggestions.filter(s => s.color === 'black');
+  const blackSuggestions: OpeningWDL[] = mostPlayedData
+    ? mostPlayedData.black
+        .slice(0, SUGGESTIONS_POOL_SIZE)
+        .filter(o => !bookmarkedHashes.has(o.full_hash))
+        .slice(0, SUGGESTIONS_PER_COLOR)
+    : [];
 
-  const getIndexInSuggestions = (s: PositionSuggestion) => suggestions.indexOf(s);
+  const allSuggestions = whiteSuggestions.length === 0 && blackSuggestions.length === 0;
+  const allBookmarked =
+    mostPlayedData !== undefined &&
+    mostPlayedData.white.slice(0, SUGGESTIONS_POOL_SIZE).every(o => bookmarkedHashes.has(o.full_hash)) &&
+    mostPlayedData.black.slice(0, SUGGESTIONS_POOL_SIZE).every(o => bookmarkedHashes.has(o.full_hash));
 
-  const toggleSelected = (index: number) => {
+  const makeKey = (color: 'white' | 'black', index: number) => `${color}-${index}`;
+
+  const toggleSelected = (color: 'white' | 'black', index: number) => {
+    const key = makeKey(color, index);
     setSelected(prev => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
+      if (next.has(key)) {
+        next.delete(key);
       } else {
-        next.add(index);
+        next.add(key);
       }
       return next;
     });
   };
 
   const handleSave = async () => {
-    const toSave = suggestions
-      .map((s, i) => ({ suggestion: s, index: i }))
-      .filter(({ index }) => selected.has(index));
+    const toSave: { opening: OpeningWDL; color: 'white' | 'black' }[] = [];
+    whiteSuggestions.forEach((o, i) => {
+      if (selected.has(makeKey('white', i))) toSave.push({ opening: o, color: 'white' });
+    });
+    blackSuggestions.forEach((o, i) => {
+      if (selected.has(makeKey('black', i))) toSave.push({ opening: o, color: 'black' });
+    });
 
     if (toSave.length === 0) return;
 
@@ -76,19 +91,16 @@ export function SuggestionsModal({ open, onOpenChange }: SuggestionsModalProps) 
     setSaveProgress(0);
 
     for (let i = 0; i < toSave.length; i++) {
-      const { suggestion, index } = toSave[i];
-
-      const label = suggestion.opening_name
-        ?? `${suggestion.color} opening #${index + 1}`;
+      const { opening, color } = toSave[i];
 
       await positionBookmarksApi.create({
-        label,
-        target_hash: suggestion.full_hash,
-        fen: suggestion.fen,
-        moves: suggestion.moves,
-        color: suggestion.color,
+        label: opening.label,
+        target_hash: opening.full_hash,
+        fen: opening.fen,
+        moves: [],  // opening moves not needed for hash-based matching
+        color: color,
         match_side: 'both',
-        is_flipped: suggestion.color === 'black',
+        is_flipped: color === 'black',
       });
 
       setSaveProgress(i + 1);
@@ -97,6 +109,7 @@ export function SuggestionsModal({ open, onOpenChange }: SuggestionsModalProps) 
     await qc.invalidateQueries({ queryKey: ['position-bookmarks'] });
     await qc.refetchQueries({ queryKey: ['position-bookmarks'] });
     setSaving(false);
+    setSelected(new Set());
     onOpenChange(false);
   };
 
@@ -107,52 +120,50 @@ export function SuggestionsModal({ open, onOpenChange }: SuggestionsModalProps) 
       ? `Save ${selectedCount} bookmark${selectedCount !== 1 ? 's' : ''}`
       : 'Save selected';
 
-  const renderSuggestionCard = (suggestion: PositionSuggestion) => {
-    const globalIndex = getIndexInSuggestions(suggestion);
-    const isSelected = selected.has(globalIndex);
-    const openingLabel = suggestion.opening_name ?? 'Unknown opening';
-    const ecoLabel = suggestion.opening_eco ? ` (${suggestion.opening_eco})` : '';
+  const renderSuggestionCard = (opening: OpeningWDL, color: 'white' | 'black', index: number) => {
+    const key = makeKey(color, index);
+    const isSelected = selected.has(key);
 
     return (
       <div
-        key={globalIndex}
-        data-testid={`suggestion-card-${globalIndex}`}
+        key={key}
+        data-testid={`suggestion-card-${key}`}
         className={`flex gap-3 items-start p-3 rounded-lg border transition-colors ${
           isSelected ? 'border-primary/50 bg-primary/5' : 'border-border bg-muted/30'
         }`}
       >
         <Checkbox
           checked={isSelected}
-          onCheckedChange={() => toggleSelected(globalIndex)}
-          aria-label={`Select ${openingLabel}`}
+          onCheckedChange={() => toggleSelected(color, index)}
+          aria-label={`Select ${opening.label}`}
           className="mt-1 flex-shrink-0"
-          data-testid={`suggestion-checkbox-${globalIndex}`}
+          data-testid={`suggestion-checkbox-${key}`}
         />
         <MiniBoard
-          fen={suggestion.fen}
-          flipped={suggestion.color === 'black'}
+          fen={opening.fen}
+          flipped={color === 'black'}
           size={100}
         />
         <div className="flex flex-col gap-1 flex-1 min-w-0">
           <span className="font-medium text-sm truncate">
-            {openingLabel}{ecoLabel}
+            {opening.label}
           </span>
           <Badge variant="secondary" className="w-fit text-xs">
-            {suggestion.game_count} {suggestion.game_count === 1 ? 'game' : 'games'}
+            {opening.total} {opening.total === 1 ? 'game' : 'games'}
           </Badge>
         </div>
       </div>
     );
   };
 
-  const renderSection = (title: string, sectionSuggestions: PositionSuggestion[]) => {
+  const renderSection = (title: string, sectionSuggestions: OpeningWDL[], color: 'white' | 'black') => {
     if (sectionSuggestions.length === 0) return null;
     return (
       <div className="space-y-2">
         <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
           {title}
         </h3>
-        {sectionSuggestions.map((s) => renderSuggestionCard(s))}
+        {sectionSuggestions.map((o, i) => renderSuggestionCard(o, color, i))}
       </div>
     );
   };
@@ -168,27 +179,33 @@ export function SuggestionsModal({ open, onOpenChange }: SuggestionsModalProps) 
         </DialogHeader>
 
         <div className="flex-1 overflow-y-auto space-y-4 pr-1">
-          {isFetching && (
+          {mostPlayedData === undefined && (
             <div className="text-center py-8 text-muted-foreground text-sm">
               Loading suggestions...
             </div>
           )}
 
-          {!isFetching && suggestions.length === 0 && (
+          {mostPlayedData !== undefined && allSuggestions && allBookmarked && (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              All your most-played openings are already bookmarked. Try creating custom bookmarks on the board and experimenting with the Piece filter.
+            </div>
+          )}
+
+          {mostPlayedData !== undefined && allSuggestions && !allBookmarked && (
             <div className="text-center py-8 text-muted-foreground text-sm">
               No suggestions available. Import games to get bookmark suggestions based on your most-played openings.
             </div>
           )}
 
-          {!isFetching && suggestions.length > 0 && (
+          {mostPlayedData !== undefined && !allSuggestions && (
             <>
-              {renderSection('White openings', whiteSuggestions)}
-              {renderSection('Black openings', blackSuggestions)}
+              {renderSection('White openings', whiteSuggestions, 'white')}
+              {renderSection('Black openings', blackSuggestions, 'black')}
             </>
           )}
         </div>
 
-        {!isFetching && suggestions.length > 0 && (
+        {mostPlayedData !== undefined && !allSuggestions && (
           <DialogFooter>
             <Button
               data-testid="btn-save-suggestions"

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { Toggle as TogglePrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:border-primary dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-toggle-active aria-pressed:text-toggle-active-foreground aria-pressed:border-toggle-active data-[state=on]:bg-toggle-active data-[state=on]:text-toggle-active-foreground data-[state=on]:border-toggle-active dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/frontend/src/hooks/usePositionBookmarks.ts
+++ b/frontend/src/hooks/usePositionBookmarks.ts
@@ -92,11 +92,3 @@ export function useTimeSeries(req: TimeSeriesRequest | null) {
   });
 }
 
-export function usePositionSuggestions() {
-  return useQuery({
-    queryKey: ['position-bookmark-suggestions'],
-    queryFn: positionBookmarksApi.getSuggestions,
-    staleTime: 60_000,
-    enabled: false,  // only fetch when user clicks "Suggest bookmarks"
-  });
-}

--- a/frontend/src/hooks/usePositionBookmarks.ts
+++ b/frontend/src/hooks/usePositionBookmarks.ts
@@ -38,6 +38,8 @@ export function useDeletePositionBookmark() {
       qc.setQueryData(['position-bookmarks'], (old: unknown) =>
         (old as PositionBookmarkResponse[])?.filter((b) => b.id !== id)
       );
+      // Clean up chart-enable toggle state so re-created bookmarks default to enabled
+      localStorage.removeItem(`bookmark-chart-enabled-${id}`);
       return { prev };
     },
     onError: (_: Error, __: number, ctx: DeleteContext | undefined) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -47,6 +47,8 @@
     --inactive-bg: #171717;
     --inactive-bg-hover: #262626;
     --sidebar-bg: #171513;
+    --toggle-active: oklch(0.55 0 0);
+    --toggle-active-foreground: oklch(0.98 0 0);
 }
 
 .dark {
@@ -81,6 +83,8 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+    --toggle-active: oklch(0.55 0 0);
+    --toggle-active-foreground: oklch(0.98 0 0);
 }
 
 @theme inline {
@@ -131,6 +135,8 @@
     --color-inactive-bg: var(--inactive-bg);
     --color-inactive-bg-hover: var(--inactive-bg-hover);
     --color-sidebar-bg: var(--sidebar-bg);
+    --color-toggle-active: var(--toggle-active);
+    --color-toggle-active-foreground: var(--toggle-active-foreground);
 }
 
 @layer base {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,13 @@
 import { useState, useCallback, useMemo } from 'react';
+
+// localStorage helpers for per-bookmark chart-enable toggle (default: enabled)
+function getChartEnabled(bookmarkId: number): boolean {
+  const stored = localStorage.getItem(`bookmark-chart-enabled-${bookmarkId}`);
+  return stored === null ? true : stored === 'true';
+}
+function setChartEnabledStorage(bookmarkId: number, enabled: boolean): void {
+  localStorage.setItem(`bookmark-chart-enabled-${bookmarkId}`, String(enabled));
+}
 import { Chess } from 'chess.js';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -58,6 +67,21 @@ export function DashboardPage() {
   const reorder = useReorderPositionBookmarks();
   const [bookmarkDialogOpen, setBookmarkDialogOpen] = useState(false);
   const [bookmarkLabel, setBookmarkLabel] = useState('');
+
+  // Chart-enable toggle (persisted per bookmark in localStorage)
+  const [chartToggleVersion, setChartToggleVersion] = useState(0);
+  const chartEnabledMap = useMemo(() => {
+    const map: Record<number, boolean> = {};
+    for (const b of bookmarks) {
+      map[b.id] = getChartEnabled(b.id);
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookmarks, chartToggleVersion]);
+  const handleChartEnabledChange = useCallback((id: number, enabled: boolean) => {
+    setChartEnabledStorage(id, enabled);
+    setChartToggleVersion(v => v + 1);
+  }, []);
 
   // Filter state
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS);
@@ -429,6 +453,8 @@ export function DashboardPage() {
               bookmarks={bookmarks}
               onReorder={handleReorder}
               onLoad={handleLoadBookmark}
+              chartEnabledMap={chartEnabledMap}
+              onChartEnabledChange={handleChartEnabledChange}
             />
           </div>
         </CollapsibleContent>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -707,7 +707,7 @@ export function OpeningsPage() {
                     Your most frequently played openings as White, based on the lichess opening table. Only openings where White made the last move are shown here.
                   </p>
                   <p>
-                    The game count reflects how many of your games ended up with this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                    The game count shows how many of your games passed through that position — this is usually more than just the games classified under that specific opening name, since many openings share the same early moves. Clicking the folder icon loads the opening on the board and shows those games.
                   </p>
                 </div>
               </InfoPopover>
@@ -734,7 +734,7 @@ export function OpeningsPage() {
                     Your most frequently played openings as Black, based on the lichess opening table. Only openings where Black made the last move are shown here.
                   </p>
                   <p>
-                    The game count reflects how many of your games ended up with this specific opening name. Clicking the folder icon loads the opening on the board and shows all games that passed through that position — which is usually more, since many openings share the same early moves.
+                    The game count shows how many of your games passed through that position — this is usually more than just the games classified under that specific opening name, since many openings share the same early moves. Clicking the folder icon loads the opening on the board and shows those games.
                   </p>
                 </div>
               </InfoPopover>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -311,7 +311,7 @@ export function OpeningsPage() {
     setBoardFlipped(color === 'black');
     setFilters(prev => ({ ...prev, color, matchSide: bookmark.match_side }));
     navigate('/openings/games');
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0 });
   }, [chess, navigate, mostPlayedData]);
 
   /** Load opening PGN onto the board, set color/flip/filters, and navigate to games subtab */
@@ -320,14 +320,14 @@ export function OpeningsPage() {
     setBoardFlipped(color === 'black');
     setFilters(prev => ({ ...prev, color, matchSide: 'both' as MatchSide }));
     navigate('/openings/games');
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0 });
   }, [chess, navigate]);
 
   const handleLoadBookmark = useCallback((bkm: PositionBookmarkResponse) => {
     chess.loadMoves(bkm.moves);
     setBoardFlipped(bkm.is_flipped ?? false);
     setFilters(prev => ({ ...prev, color: bkm.color ?? 'white', matchSide: bkm.match_side }));
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0 });
   }, [chess]);
 
   const handleReorder = useCallback((orderedIds: number[]) => {
@@ -554,7 +554,7 @@ export function OpeningsPage() {
             label={filters.matchSide === 'both' ? 'Position Results' : `Position Results (Piece filter: ${filters.matchSide === 'mine' ? 'Mine' : 'Opponent'})`}
             barHeight="h-6"
             gamesLink="/openings/games"
-            onGamesLinkClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            onGamesLinkClick={() => window.scrollTo({ top: 0 })}
             gamesLinkTestId="btn-moves-to-games"
             gamesLinkAriaLabel="View games for this position"
             testId="wdl-moves-position"

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -1,4 +1,13 @@
 import { useState, useMemo, useCallback } from 'react';
+
+// localStorage helpers for per-bookmark chart-enable toggle (default: enabled)
+function getChartEnabled(bookmarkId: number): boolean {
+  const stored = localStorage.getItem(`bookmark-chart-enabled-${bookmarkId}`);
+  return stored === null ? true : stored === 'true';
+}
+function setChartEnabledStorage(bookmarkId: number, enabled: boolean): void {
+  localStorage.setItem(`bookmark-chart-enabled-${bookmarkId}`, String(enabled));
+}
 import { useNavigate, useLocation, Navigate, Link } from 'react-router-dom';
 import { Chess } from 'chess.js';
 import { useQuery } from '@tanstack/react-query';
@@ -102,6 +111,19 @@ export function OpeningsPage() {
   const [bookmarkLabel, setBookmarkLabel] = useState('');
   const [suggestionsOpen, setSuggestionsOpen] = useState(false);
 
+  // ── Chart-enable toggle (persisted per bookmark in localStorage) ─────────────
+  // Version counter to force chartEnabledMap recompute when a toggle changes
+  const [chartToggleVersion, setChartToggleVersion] = useState(0);
+
+  const chartEnabledMap = useMemo(() => {
+    const map: Record<number, boolean> = {};
+    for (const b of bookmarks) {
+      map[b.id] = getChartEnabled(b.id);
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bookmarks, chartToggleVersion]);
+
   // ── Moves data ──────────────────────────────────────────────────────
   const nextMoves = useNextMoves(chess.hashes.fullHash, debouncedFilters);
 
@@ -190,8 +212,10 @@ export function OpeningsPage() {
     return [...white, ...black];
   }, [bookmarks, mostPlayedData]);
 
-  // Chart entries: real bookmarks if any, else most-played defaults
-  const chartBookmarks = bookmarks.length > 0 ? bookmarks : defaultChartEntries;
+  // Chart entries: real bookmarks filtered by chart-enable toggle, else most-played defaults
+  const chartBookmarks = bookmarks.length > 0
+    ? bookmarks.filter(b => chartEnabledMap[b.id] !== false)
+    : defaultChartEntries;
 
   const timeSeriesRequest: TimeSeriesRequest | null = useMemo(() => {
     if (chartBookmarks.length === 0) return null;
@@ -227,6 +251,11 @@ export function OpeningsPage() {
   }, [tsData]);
 
   // ── Handlers ────────────────────────────────────────────────────────────────
+
+  const handleChartEnabledChange = useCallback((id: number, enabled: boolean) => {
+    setChartEnabledStorage(id, enabled);
+    setChartToggleVersion(v => v + 1);
+  }, []);
 
   const handleFiltersChange = useCallback((newFilters: FilterState) => {
     setFilters(newFilters);
@@ -411,7 +440,17 @@ export function OpeningsPage() {
               Position bookmarks
               <span onClick={(e) => e.stopPropagation()}>
                 <InfoPopover ariaLabel="Position bookmarks info" testId="position-bookmarks-info" side="top">
-                  Save positions as bookmarks to track your openings. Bookmarks appear as entries in the Statistics tab charts, showing your win/draw/loss breakdown and win rate over time for each saved position.
+                  <div className="space-y-2">
+                    <p>
+                      Save positions as bookmarks to track your openings. Bookmarks appear as entries in the Statistics tab charts, showing your win/draw/loss breakdown and win rate over time for each saved position.
+                    </p>
+                    <p>
+                      Each bookmark has a Piece filter setting (Mine/Opponent/Both) that controls how positions are matched. You can change the Piece filter directly on each bookmark card.
+                    </p>
+                    <p>
+                      Use the chart toggle on each bookmark to include or exclude it from the Results by Opening and Win Rate Over Time charts.
+                    </p>
+                  </div>
                 </InfoPopover>
               </span>
             </span>
@@ -445,6 +484,8 @@ export function OpeningsPage() {
               bookmarks={bookmarks}
               onReorder={handleReorder}
               onLoad={handleLoadBookmark}
+              chartEnabledMap={chartEnabledMap}
+              onChartEnabledChange={handleChartEnabledChange}
             />
           </div>
         </CollapsibleContent>
@@ -876,7 +917,17 @@ export function OpeningsPage() {
                   Position bookmarks
                   <span onClick={(e) => e.stopPropagation()}>
                     <InfoPopover ariaLabel="Position bookmarks info" testId="position-bookmarks-info-mobile" side="top">
-                      Save positions as bookmarks to track your openings. Bookmarks appear as entries in the Statistics tab charts, showing your win/draw/loss breakdown and win rate over time for each saved position.
+                      <div className="space-y-2">
+                        <p>
+                          Save positions as bookmarks to track your openings. Bookmarks appear as entries in the Statistics tab charts, showing your win/draw/loss breakdown and win rate over time for each saved position.
+                        </p>
+                        <p>
+                          Each bookmark has a Piece filter setting (Mine/Opponent/Both) that controls how positions are matched. You can change the Piece filter directly on each bookmark card.
+                        </p>
+                        <p>
+                          Use the chart toggle on each bookmark to include or exclude it from the Results by Opening and Win Rate Over Time charts.
+                        </p>
+                      </div>
                     </InfoPopover>
                   </span>
                 </span>
@@ -910,6 +961,8 @@ export function OpeningsPage() {
                   bookmarks={bookmarks}
                   onReorder={handleReorder}
                   onLoad={handleLoadBookmark}
+                  chartEnabledMap={chartEnabledMap}
+                  onChartEnabledChange={handleChartEnabledChange}
                 />
               </div>
             </CollapsibleContent>
@@ -976,7 +1029,12 @@ export function OpeningsPage() {
         </DialogContent>
       </Dialog>
 
-      <SuggestionsModal open={suggestionsOpen} onOpenChange={setSuggestionsOpen} />
+      <SuggestionsModal
+        open={suggestionsOpen}
+        onOpenChange={setSuggestionsOpen}
+        mostPlayedData={mostPlayedData}
+        bookmarks={bookmarks}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -702,14 +702,7 @@ export function OpeningsPage() {
             <span className="inline-flex items-center gap-1">
               Most Played Openings as White
               <InfoPopover ariaLabel="White openings info" testId="mpo-white-info" side="top">
-                <div className="space-y-2">
-                  <p>
-                    Your most frequently played openings as White, based on the lichess opening table. Only openings where White made the last move are shown here.
-                  </p>
-                  <p>
-                    The game count shows how many of your games passed through that position — this is usually more than just the games classified under that specific opening name, since many openings share the same early moves. Clicking the folder icon loads the opening on the board and shows those games.
-                  </p>
-                </div>
+                Your most frequently played openings as White, based on the lichess opening table. Only openings where White made the last move are shown here.
               </InfoPopover>
             </span>
           </h2>
@@ -729,14 +722,7 @@ export function OpeningsPage() {
             <span className="inline-flex items-center gap-1">
               Most Played Openings as Black
               <InfoPopover ariaLabel="Black openings info" testId="mpo-black-info" side="top">
-                <div className="space-y-2">
-                  <p>
-                    Your most frequently played openings as Black, based on the lichess opening table. Only openings where Black made the last move are shown here.
-                  </p>
-                  <p>
-                    The game count shows how many of your games passed through that position — this is usually more than just the games classified under that specific opening name, since many openings share the same early moves. Clicking the folder icon loads the opening on the board and shows those games.
-                  </p>
-                </div>
+                Your most frequently played openings as Black, based on the lichess opening table. Only openings where Black made the last move are shown here.
               </InfoPopover>
             </span>
           </h2>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -327,6 +327,7 @@ export function OpeningsPage() {
     chess.loadMoves(bkm.moves);
     setBoardFlipped(bkm.is_flipped ?? false);
     setFilters(prev => ({ ...prev, color: bkm.color ?? 'white', matchSide: bkm.match_side }));
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [chess]);
 
   const handleReorder = useCallback((orderedIds: number[]) => {

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -294,12 +294,33 @@ export function OpeningsPage() {
     }
   }, [chess, filters, boardFlipped, bookmarkLabel, createBookmark]);
 
+  /** Open games for a chart bookmark — loads position on board and navigates to games tab */
+  const handleOpenChartBookmarkGames = useCallback((bookmark: PositionBookmarkResponse) => {
+    if (bookmark.moves.length > 0) {
+      // Real bookmark — load its moves
+      chess.loadMoves(bookmark.moves);
+    } else if (mostPlayedData) {
+      // Default chart entry — find PGN from most-played data
+      const allOpenings = [...(mostPlayedData.white ?? []), ...(mostPlayedData.black ?? [])];
+      const opening = allOpenings.find(o => o.full_hash === bookmark.target_hash);
+      if (opening) {
+        chess.loadMoves(pgnToSanArray(opening.pgn));
+      }
+    }
+    const color = bookmark.color ?? 'white';
+    setBoardFlipped(color === 'black');
+    setFilters(prev => ({ ...prev, color, matchSide: bookmark.match_side }));
+    navigate('/openings/games');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [chess, navigate, mostPlayedData]);
+
   /** Load opening PGN onto the board, set color/flip/filters, and navigate to games subtab */
   const handleOpenGames = useCallback((pgn: string, color: "white" | "black") => {
     chess.loadMoves(pgnToSanArray(pgn));
     setBoardFlipped(color === 'black');
     setFilters(prev => ({ ...prev, color, matchSide: 'both' as MatchSide }));
     navigate('/openings/games');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [chess, navigate]);
 
   const handleLoadBookmark = useCallback((bkm: PositionBookmarkResponse) => {
@@ -654,6 +675,8 @@ export function OpeningsPage() {
                       }}
                       label={row.label}
                       maxTotal={maxTotal}
+                      onOpenGames={() => handleOpenChartBookmarkGames(row.bookmark)}
+                      openGamesTestId={`wdl-opening-games-${row.bookmark.id}`}
                       testId={`wdl-opening-${row.bookmark.id}`}
                     />
                   ))}

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -50,6 +50,8 @@ import { resolveMatchSide } from '@/types/api';
 import type { PositionBookmarkResponse, TimeSeriesRequest } from '@/types/position_bookmarks';
 
 const PAGE_SIZE = 20;
+// Number of most-played openings per color to use as default chart data when no bookmarks exist
+const DEFAULT_CHART_LIMIT = 3;
 
 export function OpeningsPage() {
   const location = useLocation();
@@ -150,10 +152,51 @@ export function OpeningsPage() {
   const gameCount = gameCountData?.count ?? null;
 
   // ── Statistics tab data ────────────────────────────────────────────────────────
+
+  // Most played openings — filter params applied to show top openings per color
+  const { data: mostPlayedData } = useMostPlayedOpenings({
+    recency: debouncedFilters.recency,
+    timeControls: debouncedFilters.timeControls,
+    platforms: debouncedFilters.platforms,
+    rated: debouncedFilters.rated,
+    opponentType: debouncedFilters.opponentType,
+  });
+
+  // When no bookmarks exist, derive synthetic bookmark entries from most-played openings
+  const defaultChartEntries: PositionBookmarkResponse[] = useMemo(() => {
+    if (bookmarks.length > 0 || !mostPlayedData) return [];
+    const white = mostPlayedData.white.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+      id: -(i + 1),
+      label: o.label,
+      target_hash: o.full_hash,
+      fen: o.fen,
+      moves: [],
+      color: 'white' as const,
+      match_side: 'both' as MatchSide,
+      is_flipped: false,
+      sort_order: i,
+    }));
+    const black = mostPlayedData.black.slice(0, DEFAULT_CHART_LIMIT).map((o, i) => ({
+      id: -(DEFAULT_CHART_LIMIT + i + 1),
+      label: o.label,
+      target_hash: o.full_hash,
+      fen: o.fen,
+      moves: [],
+      color: 'black' as const,
+      match_side: 'both' as MatchSide,
+      is_flipped: false,
+      sort_order: DEFAULT_CHART_LIMIT + i,
+    }));
+    return [...white, ...black];
+  }, [bookmarks, mostPlayedData]);
+
+  // Chart entries: real bookmarks if any, else most-played defaults
+  const chartBookmarks = bookmarks.length > 0 ? bookmarks : defaultChartEntries;
+
   const timeSeriesRequest: TimeSeriesRequest | null = useMemo(() => {
-    if (bookmarks.length === 0) return null;
+    if (chartBookmarks.length === 0) return null;
     return {
-      bookmarks: bookmarks.map((b) => ({
+      bookmarks: chartBookmarks.map((b) => ({
         bookmark_id: b.id,
         target_hash: b.target_hash,
         match_side: resolveMatchSide(b.match_side, (b.color ?? 'white') as Color),
@@ -165,18 +208,9 @@ export function OpeningsPage() {
       opponent_type: debouncedFilters.opponentType,
       recency: debouncedFilters.recency === 'all' ? null : debouncedFilters.recency,
     };
-  }, [bookmarks, debouncedFilters]);
+  }, [chartBookmarks, debouncedFilters]);
 
   const { data: tsData } = useTimeSeries(timeSeriesRequest);
-
-  // Most played openings — filter params applied to show top openings per color
-  const { data: mostPlayedData } = useMostPlayedOpenings({
-    recency: debouncedFilters.recency,
-    timeControls: debouncedFilters.timeControls,
-    platforms: debouncedFilters.platforms,
-    rated: debouncedFilters.rated,
-    opponentType: debouncedFilters.opponentType,
-  });
 
   // Derive WDL stats per bookmark using aggregate fields (not rolling sub-counts)
   const wdlStatsMap = useMemo(() => {
@@ -522,13 +556,85 @@ export function OpeningsPage() {
 
   const statisticsContent = (
     <div className="flex flex-col gap-4">
-      {/* White openings */}
+      {/* Results by Opening — shown when chart data is available or loading */}
+      {chartBookmarks.length > 0 && (
+        <div className="charcoal-texture rounded-md p-4">
+          <div>
+            <h2 className="text-lg font-medium mb-3">
+              <span className="inline-flex items-center gap-1">
+                Results by Opening
+                <InfoPopover ariaLabel="Results by opening info" testId="wdl-bar-chart-info" side="top">
+                  Shows your win, draw, and loss percentages for each saved position, based on the games that match the current filter settings. The length of the grey bar indicates game count relative to other openings.
+                </InfoPopover>
+              </span>
+            </h2>
+            {!tsData ? (
+              <div className="text-center text-muted-foreground py-8">Loading chart data...</div>
+            ) : (() => {
+              const rows = chartBookmarks
+                .filter((b) => wdlStatsMap[b.id] && wdlStatsMap[b.id].total > 0)
+                .map((b) => {
+                  const s = wdlStatsMap[b.id];
+                  const colorIcon = b.color === 'white' ? (
+                    <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white" />
+                  ) : b.color === 'black' ? (
+                    <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900" />
+                  ) : null;
+                  const label = colorIcon ? (
+                    <span className="inline-flex items-center gap-1.5">{colorIcon}{b.label}</span>
+                  ) : b.label;
+                  return { bookmark: b, label, stats: s };
+                })
+                .sort((a, b) => b.stats.total - a.stats.total);
+
+              if (rows.length === 0) {
+                return (
+                  <div className="text-center text-muted-foreground py-8">
+                    No stats available for saved positions yet.
+                  </div>
+                );
+              }
+
+              const maxTotal = Math.max(...rows.map((r) => r.stats.total));
+
+              return (
+                <div className="space-y-2">
+                  {rows.map((row) => (
+                    <WDLChartRow
+                      key={row.bookmark.id}
+                      data={{
+                        wins: row.stats.wins,
+                        draws: row.stats.draws,
+                        losses: row.stats.losses,
+                        total: row.stats.total,
+                        win_pct: row.stats.total > 0 ? (row.stats.wins / row.stats.total) * 100 : 0,
+                        draw_pct: row.stats.total > 0 ? (row.stats.draws / row.stats.total) * 100 : 0,
+                        loss_pct: row.stats.total > 0 ? (row.stats.losses / row.stats.total) * 100 : 0,
+                      }}
+                      label={row.label}
+                      maxTotal={maxTotal}
+                      testId={`wdl-opening-${row.bookmark.id}`}
+                    />
+                  ))}
+                </div>
+              );
+            })()}
+          </div>
+        </div>
+      )}
+      {/* Win Rate Over Time — shown when time series data is ready */}
+      {tsData && (
+        <div className="charcoal-texture rounded-md p-4">
+          <WinRateChart bookmarks={chartBookmarks} series={tsData.series} />
+        </div>
+      )}
+      {/* Most Played Openings as White */}
       {mostPlayedData && mostPlayedData.white.length > 0 && (
         <div className="charcoal-texture rounded-md p-4" data-testid="mpo-white-section">
           <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
             <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-white" />
             <span className="inline-flex items-center gap-1">
-              White: Most Played Openings
+              Most Played Openings as White
               <InfoPopover ariaLabel="White openings info" testId="mpo-white-info" side="top">
                 <div className="space-y-2">
                   <p>
@@ -549,13 +655,13 @@ export function OpeningsPage() {
           />
         </div>
       )}
-      {/* Black openings */}
+      {/* Most Played Openings as Black */}
       {mostPlayedData && mostPlayedData.black.length > 0 && (
         <div className="charcoal-texture rounded-md p-4" data-testid="mpo-black-section">
           <h2 className="text-lg font-medium mb-3 flex items-center gap-1.5">
             <span className="inline-block h-3.5 w-3.5 rounded-full border border-muted-foreground bg-zinc-900" />
             <span className="inline-flex items-center gap-1">
-              Black: Most Played Openings
+              Most Played Openings as Black
               <InfoPopover ariaLabel="Black openings info" testId="mpo-black-info" side="top">
                 <div className="space-y-2">
                   <p>
@@ -576,79 +682,6 @@ export function OpeningsPage() {
           />
         </div>
       )}
-      {bookmarks.length === 0 ? (
-        <div className="flex flex-1 flex-col items-center justify-center py-12 text-center text-muted-foreground">
-          <p className="text-base font-medium text-foreground">No bookmarks yet</p>
-          <p className="mt-1 text-sm">Save positions on the Games tab to see opening stats here.</p>
-        </div>
-      ) : tsData ? (
-        <>
-          <div className="charcoal-texture rounded-md p-4">
-            <div>
-              <h2 className="text-lg font-medium mb-3">
-                <span className="inline-flex items-center gap-1">
-                  Results by Opening
-                  <InfoPopover ariaLabel="Results by opening info" testId="wdl-bar-chart-info" side="top">
-                    Shows your win, draw, and loss percentages for each saved position, based on the games that match the current filter settings. The length of the grey bar indicates game count relative to other openings.
-                  </InfoPopover>
-                </span>
-              </h2>
-              {(() => {
-                const rows = bookmarks
-                  .filter((b) => wdlStatsMap[b.id] && wdlStatsMap[b.id].total > 0)
-                  .map((b) => {
-                    const s = wdlStatsMap[b.id];
-                    const colorIcon = b.color === 'white' ? (
-                      <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-white" />
-                    ) : b.color === 'black' ? (
-                      <span className="inline-block h-3 w-3 rounded-full border border-muted-foreground bg-zinc-900" />
-                    ) : null;
-                    const label = colorIcon ? (
-                      <span className="inline-flex items-center gap-1.5">{colorIcon}{b.label}</span>
-                    ) : b.label;
-                    return { bookmark: b, label, stats: s };
-                  })
-                  .sort((a, b) => b.stats.total - a.stats.total);
-
-                if (rows.length === 0) {
-                  return (
-                    <div className="text-center text-muted-foreground py-8">
-                      No stats available for saved positions yet.
-                    </div>
-                  );
-                }
-
-                const maxTotal = Math.max(...rows.map((r) => r.stats.total));
-
-                return (
-                  <div className="space-y-2">
-                    {rows.map((row) => (
-                      <WDLChartRow
-                        key={row.bookmark.id}
-                        data={{
-                          wins: row.stats.wins,
-                          draws: row.stats.draws,
-                          losses: row.stats.losses,
-                          total: row.stats.total,
-                          win_pct: row.stats.total > 0 ? (row.stats.wins / row.stats.total) * 100 : 0,
-                          draw_pct: row.stats.total > 0 ? (row.stats.draws / row.stats.total) * 100 : 0,
-                          loss_pct: row.stats.total > 0 ? (row.stats.losses / row.stats.total) * 100 : 0,
-                        }}
-                        label={row.label}
-                        maxTotal={maxTotal}
-                        testId={`wdl-opening-${row.bookmark.id}`}
-                      />
-                    ))}
-                  </div>
-                );
-              })()}
-            </div>
-          </div>
-          <div className="charcoal-texture rounded-md p-4">
-            <WinRateChart bookmarks={bookmarks} series={tsData.series} />
-          </div>
-        </>
-      ) : null}
     </div>
   );
 

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -553,6 +553,7 @@ export function OpeningsPage() {
             label={filters.matchSide === 'both' ? 'Position Results' : `Position Results (Piece filter: ${filters.matchSide === 'mine' ? 'Mine' : 'Opponent'})`}
             barHeight="h-6"
             gamesLink="/openings/games"
+            onGamesLinkClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
             gamesLinkTestId="btn-moves-to-games"
             gamesLinkAriaLabel="View games for this position"
             testId="wdl-moves-position"

--- a/frontend/src/types/position_bookmarks.ts
+++ b/frontend/src/types/position_bookmarks.ts
@@ -1,21 +1,5 @@
 import type { MatchSide } from './api';
 
-export interface PositionSuggestion {
-  white_hash: string;
-  black_hash: string;
-  full_hash: string;
-  fen: string;
-  moves: string[];
-  color: 'white' | 'black';
-  game_count: number;
-  opening_name: string | null;
-  opening_eco: string | null;
-}
-
-export interface SuggestionsResponse {
-  suggestions: PositionSuggestion[];
-}
-
 export interface PositionBookmarkResponse {
   id: number;
   label: string;

--- a/frontend/src/types/stats.ts
+++ b/frontend/src/types/stats.ts
@@ -31,6 +31,7 @@ export interface OpeningWDL {
   label: string;
   pgn: string;
   fen: string;
+  full_hash: string;
   wins: number;
   draws: number;
   losses: number;

--- a/scripts/seed_openings.py
+++ b/scripts/seed_openings.py
@@ -1,7 +1,8 @@
 """Idempotent seed script: populate openings table from app/data/openings.tsv.
 
-Uses board.board_fen() (not board.fen()) per project convention.
-Uses INSERT ... ON CONFLICT DO NOTHING for idempotency.
+Uses board.board_fen() (not board.fen()) per project convention for the FEN column.
+Precomputes Zobrist hashes (full, white, black) from the replayed PGN board state.
+Uses INSERT ... ON CONFLICT DO UPDATE to backfill hashes on existing rows.
 Run with: uv run python -m scripts.seed_openings
 """
 import asyncio
@@ -17,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
+from app.services.zobrist import compute_hashes
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -24,10 +26,12 @@ logging.basicConfig(level=logging.INFO)
 TSV_PATH = Path(__file__).resolve().parent.parent / "app" / "data" / "openings.tsv"
 
 
-def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
-    """Compute piece-placement FEN and ply count from a PGN move sequence.
+def pgn_to_fen_ply_hashes(pgn_str: str) -> tuple[str, int, int, int, int]:
+    """Compute piece-placement FEN, ply count, and Zobrist hashes from a PGN.
 
-    Uses board.board_fen() (not board.fen()) per project convention.
+    Replays the PGN to get the correct board state (with castling rights,
+    en passant, side to move) for accurate polyglot Zobrist hash computation.
+    Returns (board_fen, ply_count, white_hash, black_hash, full_hash).
     """
     game = chess.pgn.read_game(io.StringIO(pgn_str))
     if game is None:
@@ -35,7 +39,8 @@ def pgn_to_fen_and_ply(pgn_str: str) -> tuple[str, int]:
     board = game.board()
     for move in game.mainline_moves():
         board.push(move)
-    return board.board_fen(), board.ply()
+    white_hash, black_hash, full_hash = compute_hashes(board)
+    return board.board_fen(), board.ply(), white_hash, black_hash, full_hash
 
 
 async def seed_openings() -> int:
@@ -55,7 +60,7 @@ async def seed_openings() -> int:
                 name = row["name"]
                 pgn_str = row["pgn"]
                 try:
-                    fen, ply_count = pgn_to_fen_and_ply(pgn_str)
+                    fen, ply_count, white_hash, black_hash, full_hash = pgn_to_fen_ply_hashes(pgn_str)
                 except Exception:
                     logger.warning("Row %d: failed to parse PGN %r — skipping", row_num, pgn_str)
                     errors += 1
@@ -63,13 +68,20 @@ async def seed_openings() -> int:
 
                 result = await session.execute(
                     text(
-                        "INSERT INTO openings (eco, name, pgn, ply_count, fen) "
-                        "VALUES (:eco, :name, :pgn, :ply_count, :fen) "
-                        "ON CONFLICT ON CONSTRAINT uq_openings_eco_name_pgn DO NOTHING"
+                        "INSERT INTO openings (eco, name, pgn, ply_count, fen, full_hash, white_hash, black_hash) "
+                        "VALUES (:eco, :name, :pgn, :ply_count, :fen, :full_hash, :white_hash, :black_hash) "
+                        "ON CONFLICT ON CONSTRAINT uq_openings_eco_name_pgn "
+                        "DO UPDATE SET full_hash = EXCLUDED.full_hash, "
+                        "white_hash = EXCLUDED.white_hash, black_hash = EXCLUDED.black_hash"
                     ),
-                    {"eco": eco, "name": name, "pgn": pgn_str, "ply_count": ply_count, "fen": fen},
+                    {
+                        "eco": eco, "name": name, "pgn": pgn_str,
+                        "ply_count": ply_count, "fen": fen,
+                        "full_hash": full_hash, "white_hash": white_hash, "black_hash": black_hash,
+                    },
                 )
                 if result.rowcount > 0:
+                    # Can't distinguish insert vs update with ON CONFLICT DO UPDATE
                     inserted += 1
                 else:
                     skipped += 1
@@ -77,7 +89,7 @@ async def seed_openings() -> int:
         await session.commit()
 
     await engine.dispose()
-    logger.info("Seed complete: %d inserted, %d skipped (already exist), %d errors", inserted, skipped, errors)
+    logger.info("Seed complete: %d upserted, %d skipped, %d errors", inserted, skipped, errors)
     return inserted
 
 

--- a/tests/test_seed_openings.py
+++ b/tests/test_seed_openings.py
@@ -12,7 +12,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.opening import Opening
-from scripts.seed_openings import pgn_to_fen_and_ply, seed_openings
+from scripts.seed_openings import pgn_to_fen_ply_hashes, seed_openings
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -30,24 +30,28 @@ def seed_openings_for_tests(test_engine):
     asyncio.run(seed_openings())
 
 
-class TestPgnToFenAndPly:
-    """Unit tests for pgn_to_fen_and_ply helper."""
+class TestPgnToFenPlyHashes:
+    """Unit tests for pgn_to_fen_ply_hashes helper."""
 
     def test_single_move_opening(self) -> None:
         """1. e4 should produce ply_count=1 and correct FEN."""
-        fen, ply = pgn_to_fen_and_ply("1. e4")
+        fen, ply, wh, bh, fh = pgn_to_fen_ply_hashes("1. e4")
         assert ply == 1
         # After 1. e4, the board should have the pawn on e4
         assert "4P3" in fen  # e4 pawn in rank 4
+        # Hashes should be non-zero integers
+        assert isinstance(fh, int) and fh != 0
+        assert isinstance(wh, int) and wh != 0
+        assert isinstance(bh, int) and bh != 0
 
     def test_two_move_opening(self) -> None:
         """1. e4 e5 should produce ply_count=2."""
-        fen, ply = pgn_to_fen_and_ply("1. e4 e5")
+        fen, ply, _wh, _bh, _fh = pgn_to_fen_ply_hashes("1. e4 e5")
         assert ply == 2
 
     def test_uses_board_fen_not_full_fen(self) -> None:
         """FEN must be piece-placement only (no castling/en passant/move counters)."""
-        fen, _ = pgn_to_fen_and_ply("1. e4 e5")
+        fen, *_ = pgn_to_fen_ply_hashes("1. e4 e5")
         # board_fen() has exactly 7 slashes (8 ranks separated by /)
         assert fen.count("/") == 7
         # board_fen() does NOT contain spaces (full FEN has spaces for castling etc.)
@@ -56,7 +60,20 @@ class TestPgnToFenAndPly:
     def test_invalid_pgn_raises(self) -> None:
         """Invalid PGN should raise ValueError."""
         with pytest.raises(ValueError, match="Failed to parse PGN"):
-            pgn_to_fen_and_ply("")
+            pgn_to_fen_ply_hashes("")
+
+    def test_hashes_match_import_pipeline(self) -> None:
+        """full_hash from seed must match what hashes_for_game produces during import."""
+        from app.services.zobrist import hashes_for_game
+        pgn = "1. e4 e5 2. Nf3 Nc6 3. Bb5"
+        _fen, _ply, _wh, _bh, seed_full_hash = pgn_to_fen_ply_hashes(pgn)
+        # hashes_for_game returns list of (ply, wh, bh, fh, move, clock) tuples
+        hashes, _result_fen = hashes_for_game(pgn)
+        # Last entry is the final position (ply 3)
+        import_full_hash = hashes[-1][3]
+        assert seed_full_hash == import_full_hash, (
+            f"Seed hash {seed_full_hash} != import hash {import_full_hash}"
+        )
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -113,6 +130,14 @@ class TestSeedOpeningsIntegration:
 
         assert dedup_count < total, f"Dedup ({dedup_count}) should be < total ({total})"
         assert dedup_count >= 3200, f"Expected ~3301 dedup rows, got {dedup_count}"
+
+    async def test_openings_have_zobrist_hashes(self, db_session: AsyncSession) -> None:
+        """All openings should have non-null Zobrist hashes after seeding."""
+        result = await db_session.execute(
+            select(func.count()).select_from(Opening).where(Opening.full_hash.is_(None))
+        )
+        null_count = result.scalar_one()
+        assert null_count == 0, f"{null_count} openings have NULL full_hash"
 
     async def test_dedup_view_has_one_row_per_eco_name(self, db_session: AsyncSession) -> None:
         """Each (eco, name) pair appears exactly once in the dedup view."""

--- a/tests/test_stats_repository.py
+++ b/tests/test_stats_repository.py
@@ -456,7 +456,7 @@ class TestQueryTopOpeningsSqlWDL:
         # Find the King's Pawn Game row
         kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
         assert len(kpg) == 1
-        eco, name, pgn, fen, total, wins, draws, losses = kpg[0]
+        eco, name, pgn, fen, full_hash, total, wins, draws, losses = kpg[0]
         assert wins == 3
         assert draws == 2
         assert losses == 0
@@ -464,6 +464,7 @@ class TestQueryTopOpeningsSqlWDL:
         assert pgn  # non-empty PGN from openings_dedup
         assert fen  # non-empty FEN from openings_dedup
         assert "/" in fen  # FEN has rank separators
+        assert full_hash is not None  # precomputed Zobrist hash from openings_dedup
 
     @pytest.mark.asyncio
     async def test_sql_wdl_excludes_below_min_games(self, db_session: AsyncSession) -> None:
@@ -492,7 +493,7 @@ class TestQueryTopOpeningsSqlWDL:
             time_control=["blitz"])
         kpg = [r for r in rows if r[0] == "B00" and r[1] == "King's Pawn Game"]
         assert len(kpg) == 1
-        assert kpg[0][4] == 10  # total = 10 blitz games only
+        assert kpg[0][5] == 10  # total = 10 blitz games only (index shifted by full_hash column)
 
     @pytest.mark.asyncio
     async def test_sql_wdl_ply_threshold_excludes_short_openings(self, db_session: AsyncSession) -> None:

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -300,10 +300,13 @@ class TestGetMostPlayedOpenings:
 
         assert resp.status_code == 200
         data = resp.json()
-        # If there are openings, they must have pgn and fen fields
+        # If there are openings, they must have pgn, fen, and full_hash fields
         for opening in data.get("white", []) + data.get("black", []):
             assert "pgn" in opening
             assert "fen" in opening
+            assert "full_hash" in opening
+            assert isinstance(opening["full_hash"], str)
+            assert len(opening["full_hash"]) > 0
 
     @pytest.mark.asyncio
     async def test_most_played_openings_accepts_filters(self, auth_headers: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- Reorder Statistics tab: Results by Opening → Win Rate Over Time → Most Played as White → Most Played as Black
- Default chart data from top 3 most-played openings per color when no bookmarks exist
- Rework bookmark suggestions to derive from most-played openings client-side (no backend call)
- Add chart-enable toggle to bookmark cards with localStorage persistence
- Redesign bookmark card layout: 84px minimap, full-width piece filter, button row (toggle/load/delete)
- Add precomputed Zobrist hashes to openings table (migration + seed), eliminating PGN replay at query time
- Position-based game counts and WDL in Most Played Openings (matches Results by Opening)
- Consistent toggle brightness across all filter controls
- FolderOpen icon for game navigation with scroll-to-top
- Label truncation preserving ECO suffix
- Fix Enter key saving bookmark label edits
- Suggested bookmarks now save PGN moves so loading shows correct position

## Test plan
- [ ] Backend: `uv run pytest` — 473 tests pass
- [ ] Frontend: `npm run build` — clean build
- [ ] Statistics tab shows charts from most-played openings when no bookmarks
- [ ] Bookmark suggestions appear from most-played data without backend delay
- [ ] Chart toggle persists across page reload
- [ ] Mobile bookmark card layout renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)