### PR TITLE
fix: always run npm install in run_local.sh

### DIFF
--- a/bin/run_local.sh
+++ b/bin/run_local.sh
@@ -44,7 +44,7 @@ BACKEND_PID=$!
 # Start frontend
 echo "Starting frontend..."
 cd frontend
-[ ! -d node_modules ] && npm install
+npm install
 npm run dev:mobile &
 FRONTEND_PID=$!
 cd ..


### PR DESCRIPTION
## Summary
- Replace conditional `[ ! -d node_modules ] && npm install` with unconditional `npm install` in `bin/run_local.sh`
- Fixes startup failures when `node_modules` exists but packages are out of sync (e.g. after adding a new dependency)
- No downside: `npm install` with everything up-to-date completes in under a second

## Test plan
- [ ] Run `bin/run_local.sh` with up-to-date `node_modules` — should start quickly without reinstalling
- [ ] Delete a package from `node_modules`, run `bin/run_local.sh` — should auto-install and start successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)