### PR TITLE
feat(48): conversion/recovery persistence filter

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -110,7 +110,7 @@ Users can determine their success rate for any opening position they specify, fi
 
 ## Current State
 
-v1.8 shipped 2026-04-06. Nine milestones complete (v1.0–v1.8), 47 phases (+2 inserted), live at flawchess.com. Guest access now lets visitors try the platform without signing up, with seamless promotion to full accounts via email/password or Google SSO. ~20K lines of code (8K Python, 12K TypeScript).
+v1.8 shipped 2026-04-06. Nine milestones complete (v1.0–v1.8), 48 phases (+2 inserted), live at flawchess.com. Guest access now lets visitors try the platform without signing up, with seamless promotion to full accounts via email/password or Google SSO. ~20K lines of code (8K Python, 12K TypeScript). Phase 48 complete — endgame conversion/recovery now uses persistence filter (imbalance must hold 4 plies) with lowered 100cp threshold.
 
 ## Context
 
@@ -189,4 +189,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-04-06 after v1.8 Guest Access milestone shipped*
+*Last updated: 2026-04-07 after Phase 48 (conversion/recovery persistence filter) complete*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -119,7 +119,7 @@
 
 ### v1.9 Advanced Analytics (Phases 48-51)
 
-- [ ] **Phase 48: Conversion & Recovery Persistence Filter** - Reduce noise in endgame conv/recov metrics by requiring material imbalance to persist 4 plies after endgame entry, lower threshold from 300cp to 100cp
+- [x] **Phase 48: Conversion & Recovery Persistence Filter** - Reduce noise in endgame conv/recov metrics by requiring material imbalance to persist 4 plies after endgame entry, lower threshold from 300cp to 100cp (completed 2026-04-07)
 - [ ] **Phase 49: Endgame ELO — Backend + Breakdown Table** - Backend computation and per-(platform, time-control) table UI with filters
 - [ ] **Phase 50: Endgame ELO — Timeline Chart** - Rolling-window timeline chart tracking Endgame ELO over time per combination
 - [ ] **Phase 51: Opening Risk & Drawishness** - Risk and drawishness metrics per position in the move explorer
@@ -140,8 +140,8 @@
 **Plans**: 2 plans
 
 Plans:
-- [ ] 48-01-PLAN.md — Backend: persistence field in repo queries, threshold to 100cp, persistence check in service
-- [ ] 48-02-PLAN.md — Frontend: update constants, popover/tooltip/accordion text for new threshold and persistence
+- [x] 48-01-PLAN.md — Backend: persistence field in repo queries, threshold to 100cp, persistence check in service
+- [x] 48-02-PLAN.md — Frontend: update constants, popover/tooltip/accordion text for new threshold and persistence
 
 ### Phase 49: Endgame ELO — Backend + Breakdown Table
 **Goal**: Users can see their Endgame ELO per platform/time-control combination and understand how their endgame skill compares to their actual rating
@@ -230,7 +230,7 @@ Plans:
 | 45. Guest Frontend | v1.8 | N/A | Complete | 2026-04-06 |
 | 46. Email/Password Promotion | v1.8 | N/A | Complete | 2026-04-06 |
 | 47. Google SSO Promotion | v1.8 | N/A | Complete | 2026-04-06 |
-| 48. Conversion & Recovery Persistence Filter | v1.9 | 0/2 | Not started | - |
+| 48. Conversion & Recovery Persistence Filter | v1.9 | 2/2 | Complete    | 2026-04-07 |
 | 49. Endgame ELO — Backend + Breakdown Table | v1.9 | 0/? | Not started | - |
 | 50. Endgame ELO — Timeline Chart | v1.9 | 0/? | Not started | - |
 | 51. Opening Risk & Drawishness | v1.9 | 0/? | Not started | - |
@@ -241,7 +241,7 @@ Plans:
 
 **Goal:** Users can recover account access when they forget their password — request reset link, receive email, set new password
 **Requirements:** TBD
-**Plans:** 1/1 plans complete
+**Plans:** 2/2 plans complete
 
 Plans:
 - [ ] TBD (promote with /gsd:review-backlog when ready)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -11,7 +11,7 @@
 - ✅ **v1.6 UI Polish & Improvements** — Phases 34-39 (shipped 2026-03-30)
 - ✅ **v1.7 Consolidation, Tooling & Refactoring** — Phases 40-43 (shipped 2026-04-03)
 - ✅ **v1.8 Guest Access** — Phases 44-47 (shipped 2026-04-06)
-- ○ **v1.9 Advanced Analytics** — Phases 48-50 (planned)
+- ○ **v1.9 Advanced Analytics** — Phases 48-51 (planned)
 
 ## Phases
 
@@ -117,17 +117,35 @@
 
 </details>
 
-### v1.9 Advanced Analytics (Phases 48-50)
+### v1.9 Advanced Analytics (Phases 48-51)
 
-- [ ] **Phase 48: Endgame ELO — Backend + Breakdown Table** - Backend computation and per-(platform, time-control) table UI with filters
-- [ ] **Phase 49: Endgame ELO — Timeline Chart** - Rolling-window timeline chart tracking Endgame ELO over time per combination
-- [ ] **Phase 50: Opening Risk & Drawishness** - Risk and drawishness metrics per position in the move explorer
+- [ ] **Phase 48: Conversion & Recovery Persistence Filter** - Reduce noise in endgame conv/recov metrics by requiring material imbalance to persist 4 plies after endgame entry, lower threshold from 300cp to 100cp
+- [ ] **Phase 49: Endgame ELO — Backend + Breakdown Table** - Backend computation and per-(platform, time-control) table UI with filters
+- [ ] **Phase 50: Endgame ELO — Timeline Chart** - Rolling-window timeline chart tracking Endgame ELO over time per combination
+- [ ] **Phase 51: Opening Risk & Drawishness** - Risk and drawishness metrics per position in the move explorer
 
 ## Phase Details
 
-### Phase 48: Endgame ELO — Backend + Breakdown Table
-**Goal**: Users can see their Endgame ELO per platform/time-control combination and understand how their endgame skill compares to their actual rating
+### Phase 48: Conversion & Recovery Persistence Filter
+**Goal**: Reduce noise in endgame conversion/recovery metrics by requiring material imbalance to persist after endgame entry, and lower the threshold from 300cp (3 points) to 100cp (1 point) for a larger, more meaningful dataset
 **Depends on**: Phase 47
+**Requirements**: N/A (improvement to existing feature)
+**Success Criteria** (what must be TRUE):
+  1. Conversion/recovery classification requires the material imbalance to meet the threshold at BOTH the endgame entry ply AND 4 plies later (persistence check)
+  2. Material advantage threshold is lowered from 300cp to 100cp for both conversion and recovery
+  3. All frontend tooltips, popovers, and explanatory text on the Endgames page reflect the new threshold (1 point) and mention the persistence requirement
+  4. Endgame performance gauges, conv/recov bar chart, conv/recov timeline chart, and the stats accordion all show updated explanations
+  5. Backend constants `_MATERIAL_ADVANTAGE_THRESHOLD` and frontend constant `MATERIAL_ADVANTAGE_POINTS` are updated
+  6. Conv/recov timeline chart uses the constant instead of hardcoded "3 points"
+**Plans**: 2 plans
+
+Plans:
+- [ ] 48-01-PLAN.md — Backend: persistence field in repo queries, threshold to 100cp, persistence check in service
+- [ ] 48-02-PLAN.md — Frontend: update constants, popover/tooltip/accordion text for new threshold and persistence
+
+### Phase 49: Endgame ELO — Backend + Breakdown Table
+**Goal**: Users can see their Endgame ELO per platform/time-control combination and understand how their endgame skill compares to their actual rating
+**Depends on**: Phase 48
 **Requirements**: ELO-01, ELO-02, ELO-03, ELO-04, ELO-06
 **Success Criteria** (what must be TRUE):
   1. User sees a breakdown table showing Endgame ELO, Actual ELO, and the gap for each qualifying (platform, time-control) combination
@@ -137,9 +155,9 @@
 **Plans**: TBD
 **UI hint**: yes
 
-### Phase 49: Endgame ELO — Timeline Chart
+### Phase 50: Endgame ELO — Timeline Chart
 **Goal**: Users can track their Endgame ELO over time per combination and visually see where it diverges from their actual rating
-**Depends on**: Phase 48
+**Depends on**: Phase 49
 **Requirements**: ELO-05
 **Success Criteria** (what must be TRUE):
   1. User sees a timeline chart with paired lines per (platform, time-control) combination — one bright line for Endgame ELO and one dark line for Actual ELO
@@ -148,7 +166,7 @@
 **Plans**: TBD
 **UI hint**: yes
 
-### Phase 50: Opening Risk & Drawishness
+### Phase 51: Opening Risk & Drawishness
 **Goal**: Users can see risk and drawishness signals per candidate move in the move explorer to inform opening selection
 **Depends on**: Phase 47
 **Requirements**: OPN-01, OPN-02
@@ -212,9 +230,10 @@
 | 45. Guest Frontend | v1.8 | N/A | Complete | 2026-04-06 |
 | 46. Email/Password Promotion | v1.8 | N/A | Complete | 2026-04-06 |
 | 47. Google SSO Promotion | v1.8 | N/A | Complete | 2026-04-06 |
-| 48. Endgame ELO — Backend + Breakdown Table | v1.9 | 0/? | Not started | - |
-| 49. Endgame ELO — Timeline Chart | v1.9 | 0/? | Not started | - |
-| 50. Opening Risk & Drawishness | v1.9 | 0/? | Not started | - |
+| 48. Conversion & Recovery Persistence Filter | v1.9 | 0/2 | Not started | - |
+| 49. Endgame ELO — Backend + Breakdown Table | v1.9 | 0/? | Not started | - |
+| 50. Endgame ELO — Timeline Chart | v1.9 | 0/? | Not started | - |
+| 51. Opening Risk & Drawishness | v1.9 | 0/? | Not started | - |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,15 +1,15 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.8
-milestone_name: Guest Access
-status: complete
-last_updated: "2026-04-06T00:00:00.000Z"
-last_activity: 2026-04-06
+milestone: v1.9
+milestone_name: Advanced Analytics
+status: executing
+last_updated: "2026-04-07T19:24:44.530Z"
+last_activity: 2026-04-07
 progress:
-  total_phases: 4
-  completed_phases: 4
-  total_plans: 0
-  completed_plans: 0
+  total_phases: 6
+  completed_phases: 1
+  total_plans: 2
+  completed_plans: 2
   percent: 100
 ---
 
@@ -17,9 +17,11 @@ progress:
 
 ## Current Position
 
+Phase: 49
+Plan: Not started
 Milestone: v1.8 Guest Access — SHIPPED 2026-04-06
-Status: Complete — ready for v1.9 planning
-Last activity: 2026-04-06 — milestone archived, git tagged
+Status: Executing Phase 48
+Last activity: 2026-04-07
 
 Progress: [██████████] 100% (v1.8 phases)
 

--- a/.planning/phases/48-conversion-recovery-persistence-filter/48-01-PLAN.md
+++ b/.planning/phases/48-conversion-recovery-persistence-filter/48-01-PLAN.md
@@ -1,0 +1,333 @@
+---
+phase: 48-conversion-recovery-persistence-filter
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - app/repositories/endgame_repository.py
+  - app/services/endgame_service.py
+  - tests/test_endgame_service.py
+  - tests/test_endgame_repository.py
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "Conversion classification requires material imbalance >= 100cp at BOTH entry ply AND 4 plies later"
+    - "Recovery classification requires material imbalance <= -100cp at BOTH entry ply AND 4 plies later"
+    - "Timeline chart filtering uses the same persistence + threshold logic"
+    - "All existing tests pass with updated threshold and row shape"
+  artifacts:
+    - path: "app/repositories/endgame_repository.py"
+      provides: "Entry rows and timeline rows with imbalance_after_4 field"
+      contains: "PERSISTENCE_PLIES = 4"
+    - path: "app/services/endgame_service.py"
+      provides: "Persistence check in aggregation and timeline filtering"
+      contains: "_MATERIAL_ADVANTAGE_THRESHOLD = 100"
+    - path: "tests/test_endgame_service.py"
+      provides: "Updated tests for 100cp threshold and persistence check"
+      contains: "persistence"
+  key_links:
+    - from: "app/repositories/endgame_repository.py"
+      to: "app/services/endgame_service.py"
+      via: "row shape includes imbalance_after_4 as 6th element (entry rows) / 5th element (timeline rows)"
+      pattern: "imbalance_after_4"
+---
+
+<objective>
+Add persistence filter and lower threshold for endgame conversion/recovery classification.
+
+Purpose: Reduce noise in conversion/recovery metrics caused by transient material imbalances from piece trades at endgame entry. Production data shows ~22% of entries at the old 300cp threshold are transient noise.
+
+Output: Backend repository queries return imbalance at entry+4 plies; service applies persistence check requiring both entry AND entry+4 to meet threshold; threshold lowered from 300cp to 100cp.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add persistence field to repository queries and lower thresholds</name>
+  <files>app/repositories/endgame_repository.py</files>
+  <read_first>
+    - app/repositories/endgame_repository.py (full file — understand both query functions)
+    - app/services/endgame_service.py (lines 140-205 and 730-770 — understand how rows are consumed)
+  </read_first>
+  <action>
+In `app/repositories/endgame_repository.py`, make these changes:
+
+1. **Add constant** at module level near `ENDGAME_PLY_THRESHOLD`:
+   ```python
+   # Number of plies after endgame entry to check for persistence of material imbalance.
+   # Filters out transient imbalances from piece trades at the endgame transition.
+   PERSISTENCE_PLIES = 4
+   ```
+
+2. **In `query_endgame_entry_rows()`** (around line 90):
+   - The existing `entry_imbalance_agg` uses `[1]` to get the first element. Add a second aggregate that gets element `[5]` (= entry ply + 4 plies later):
+   ```python
+   # Imbalance at entry ply (first position in the endgame span)
+   entry_imbalance_agg = type_coerce(
+       func.array_agg(
+           aggregate_order_by(GamePosition.material_imbalance, GamePosition.ply.asc())
+       ),
+       ARRAY(SmallIntegerType),
+   )[1]
+
+   # Imbalance 4 plies after entry — used for persistence check.
+   # Index [5] is safe because spans already require >= ENDGAME_PLY_THRESHOLD (6) plies.
+   imbalance_after_persistence_agg = type_coerce(
+       func.array_agg(
+           aggregate_order_by(GamePosition.material_imbalance, GamePosition.ply.asc())
+       ),
+       ARRAY(SmallIntegerType),
+   )[PERSISTENCE_PLIES + 1]
+   ```
+   - Add `imbalance_after_persistence_agg.label("entry_imbalance_after")` to the `span_subq` select list.
+   - In the main query select, add a new column after `user_material_imbalance`:
+   ```python
+   (span_subq.c.entry_imbalance_after * color_sign).label("user_material_imbalance_after"),
+   ```
+   - Update the function docstring to document the new 6th column: rows now return `(game_id, endgame_class, result, user_color, user_material_imbalance, user_material_imbalance_after)`.
+
+3. **In `query_conv_recov_timeline_rows()`** (around line 225-278):
+   - Change `SIGNIFICANT_IMBALANCE_CP = 300` to `SIGNIFICANT_IMBALANCE_CP = 100`.
+   - Add the same `imbalance_after_persistence_agg` pattern (element `[PERSISTENCE_PLIES + 1]`) to get the after-4-ply value.
+   - Add `imbalance_after_persistence_agg.label("entry_imbalance_after")` to `span_subq`.
+   - In the main query, add a new select column: `(span_subq.c.entry_imbalance_after * color_sign).label("user_material_imbalance_after")`.
+   - **Remove** the `func.abs(span_subq.c.entry_imbalance) >= SIGNIFICANT_IMBALANCE_CP` filter from the WHERE clause — the service layer now handles filtering with persistence logic. The repository should return ALL endgame rows regardless of imbalance.
+   - Update the function docstring: rows now return `(played_at, result, user_color, user_material_imbalance, user_material_imbalance_after)`. Remove the "Only includes games where abs >= 300" statement since the repo no longer filters.
+   - Update the docstring text and comments that mention "300" to say "100".
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run ruff check app/repositories/endgame_repository.py && uv run ty check app/repositories/endgame_repository.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - `endgame_repository.py` contains `PERSISTENCE_PLIES = 4`
+    - `query_endgame_entry_rows` docstring mentions `user_material_imbalance_after` as 6th column
+    - `query_endgame_entry_rows` select list includes `.label("user_material_imbalance_after")`
+    - `query_conv_recov_timeline_rows` contains `SIGNIFICANT_IMBALANCE_CP = 100`
+    - `query_conv_recov_timeline_rows` select list includes `.label("user_material_imbalance_after")`
+    - `query_conv_recov_timeline_rows` WHERE clause does NOT contain `func.abs(span_subq.c.entry_imbalance) >= SIGNIFICANT_IMBALANCE_CP`
+    - `ruff check` and `ty check` pass with zero errors
+  </acceptance_criteria>
+  <done>Both repository query functions return the imbalance-after-persistence field, threshold lowered to 100cp in timeline query, timeline query no longer pre-filters by imbalance (service handles it).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add persistence check to service layer and update tests</name>
+  <files>app/services/endgame_service.py, tests/test_endgame_service.py, tests/test_endgame_repository.py</files>
+  <read_first>
+    - app/services/endgame_service.py (full file — understand _aggregate_endgame_stats and get_conv_recov_timeline)
+    - tests/test_endgame_service.py (full file — understand existing test cases and row shapes)
+    - tests/test_endgame_repository.py (full file — understand integration test patterns)
+    - app/repositories/endgame_repository.py (to see the updated row shapes from Task 1)
+  </read_first>
+  <action>
+**In `app/services/endgame_service.py`:**
+
+1. Change `_MATERIAL_ADVANTAGE_THRESHOLD = 300` to `_MATERIAL_ADVANTAGE_THRESHOLD = 100`.
+
+2. Update the comment above it:
+   ```python
+   # Minimum material imbalance (in centipawns) to count as conversion or recovery.
+   # Lowered from 300cp to 100cp alongside the persistence filter — the persistence
+   # requirement (imbalance must also hold 4 plies later) eliminates transient noise
+   # from piece trades, allowing a lower threshold for a larger meaningful dataset.
+   _MATERIAL_ADVANTAGE_THRESHOLD = 100
+   ```
+
+3. **In `_aggregate_endgame_stats()`:**
+   - Update the function docstring: each row now has 6 elements: `(game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after)`.
+   - Update the for-loop unpacking from:
+     ```python
+     for _game_id, endgame_class_int, result, user_color, user_material_imbalance in rows:
+     ```
+     to:
+     ```python
+     for _game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after in rows:
+     ```
+   - Update the conversion check (around line 191) to require persistence:
+     ```python
+     # Conversion: user entered with significant material advantage (>= 100cp)
+     # that persisted 4 plies into the endgame — filters transient trade imbalances.
+     if (
+         user_material_imbalance is not None
+         and user_material_imbalance >= _MATERIAL_ADVANTAGE_THRESHOLD
+         and user_material_imbalance_after is not None
+         and user_material_imbalance_after >= _MATERIAL_ADVANTAGE_THRESHOLD
+     ):
+     ```
+   - Update the recovery check (around line 198) similarly:
+     ```python
+     # Recovery: user entered with significant material deficit (<= -100cp)
+     # that persisted 4 plies into the endgame.
+     if (
+         user_material_imbalance is not None
+         and user_material_imbalance <= -_MATERIAL_ADVANTAGE_THRESHOLD
+         and user_material_imbalance_after is not None
+         and user_material_imbalance_after <= -_MATERIAL_ADVANTAGE_THRESHOLD
+     ):
+     ```
+
+4. **In `get_conv_recov_timeline()`** (around line 745-747):
+   - The rows now have 5 elements: `(played_at, result, user_color, user_material_imbalance, user_material_imbalance_after)`.
+   - Update the timeline filtering to apply persistence:
+     ```python
+     # Split by material advantage direction — require persistence at entry AND 4 plies later.
+     # r[3] = user_material_imbalance (at entry), r[4] = user_material_imbalance_after (4 plies later)
+     conversion_rows = [
+         r for r in rows
+         if r[3] is not None and r[3] >= _MATERIAL_ADVANTAGE_THRESHOLD
+         and r[4] is not None and r[4] >= _MATERIAL_ADVANTAGE_THRESHOLD
+     ]
+     recovery_rows = [
+         r for r in rows
+         if r[3] is not None and r[3] <= -_MATERIAL_ADVANTAGE_THRESHOLD
+         and r[4] is not None and r[4] <= -_MATERIAL_ADVANTAGE_THRESHOLD
+     ]
+     ```
+
+**In `tests/test_endgame_service.py`:**
+
+5. All test row tuples must gain a 6th element for `user_material_imbalance_after`. Update every row tuple in `TestAggregateEndgameStats`:
+
+   - **`test_sorted_by_total_descending`**: Add matching after-value as 6th element to each tuple. For rows where imbalance is irrelevant to the test, use the same value as the 5th element (entry imbalance). Example: `(1, 1, "1-0", "white", 100, 100)`.
+
+   - **`test_win_draw_loss_percentages`**: All imbalances are 0, so add 0 as 6th: `(1, 1, "1-0", "white", 0, 0)`.
+
+   - **`test_conversion_pct_per_category`**: This is the critical test. Update docstring from "300cp" to "100cp". New rows (threshold is now 100):
+     ```python
+     rows = [
+         (1, 1, "1-0", "white", 500, 500),     # rook, up 500cp, persisted, won -> converted
+         (2, 1, "0-1", "white", 350, 350),      # rook, up 350cp, persisted, lost -> failed conversion
+         (3, 1, "1/2-1/2", "white", 100, 100),  # rook, up 100cp (threshold), persisted, draw -> draw conversion
+         (4, 1, "1-0", "white", 200, 50),        # rook, up 200cp at entry but only 50cp after -> NOT conversion (didn't persist)
+         (5, 1, "1-0", "white", -400, -400),     # rook, down, won -> not a conversion game
+     ]
+     ```
+     Assertions stay the same (3 conversion games, 1 win, 1 draw, 1 loss, 33.3%).
+
+   - **`test_recovery_pct_per_category`**: Update docstring from "300cp" to "100cp". New rows:
+     ```python
+     rows = [
+         (1, 1, "1-0", "white", -400, -400),    # rook, down 400cp, persisted, won -> recovery win
+         (2, 1, "1/2-1/2", "white", -500, -500), # rook, down 500cp, persisted, draw -> recovery draw
+         (3, 1, "0-1", "white", -100, -100),      # rook, down 100cp (threshold), persisted, lost -> not recovered
+         (4, 1, "0-1", "white", -200, -50),       # rook, down 200cp but only -50cp after -> NOT recovery (didn't persist)
+     ]
+     ```
+     Assertions stay the same (3 recovery games, 2 saves, 66.7%).
+
+   - **`test_no_game_phase_breakdown`**: `(1, 1, "1-0", "white", 100, 100)`.
+
+   - **`test_multiple_categories_aggregated_correctly`**: Add matching after-value: `(1, 1, "1-0", "white", 0, 0)`, etc.
+
+   - **`test_zero_conversion_games_returns_zero_pct`**: `(1, 1, "1-0", "white", -100, -100)`, `(2, 1, "0-1", "white", 0, 0)`.
+
+   - **`test_zero_recovery_games_returns_zero_pct`**: `(1, 1, "1-0", "white", 200, 200)`, `(2, 1, "0-1", "white", 0, 0)`.
+
+   - **`test_multi_class_per_game_in_aggregation`**: `(1, 1, "1-0", "white", 100, 100)`, `(1, 3, "1-0", "white", 50, 50)`, `(2, 1, "0-1", "white", 0, 0)`.
+
+6. **Add a new test** for persistence filtering:
+   ```python
+   def test_persistence_filter_excludes_transient_imbalance(self):
+       """Imbalance must persist 4 plies after entry — transient trade imbalances are excluded."""
+       rows = [
+           # Entry imbalance 200cp but after 4 plies only 50cp -> NOT conversion (transient)
+           (1, 1, "1-0", "white", 200, 50),
+           # Entry imbalance -300cp but after 4 plies only -80cp -> NOT recovery (transient)
+           (2, 1, "0-1", "white", -300, -80),
+           # Entry 150cp, persisted at 120cp -> IS conversion (both >= 100)
+           (3, 1, "1-0", "white", 150, 120),
+           # Entry -200cp, persisted at -150cp -> IS recovery (both <= -100)
+           (4, 1, "1/2-1/2", "white", -200, -150),
+       ]
+       result = _aggregate_endgame_stats(rows)
+       rook = next(c for c in result if c.endgame_class == "rook")
+       # Only game 3 qualifies for conversion
+       assert rook.conversion.conversion_games == 1
+       assert rook.conversion.conversion_wins == 1
+       # Only game 4 qualifies for recovery
+       assert rook.conversion.recovery_games == 1
+       assert rook.conversion.recovery_draws == 1
+   ```
+
+7. **Add a test** for `None` after-value (edge case):
+   ```python
+   def test_persistence_none_after_value_excluded(self):
+       """If imbalance_after is None (shouldn't happen with ply threshold, but safety), exclude from conv/recov."""
+       rows = [
+           (1, 1, "1-0", "white", 200, None),
+           (2, 1, "0-1", "white", -200, None),
+       ]
+       result = _aggregate_endgame_stats(rows)
+       rook = next(c for c in result if c.endgame_class == "rook")
+       assert rook.conversion.conversion_games == 0
+       assert rook.conversion.recovery_games == 0
+   ```
+
+**In `tests/test_endgame_repository.py`:**
+
+8. Check if the integration tests assert on row column count or column positions. If they do (e.g., checking `row[4]` for imbalance), update them to account for the new 6th column. If they only check general behavior (row count, game_id), they likely need no changes beyond verifying the new column exists. Add an assertion in the material_imbalance test that verifies the new 6th column `user_material_imbalance_after` is present and not None.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess && uv run ruff check app/services/endgame_service.py tests/test_endgame_service.py tests/test_endgame_repository.py && uv run ty check app/services/ tests/ && uv run pytest tests/test_endgame_service.py tests/test_endgame_repository.py -x -v</automated>
+  </verify>
+  <acceptance_criteria>
+    - `endgame_service.py` contains `_MATERIAL_ADVANTAGE_THRESHOLD = 100`
+    - `endgame_service.py` `_aggregate_endgame_stats` unpacks 6 elements per row including `user_material_imbalance_after`
+    - `endgame_service.py` conversion check includes `and user_material_imbalance_after is not None and user_material_imbalance_after >= _MATERIAL_ADVANTAGE_THRESHOLD`
+    - `endgame_service.py` recovery check includes `and user_material_imbalance_after is not None and user_material_imbalance_after <= -_MATERIAL_ADVANTAGE_THRESHOLD`
+    - `endgame_service.py` timeline filtering at `get_conv_recov_timeline` uses `r[4]` for persistence check
+    - `test_endgame_service.py` contains `test_persistence_filter_excludes_transient_imbalance`
+    - `test_endgame_service.py` contains `test_persistence_none_after_value_excluded`
+    - All test row tuples in `TestAggregateEndgameStats` have 6 elements
+    - `uv run pytest tests/test_endgame_service.py tests/test_endgame_repository.py -x` exits 0
+  </acceptance_criteria>
+  <done>Service layer applies persistence check for both conversion and recovery. Threshold lowered to 100cp. All tests updated and pass including new persistence-specific tests.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+No new trust boundaries introduced — this is a backend logic change to existing internal analytics. No user input handling changes.
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-48-01 | I (Information Disclosure) | endgame_repository.py | accept | No new data exposed — same columns, just an additional array index. Analytics remain user-scoped. |
+</threat_model>
+
+<verification>
+- `uv run pytest tests/test_endgame_service.py tests/test_endgame_repository.py -x -v` passes
+- `uv run ruff check app/repositories/endgame_repository.py app/services/endgame_service.py` passes
+- `uv run ty check app/ tests/` passes
+- grep confirms `_MATERIAL_ADVANTAGE_THRESHOLD = 100` in endgame_service.py
+- grep confirms `PERSISTENCE_PLIES = 4` in endgame_repository.py
+- grep confirms `user_material_imbalance_after` in both repo and service files
+</verification>
+
+<success_criteria>
+- Backend persistence filter active: conversion requires imbalance >= 100cp at BOTH entry AND entry+4 plies
+- Backend persistence filter active: recovery requires imbalance <= -100cp at BOTH entry AND entry+4 plies
+- Timeline filtering uses same persistence logic
+- All existing tests pass with updated row shapes and thresholds
+- New persistence-specific tests cover transient exclusion and None safety
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/48-conversion-recovery-persistence-filter/48-01-SUMMARY.md`
+</output>

--- a/.planning/phases/48-conversion-recovery-persistence-filter/48-01-SUMMARY.md
+++ b/.planning/phases/48-conversion-recovery-persistence-filter/48-01-SUMMARY.md
@@ -1,0 +1,88 @@
+---
+phase: 48-conversion-recovery-persistence-filter
+plan: 01
+subsystem: backend-endgame-analytics
+tags: [endgame, conversion, recovery, persistence, threshold, analytics]
+dependency_graph:
+  requires: []
+  provides: [endgame-persistence-filter, endgame-100cp-threshold]
+  affects: [endgame_repository, endgame_service, endgame-conversion-recovery-metrics]
+tech_stack:
+  added: []
+  patterns: [array_agg persistence indexing, 6-element row shape]
+key_files:
+  created: []
+  modified:
+    - app/repositories/endgame_repository.py
+    - app/services/endgame_service.py
+    - tests/test_endgame_service.py
+    - tests/test_endgame_repository.py
+decisions:
+  - PERSISTENCE_PLIES=4 constant in repository, not service — keeps SQL logic with SQL code
+  - SIGNIFICANT_IMBALANCE_CP kept as commented constant in timeline query for documentation
+  - _entry_row test helper sets imbalance_after=imbalance so gauge tests aren't affected by persistence
+metrics:
+  duration: 7 minutes
+  completed: 2026-04-07
+  tasks_completed: 2
+  tasks_total: 2
+  files_changed: 4
+---
+
+# Phase 48 Plan 01: Persistence Filter and Threshold Lowering Summary
+
+Persistence filter added to endgame conversion/recovery classification. Material imbalance must hold at BOTH endgame entry AND 4 plies later (entry+4) to count as conversion/recovery. Threshold lowered from 300cp to 100cp — persistence requirement eliminates transient trade noise that previously required the high threshold.
+
+## Tasks Completed
+
+| Task | Description | Commit |
+|------|-------------|--------|
+| 1 | Add persistence field to repository queries and lower thresholds | 2ab9f3a |
+| 2 | Add persistence check to service layer and update tests | 1c96c12 |
+
+## What Was Built
+
+### Repository Changes (`endgame_repository.py`)
+
+- Added `PERSISTENCE_PLIES = 4` module-level constant
+- `query_endgame_entry_rows`: added `imbalance_after_persistence_agg` using `array_agg()[PERSISTENCE_PLIES + 1]` (safe because spans require >= 6 plies). Added `user_material_imbalance_after` as 6th column in result rows
+- `query_conv_recov_timeline_rows`: same `imbalance_after_persistence_agg` pattern, `SIGNIFICANT_IMBALANCE_CP` lowered to 100, **removed** the `WHERE abs >= threshold` filter (service now handles this), added `user_material_imbalance_after` as 5th column
+
+### Service Changes (`endgame_service.py`)
+
+- `_MATERIAL_ADVANTAGE_THRESHOLD` lowered from 300 to 100 with updated comment explaining the change
+- `_aggregate_endgame_stats`: loop now unpacks 6 elements per row. Conversion check requires both `user_material_imbalance >= 100` AND `user_material_imbalance_after >= 100`. Recovery check requires both `<= -100`
+- `get_conv_recov_timeline`: updated filtering from `r[3]` only to `r[3] AND r[4]` persistence check
+
+### Test Changes
+
+- `TestAggregateEndgameStats`: all row tuples updated to 6 elements (added matching after-value)
+- `test_conversion_pct_per_category`: updated for 100cp threshold, added row with non-persistent imbalance (200cp entry, 50cp after) that should NOT count
+- `test_recovery_pct_per_category`: same pattern for recovery
+- `TestEndgameGaugeCalculations._entry_row`: sets `imbalance_after = imbalance` so gauge formula tests aren't affected by the persistence requirement
+- Added `test_persistence_filter_excludes_transient_imbalance`: verifies 200cp/50cp and -300cp/-80cp are excluded, while 150cp/120cp and -200cp/-150cp qualify
+- Added `test_persistence_none_after_value_excluded`: None safety guard test
+- `test_endgame_repository.py`: updated row unpacking to 6 elements, added assertion that `user_material_imbalance_after == 50` (from ply=24 in the seeded test data)
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None — no new trust boundaries or user input handling introduced. Same analytics columns, additional array index access only.
+
+## Self-Check: PASSED
+
+- SUMMARY.md: FOUND
+- endgame_repository.py: FOUND, contains PERSISTENCE_PLIES = 4 and user_material_imbalance_after
+- endgame_service.py: FOUND, contains _MATERIAL_ADVANTAGE_THRESHOLD = 100 and user_material_imbalance_after
+- test_endgame_service.py: FOUND, contains test_persistence_filter_excludes_transient_imbalance and test_persistence_none_after_value_excluded
+- test_endgame_repository.py: FOUND, updated row unpacking
+- Commit 2ab9f3a (Task 1): FOUND
+- Commit 1c96c12 (Task 2): FOUND
+- All 61 tests pass

--- a/.planning/phases/48-conversion-recovery-persistence-filter/48-02-PLAN.md
+++ b/.planning/phases/48-conversion-recovery-persistence-filter/48-02-PLAN.md
@@ -1,0 +1,251 @@
+---
+phase: 48-conversion-recovery-persistence-filter
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - frontend/src/components/charts/EndgamePerformanceSection.tsx
+  - frontend/src/components/charts/EndgameConvRecovChart.tsx
+  - frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx
+  - frontend/src/pages/Endgames.tsx
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "All UI text refers to 1 point threshold instead of 3 points"
+    - "All UI text mentions persistence requirement (2 moves)"
+    - "Timeline chart uses MATERIAL_ADVANTAGE_POINTS constant instead of hardcoded value"
+    - "Frontend builds and lints without errors"
+  artifacts:
+    - path: "frontend/src/components/charts/EndgamePerformanceSection.tsx"
+      provides: "Updated constant and gauge popover text"
+      contains: "MATERIAL_ADVANTAGE_POINTS = 1"
+    - path: "frontend/src/components/charts/EndgameConvRecovChart.tsx"
+      provides: "Updated chart popover text with persistence mention"
+      contains: "persisted"
+    - path: "frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx"
+      provides: "Fixed hardcoded '3 points' to use constant + persistence mention"
+      contains: "MATERIAL_ADVANTAGE_POINTS"
+    - path: "frontend/src/pages/Endgames.tsx"
+      provides: "Updated accordion text with 1 point and persistence"
+      contains: "persisted"
+  key_links:
+    - from: "frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx"
+      to: "frontend/src/components/charts/EndgamePerformanceSection.tsx"
+      via: "imports MATERIAL_ADVANTAGE_POINTS constant"
+      pattern: "import.*MATERIAL_ADVANTAGE_POINTS.*EndgamePerformanceSection"
+---
+
+<objective>
+Update all frontend constants and explanatory text to reflect the new 1-point threshold and persistence requirement.
+
+Purpose: Users need accurate descriptions of how conversion/recovery metrics are calculated. The old text says "3 points" without mentioning persistence; the new text must say "1 point" and explain that the imbalance must persist for at least 2 moves.
+
+Output: All Endgames page tooltips, popovers, and accordion text updated with correct threshold and persistence language. Timeline chart bug (hardcoded "3 points") fixed.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+<interfaces>
+<!-- From EndgamePerformanceSection.tsx — exports the constant used by other components -->
+```typescript
+export const MATERIAL_ADVANTAGE_POINTS = 3;  // Will be changed to 1
+```
+
+<!-- From EndgameConvRecovChart.tsx — imports the constant -->
+```typescript
+import { MATERIAL_ADVANTAGE_POINTS } from '@/components/charts/EndgamePerformanceSection';
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update threshold constant and all gauge/chart popover text</name>
+  <files>
+    frontend/src/components/charts/EndgamePerformanceSection.tsx,
+    frontend/src/components/charts/EndgameConvRecovChart.tsx,
+    frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx
+  </files>
+  <read_first>
+    - frontend/src/components/charts/EndgamePerformanceSection.tsx (full file — see constant definition and gauge popovers)
+    - frontend/src/components/charts/EndgameConvRecovChart.tsx (full file — see chart title popover)
+    - frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx (full file — see hardcoded "3 points")
+  </read_first>
+  <action>
+**In `EndgamePerformanceSection.tsx`:**
+
+1. Change the constant:
+   ```typescript
+   // Material advantage/deficit threshold in pawn points (backend uses 100 centipawns)
+   export const MATERIAL_ADVANTAGE_POINTS = 1;
+   ```
+
+2. Add a new constant for the persistence duration in user-friendly terms:
+   ```typescript
+   // Persistence requirement in full moves (= 4 plies on the backend)
+   export const PERSISTENCE_MOVES = 2;
+   ```
+
+3. Update the Conversion gauge popover (around line 73):
+   ```tsx
+   Your win rate when entering an endgame sequence with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
+   ```
+
+4. Update the Recovery gauge popover (around line 89):
+   ```tsx
+   Your draw or win rate when entering an endgame sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
+   ```
+
+**In `EndgameConvRecovChart.tsx`:**
+
+5. Add import for `PERSISTENCE_MOVES`:
+   ```typescript
+   import { MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
+   ```
+
+6. Update the chart info popover (around lines 49-57):
+   ```tsx
+   <div className="space-y-2">
+     <p>
+       <strong>Conversion</strong>: your win rate when you entered an endgame sequence of this type with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves.
+     </p>
+     <p>
+       <strong>Recovery</strong>: your draw+win rate when you entered an endgame sequence of this type with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves.
+     </p>
+   </div>
+   ```
+
+**In `EndgameConvRecovTimelineChart.tsx`:**
+
+7. Add imports for both constants:
+   ```typescript
+   import { MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
+   ```
+
+8. Replace the hardcoded "3 points" in the popover text (around lines 81-86) with the constants:
+   ```tsx
+   <div className="space-y-2">
+     <p>
+       <strong>Conversion rate</strong>: your win rate in the last {data.window} games where you
+       entered an endgame sequence with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point
+       that persisted for at least {PERSISTENCE_MOVES} moves.
+     </p>
+     <p>
+       <strong>Recovery rate</strong>: your save rate (wins + draws) in the last {data.window} games
+       where you entered an endgame sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point
+       that persisted for at least {PERSISTENCE_MOVES} moves.
+     </p>
+   </div>
+   ```
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npx tsc --noEmit && npm run lint && npm run knip</automated>
+  </verify>
+  <acceptance_criteria>
+    - `EndgamePerformanceSection.tsx` contains `MATERIAL_ADVANTAGE_POINTS = 1`
+    - `EndgamePerformanceSection.tsx` contains `PERSISTENCE_MOVES = 2`
+    - `EndgamePerformanceSection.tsx` conversion popover contains `persisted for at least {PERSISTENCE_MOVES} moves`
+    - `EndgamePerformanceSection.tsx` recovery popover contains `persisted for at least {PERSISTENCE_MOVES} moves`
+    - `EndgameConvRecovChart.tsx` imports `PERSISTENCE_MOVES` from EndgamePerformanceSection
+    - `EndgameConvRecovChart.tsx` popover contains `persisted`
+    - `EndgameConvRecovTimelineChart.tsx` imports `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES` from EndgamePerformanceSection
+    - `EndgameConvRecovTimelineChart.tsx` does NOT contain hardcoded string `"3 points"` or `"3 point"`
+    - `EndgameConvRecovTimelineChart.tsx` popover contains `{MATERIAL_ADVANTAGE_POINTS}` and `{PERSISTENCE_MOVES}`
+    - `npx tsc --noEmit` exits 0
+    - `npm run lint` exits 0
+    - `npm run knip` exits 0
+  </acceptance_criteria>
+  <done>Threshold constant updated from 3 to 1. Persistence constant added. All three chart component popovers mention both the new threshold and persistence requirement. Timeline chart no longer has hardcoded "3 points".</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update Endgames page accordion text</name>
+  <files>frontend/src/pages/Endgames.tsx</files>
+  <read_first>
+    - frontend/src/pages/Endgames.tsx (full file — find all mentions of "3 points" and conversion/recovery text)
+    - frontend/src/components/charts/EndgamePerformanceSection.tsx (to import the constants)
+  </read_first>
+  <action>
+1. Add imports at the top of `Endgames.tsx`:
+   ```typescript
+   import { MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
+   ```
+
+2. Update the accordion content (around lines 120-126) where it explains conversion and recovery. Replace the paragraph that currently reads:
+   ```
+   Conversion: your win rate when you entered an endgame sequence with a material advantage of at least 3 points. Recovery: your draw+win rate when you entered an endgame sequence with a material deficit of at least 3 points.
+   ```
+   with:
+   ```tsx
+   <strong>Conversion:</strong> your win rate when you entered an endgame sequence
+   with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that
+   persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
+   {' '}<strong>Recovery:</strong> your draw+win rate when you entered an endgame
+   sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point
+   that persisted for at least {PERSISTENCE_MOVES} moves into the endgame. Since a
+   game can pass through multiple endgame types, it can contribute a conversion or
+   recovery entry to each type independently.
+   ```
+
+   Preserve the rest of the accordion text (endgame types explanation, rating caveat) unchanged.
+  </action>
+  <verify>
+    <automated>cd /home/aimfeld/Projects/Python/flawchess/frontend && npx tsc --noEmit && npm run lint && npm run knip && npm run build</automated>
+  </verify>
+  <acceptance_criteria>
+    - `Endgames.tsx` imports `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES` from EndgamePerformanceSection
+    - `Endgames.tsx` does NOT contain hardcoded string `"3 points"` or `"at least 3"`
+    - `Endgames.tsx` accordion text contains `{MATERIAL_ADVANTAGE_POINTS}` and `{PERSISTENCE_MOVES}`
+    - `Endgames.tsx` accordion text contains `persisted`
+    - `npm run build` exits 0 (production build succeeds)
+    - `npm run knip` exits 0 (no dead exports)
+  </acceptance_criteria>
+  <done>Endgames page accordion explanatory text updated with new threshold and persistence language. All hardcoded "3 points" references eliminated from the entire frontend.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+No trust boundaries affected — purely frontend text/constant changes.
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation Plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-48-02 | I (Information Disclosure) | Frontend text | accept | Only UI label text changes — no data exposure risk. |
+</threat_model>
+
+<verification>
+- `npm run build` succeeds (production build)
+- `npm run lint` passes
+- `npm run knip` passes (no dead exports from new constants)
+- grep confirms no remaining "3 points" or "3 point" strings in Endgames-related frontend files
+- grep confirms `MATERIAL_ADVANTAGE_POINTS = 1` in EndgamePerformanceSection.tsx
+- grep confirms `PERSISTENCE_MOVES = 2` in EndgamePerformanceSection.tsx
+- All 4 frontend files reference the constants instead of hardcoded values
+</verification>
+
+<success_criteria>
+- MATERIAL_ADVANTAGE_POINTS is 1 (not 3)
+- PERSISTENCE_MOVES constant exists and equals 2
+- All conversion/recovery UI text mentions both the threshold and persistence requirement
+- No hardcoded "3 points" remains anywhere in the Endgames-related frontend code
+- Frontend production build succeeds
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/48-conversion-recovery-persistence-filter/48-02-SUMMARY.md`
+</output>

--- a/.planning/phases/48-conversion-recovery-persistence-filter/48-02-SUMMARY.md
+++ b/.planning/phases/48-conversion-recovery-persistence-filter/48-02-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 48-conversion-recovery-persistence-filter
+plan: "02"
+subsystem: frontend
+tags: [endgames, constants, ui-text, charts]
+dependency_graph:
+  requires: []
+  provides: [accurate-conversion-recovery-ui-text]
+  affects: [EndgamePerformanceSection, EndgameConvRecovChart, EndgameConvRecovTimelineChart, Endgames]
+tech_stack:
+  added: []
+  patterns: [named-constants-for-ui-thresholds]
+key_files:
+  created: []
+  modified:
+    - frontend/src/components/charts/EndgamePerformanceSection.tsx
+    - frontend/src/components/charts/EndgameConvRecovChart.tsx
+    - frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx
+    - frontend/src/pages/Endgames.tsx
+decisions:
+  - "Used MATERIAL_ADVANTAGE_POINTS = 1 and PERSISTENCE_MOVES = 2 as exported constants from EndgamePerformanceSection so all chart components and the page share a single source of truth"
+metrics:
+  duration: "~5 minutes"
+  completed: "2026-04-07T19:15:00Z"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 4
+---
+
+# Phase 48 Plan 02: Conversion/Recovery UI Text Update Summary
+
+## One-liner
+
+Updated all endgame conversion/recovery UI text to reflect the 1-point material threshold (down from 3) and added persistence requirement language (2 moves) across all four Endgames-related frontend files.
+
+## What Was Built
+
+Two tasks executed to update frontend constants and explanatory text:
+
+**Task 1** — Updated `EndgamePerformanceSection.tsx`:
+- Changed `MATERIAL_ADVANTAGE_POINTS` from `3` to `1`
+- Added new `PERSISTENCE_MOVES = 2` constant
+- Updated Conversion gauge popover to mention persistence requirement
+- Updated Recovery gauge popover to mention persistence requirement
+
+Updated `EndgameConvRecovChart.tsx`:
+- Added `PERSISTENCE_MOVES` to import from EndgamePerformanceSection
+- Updated chart info popover to use both constants with persistence language
+
+Updated `EndgameConvRecovTimelineChart.tsx`:
+- Added imports for both `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES`
+- Replaced hardcoded "3 points" in timeline popover with the constants
+- Added persistence requirement wording
+
+**Task 2** — Updated `Endgames.tsx`:
+- Added `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES` to EndgamePerformanceSection import
+- Replaced hardcoded "3 points" in accordion explanation with constants
+- Added persistence requirement language to Conversion and Recovery description
+
+## Commits
+
+| Task | Commit | Description |
+|------|--------|-------------|
+| 1 | `8828705` | feat(48-02): update threshold constant to 1pt and add persistence text to chart popovers |
+| 2 | `f5bc9f7` | feat(48-02): update Endgames accordion text with 1pt threshold and persistence language |
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None — all four files have real constant values and accurate UI text.
+
+## Threat Flags
+
+None — purely frontend label/text changes with no new network endpoints or trust boundaries.
+
+## Self-Check: PASSED
+
+- [x] `frontend/src/components/charts/EndgamePerformanceSection.tsx` — exists, contains `MATERIAL_ADVANTAGE_POINTS = 1` and `PERSISTENCE_MOVES = 2`
+- [x] `frontend/src/components/charts/EndgameConvRecovChart.tsx` — exists, imports `PERSISTENCE_MOVES`, contains "persisted"
+- [x] `frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx` — exists, imports both constants, no hardcoded "3 points"
+- [x] `frontend/src/pages/Endgames.tsx` — exists, imports both constants, contains "persisted"
+- [x] Commit `8828705` — verified in git log
+- [x] Commit `f5bc9f7` — verified in git log
+- [x] `npx tsc --noEmit` — passed (no output)
+- [x] `npm run lint` — passed (no output)
+- [x] `npm run knip` — passed (no output)
+- [x] `npm run build` — passed (built in 4.35s)

--- a/.planning/phases/48-conversion-recovery-persistence-filter/48-VERIFICATION.md
+++ b/.planning/phases/48-conversion-recovery-persistence-filter/48-VERIFICATION.md
@@ -1,0 +1,103 @@
+---
+phase: 48-conversion-recovery-persistence-filter
+verified: 2026-04-07T20:00:00Z
+status: passed
+score: 6/6 must-haves verified
+---
+
+# Phase 48: Conversion & Recovery Persistence Filter Verification Report
+
+**Phase Goal:** Reduce noise in endgame conversion/recovery metrics by requiring material imbalance to persist after endgame entry, and lower the threshold from 300cp (3 points) to 100cp (1 point) for a larger, more meaningful dataset
+**Verified:** 2026-04-07T20:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | Conversion/recovery classification requires imbalance at BOTH entry ply AND 4 plies later | VERIFIED | `_aggregate_endgame_stats` unpacks 6-element rows; conversion and recovery checks require both `user_material_imbalance` and `user_material_imbalance_after` meet threshold |
+| 2 | Material advantage threshold lowered from 300cp to 100cp | VERIFIED | `_MATERIAL_ADVANTAGE_THRESHOLD = 100` in `endgame_service.py` (line 143); `SIGNIFICANT_IMBALANCE_CP = 100` in timeline query |
+| 3 | All frontend tooltips, popovers, and accordion text reflect 1 point threshold and persistence requirement | VERIFIED | All 4 frontend files use `MATERIAL_ADVANTAGE_POINTS = 1` and `PERSISTENCE_MOVES = 2` constants from EndgamePerformanceSection; no hardcoded "3 points" in conversion/recovery context |
+| 4 | Endgame performance gauges, conv/recov bar chart, timeline chart, and stats accordion all show updated explanations | VERIFIED | All four components verified to contain persistence language via constants |
+| 5 | Backend constants `_MATERIAL_ADVANTAGE_THRESHOLD` and frontend constant `MATERIAL_ADVANTAGE_POINTS` updated | VERIFIED | Backend: `_MATERIAL_ADVANTAGE_THRESHOLD = 100`; Frontend: `MATERIAL_ADVANTAGE_POINTS = 1`, `PERSISTENCE_MOVES = 2` exported from EndgamePerformanceSection.tsx |
+| 6 | Conv/recov timeline chart uses constant instead of hardcoded "3 points" | VERIFIED | EndgameConvRecovTimelineChart.tsx imports `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES`, no hardcoded "3 point" string in file |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `app/repositories/endgame_repository.py` | Entry rows and timeline rows with imbalance_after_4 field; `PERSISTENCE_PLIES = 4` | VERIFIED | Contains `PERSISTENCE_PLIES = 4` (line 41); both query functions add `user_material_imbalance_after` column; timeline WHERE clause does NOT filter by imbalance |
+| `app/services/endgame_service.py` | Persistence check in aggregation and timeline filtering; `_MATERIAL_ADVANTAGE_THRESHOLD = 100` | VERIFIED | `_MATERIAL_ADVANTAGE_THRESHOLD = 100` (line 143); `_aggregate_endgame_stats` unpacks 6 elements and checks both `user_material_imbalance` and `user_material_imbalance_after`; `get_conv_recov_timeline` uses `r[3]` and `r[4]` for persistence |
+| `tests/test_endgame_service.py` | Updated tests with 6-element tuples; `test_persistence_filter_excludes_transient_imbalance`; `test_persistence_none_after_value_excluded` | VERIFIED | All 61 tests pass; both new persistence tests present and passing |
+| `frontend/src/components/charts/EndgamePerformanceSection.tsx` | `MATERIAL_ADVANTAGE_POINTS = 1`; `PERSISTENCE_MOVES = 2`; persistence language in gauge popovers | VERIFIED | Both constants exported (lines 14, 17); conversion and recovery gauge popovers mention `PERSISTENCE_MOVES` |
+| `frontend/src/components/charts/EndgameConvRecovChart.tsx` | Imports `PERSISTENCE_MOVES`; popover contains "persisted" | VERIFIED | Imports both constants (line 9); popover text at lines 52-55 contains "persisted for at least {PERSISTENCE_MOVES} moves" |
+| `frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx` | Imports `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES`; no hardcoded "3 points" | VERIFIED | Both constants imported (line 7); popover at lines 81-89 uses both constants; no hardcoded "3 point" string found |
+| `frontend/src/pages/Endgames.tsx` | Imports both constants; accordion text with persistence language; no hardcoded "3 points" in conversion/recovery context | VERIFIED | Constants imported (line 19); accordion at lines 121-128 uses both constants and "persisted" language; the remaining "at least 3 full moves" on line 116 refers to ply threshold classification — correct and unchanged |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `app/repositories/endgame_repository.py` | `app/services/endgame_service.py` | Row shape includes `imbalance_after_4` as 6th element (entry rows) / 5th element (timeline rows) | VERIFIED | Repository returns 6-column entry rows and 5-column timeline rows; service unpacks all columns and uses index `r[4]` for persistence in timeline |
+| `EndgameConvRecovTimelineChart.tsx` | `EndgamePerformanceSection.tsx` | Imports `MATERIAL_ADVANTAGE_POINTS` and `PERSISTENCE_MOVES` | VERIFIED | Import confirmed at line 7; both constants used in popover text |
+
+### Data-Flow Trace (Level 4)
+
+These are analytics constants in service/repository code, not React components with useQuery/useState data flows. The frontend components receive constants (not fetched data) — the constant values are verified directly.
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+|----------|---------------|--------|--------------------|--------|
+| `endgame_service.py / _aggregate_endgame_stats` | `user_material_imbalance_after` | `query_endgame_entry_rows` → `array_agg()[PERSISTENCE_PLIES + 1]` | Yes — DB array index lookup on ordered positions | FLOWING |
+| `endgame_service.py / get_conv_recov_timeline` | `r[4]` (imbalance_after) | `query_conv_recov_timeline_rows` → `array_agg()[PERSISTENCE_PLIES + 1]` | Yes — DB array index lookup, no WHERE pre-filter | FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+|----------|---------|--------|--------|
+| All endgame service and repository tests pass | `uv run pytest tests/test_endgame_service.py tests/test_endgame_repository.py -x` | 61 passed in 0.46s | PASS |
+| `test_persistence_filter_excludes_transient_imbalance` passes | included above | PASSED | PASS |
+| `test_persistence_none_after_value_excluded` passes | included above | PASSED | PASS |
+| Frontend production build succeeds | `npm run build` | built in 4.15s | PASS |
+| Frontend lint clean | `npm run lint` | no output (clean) | PASS |
+| Frontend knip clean | `npm run knip` | no output (clean) | PASS |
+| ruff check on modified backend files | `uv run ruff check app/repositories/endgame_repository.py app/services/endgame_service.py` | All checks passed | PASS |
+| ty type check on backend | `uv run ty check app/repositories/ app/services/` | All checks passed | PASS |
+
+### Requirements Coverage
+
+Phase 48 has no formal requirement IDs (improvement to existing feature). Roadmap success criteria coverage:
+
+| Success Criterion | Status | Evidence |
+|------------------|--------|----------|
+| SC1: Persistence check at entry AND 4 plies later | SATISFIED | `_aggregate_endgame_stats` and `get_conv_recov_timeline` both check `r[3]` AND `r[4]` (or unpacked names) against threshold |
+| SC2: Threshold lowered from 300cp to 100cp | SATISFIED | `_MATERIAL_ADVANTAGE_THRESHOLD = 100` in service; `SIGNIFICANT_IMBALANCE_CP = 100` in timeline query |
+| SC3: All frontend tooltips, popovers, accordion reflect 1 point and persistence | SATISFIED | All 4 files verified; constants used throughout |
+| SC4: Gauges, bar chart, timeline chart, accordion all show updated explanations | SATISFIED | All 4 components contain persistence language using constants |
+| SC5: `_MATERIAL_ADVANTAGE_THRESHOLD` and `MATERIAL_ADVANTAGE_POINTS` updated | SATISFIED | Backend 100, frontend 1 (pawn points = 100cp) |
+| SC6: Timeline chart uses constant instead of hardcoded "3 points" | SATISFIED | No hardcoded "3 point" string in EndgameConvRecovTimelineChart.tsx |
+
+### Anti-Patterns Found
+
+None found. No TODOs, stubs, hardcoded empty values, or console.log implementations in modified files.
+
+| File | Line | Pattern | Severity | Impact |
+|------|------|---------|----------|--------|
+| — | — | — | — | — |
+
+### Human Verification Required
+
+None. All changes are backend logic (constant values, SQL query columns, Python conditionals) and frontend text/constant updates — all verifiable programmatically.
+
+### Gaps Summary
+
+No gaps found. All 6 roadmap success criteria satisfied.
+
+---
+
+_Verified: 2026-04-07T20:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/app/repositories/endgame_repository.py
+++ b/app/repositories/endgame_repository.py
@@ -36,6 +36,10 @@ ENDGAME_PIECE_COUNT_THRESHOLD = 6
 # 6 plies = 3 full moves of sustained endgame play. Per D-03.
 ENDGAME_PLY_THRESHOLD = 6
 
+# Number of plies after endgame entry to check for persistence of material imbalance.
+# Filters out transient imbalances from piece trades at the endgame transition.
+PERSISTENCE_PLIES = 4
+
 
 async def count_filtered_games(
     session: AsyncSession,
@@ -72,11 +76,15 @@ async def query_endgame_entry_rows(
     plies in each class. Per D-04: material_imbalance at the FIRST position of each class span
     determines conversion/recovery classification.
 
-    Returns rows of: (game_id, endgame_class, result, user_color, user_material_imbalance)
+    Returns rows of: (game_id, endgame_class, result, user_color, user_material_imbalance, user_material_imbalance_after)
     where endgame_class is an integer (1-6, see EndgameClassInt).
 
     user_material_imbalance = material_imbalance if user_color == "white" else -material_imbalance.
     This sign flip normalizes to user perspective: positive = user has more material.
+
+    user_material_imbalance_after = material_imbalance at entry + PERSISTENCE_PLIES (4 plies later).
+    Used by the service layer for persistence check: both entry AND entry+4 must meet the threshold
+    to count as conversion/recovery (filters transient trade imbalances).
 
     NO color filter is applied per D-02 — stats cover both white and black games.
     """
@@ -94,11 +102,21 @@ async def query_endgame_entry_rows(
         ARRAY(SmallIntegerType),
     )[1]
 
+    # Imbalance 4 plies after entry — used for persistence check.
+    # Index [5] is safe because spans already require >= ENDGAME_PLY_THRESHOLD (6) plies.
+    imbalance_after_persistence_agg = type_coerce(
+        func.array_agg(
+            aggregate_order_by(GamePosition.material_imbalance, GamePosition.ply.asc())
+        ),
+        ARRAY(SmallIntegerType),
+    )[PERSISTENCE_PLIES + 1]
+
     span_subq = (
         select(
             GamePosition.game_id.label("game_id"),
             GamePosition.endgame_class.label("endgame_class"),
             entry_imbalance_agg.label("entry_imbalance"),
+            imbalance_after_persistence_agg.label("entry_imbalance_after"),
         )
         .where(
             GamePosition.user_id == user_id,
@@ -124,6 +142,7 @@ async def query_endgame_entry_rows(
             Game.result,
             Game.user_color,
             (span_subq.c.entry_imbalance * color_sign).label("user_material_imbalance"),
+            (span_subq.c.entry_imbalance_after * color_sign).label("user_material_imbalance_after"),
         )
         .join(span_subq, Game.id == span_subq.c.game_id)
         .where(Game.user_id == user_id)
@@ -214,16 +233,17 @@ async def query_conv_recov_timeline_rows(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
 ) -> list[Row[Any]]:
-    """Return rows for conversion/recovery timeline: games with significant material imbalance.
+    """Return rows for conversion/recovery timeline: all endgame games for persistence filtering.
 
-    Only includes games where abs(material_imbalance) >= 300 at endgame entry
-    (significant advantage or disadvantage of roughly 3+ pawns).
+    Returns ALL endgame games regardless of imbalance — the service layer applies the
+    persistence filter (both entry AND entry+4 plies must meet the 100cp threshold).
 
-    Returns rows of: (played_at, result, user_color, user_material_imbalance)
+    Returns rows of: (played_at, result, user_color, user_material_imbalance, user_material_imbalance_after)
     ordered by played_at ascending for chronological rolling-window computation.
     """
-    # Minimum centipawn imbalance for a game to count as "significant advantage/disadvantage"
-    SIGNIFICANT_IMBALANCE_CP = 300
+    # Minimum centipawn imbalance for a game to count as "significant advantage/disadvantage".
+    # Lowered from 300cp to 100cp — persistence filter eliminates transient trade noise.
+    SIGNIFICANT_IMBALANCE_CP = 100  # noqa: F841 — kept for documentation, filtering now in service
 
     # Single subquery: group + grab entry material_imbalance via array_agg.
     # Same pattern as query_endgame_entry_rows — eliminates 5M+ row seq scan.
@@ -234,10 +254,20 @@ async def query_conv_recov_timeline_rows(
         ARRAY(SmallIntegerType),
     )[1]
 
+    # Imbalance 4 plies after entry — used for persistence check in service layer.
+    # Index [5] is safe because spans already require >= ENDGAME_PLY_THRESHOLD (6) plies.
+    imbalance_after_persistence_agg = type_coerce(
+        func.array_agg(
+            aggregate_order_by(GamePosition.material_imbalance, GamePosition.ply.asc())
+        ),
+        ARRAY(SmallIntegerType),
+    )[PERSISTENCE_PLIES + 1]
+
     span_subq = (
         select(
             GamePosition.game_id.label("game_id"),
             entry_imbalance_agg.label("entry_imbalance"),
+            imbalance_after_persistence_agg.label("entry_imbalance_after"),
         )
         .where(
             GamePosition.user_id == user_id,
@@ -255,19 +285,19 @@ async def query_conv_recov_timeline_rows(
     )
 
     # Main query: join Game -> span_subq only (no second subquery).
-    # Filter by abs(entry_imbalance) >= 300 — works regardless of sign flip.
+    # No imbalance filter here — service layer applies persistence check with 100cp threshold.
     stmt = (
         select(
             Game.played_at,
             Game.result,
             Game.user_color,
             (span_subq.c.entry_imbalance * color_sign).label("user_material_imbalance"),
+            (span_subq.c.entry_imbalance_after * color_sign).label("user_material_imbalance_after"),
         )
         .join(span_subq, Game.id == span_subq.c.game_id)
         .where(
             Game.user_id == user_id,
             Game.played_at.isnot(None),
-            func.abs(span_subq.c.entry_imbalance) >= SIGNIFICANT_IMBALANCE_CP,
         )
         .order_by(Game.played_at.asc())
     )

--- a/app/services/endgame_service.py
+++ b/app/services/endgame_service.py
@@ -137,15 +137,16 @@ def classify_endgame_class(material_signature: str) -> EndgameClass:
 
 
 # Minimum material imbalance (in centipawns) to count as conversion or recovery.
-# Filters out minor imbalances like bishop pair (~50cp) that aren't meaningful
-# advantages to convert or deficits to recover from.
-_MATERIAL_ADVANTAGE_THRESHOLD = 300
+# Lowered from 300cp to 100cp alongside the persistence filter — the persistence
+# requirement (imbalance must also hold 4 plies later) eliminates transient noise
+# from piece trades, allowing a lower threshold for a larger meaningful dataset.
+_MATERIAL_ADVANTAGE_THRESHOLD = 100
 
 
 def _aggregate_endgame_stats(rows: Sequence[Row[Any] | tuple[Any, ...]]) -> list[EndgameCategoryStats]:
     """Aggregate raw per-(game, class) endgame rows into EndgameCategoryStats list.
 
-    Each row is: (game_id, endgame_class_int, result, user_color, user_material_imbalance)
+    Each row is: (game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after)
     where endgame_class_int is 1-6 (see EndgameClassInt).
     A game_id may appear multiple times (once per endgame class it spent >= 6 plies in).
     Per D-02: multi-class per game.
@@ -173,7 +174,7 @@ def _aggregate_endgame_stats(rows: Sequence[Row[Any] | tuple[Any, ...]]) -> list
         lambda: {"games": 0, "wins": 0, "draws": 0}
     )
 
-    for _game_id, endgame_class_int, result, user_color, user_material_imbalance in rows:
+    for _game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after in rows:
         endgame_class = _INT_TO_CLASS[endgame_class_int]
         outcome = derive_user_result(result, user_color)
 
@@ -185,18 +186,28 @@ def _aggregate_endgame_stats(rows: Sequence[Row[Any] | tuple[Any, ...]]) -> list
         else:
             wdl[endgame_class]["losses"] += 1
 
-        # Conversion: user entered with significant material advantage (>= 3 pawns / 300cp)
-        # Threshold filters out minor imbalances (e.g. bishop pair) that don't represent
-        # a meaningful advantage to "convert" into a win.
-        if user_material_imbalance is not None and user_material_imbalance >= _MATERIAL_ADVANTAGE_THRESHOLD:
+        # Conversion: user entered with significant material advantage (>= 100cp)
+        # that persisted 4 plies into the endgame — filters transient trade imbalances.
+        if (
+            user_material_imbalance is not None
+            and user_material_imbalance >= _MATERIAL_ADVANTAGE_THRESHOLD
+            and user_material_imbalance_after is not None
+            and user_material_imbalance_after >= _MATERIAL_ADVANTAGE_THRESHOLD
+        ):
             conv[endgame_class]["games"] += 1
             if outcome == "win":
                 conv[endgame_class]["wins"] += 1
             elif outcome == "draw":
                 conv[endgame_class]["draws"] += 1
 
-        # Recovery: user entered with significant material deficit (<= -3 pawns / -300cp)
-        if user_material_imbalance is not None and user_material_imbalance <= -_MATERIAL_ADVANTAGE_THRESHOLD:
+        # Recovery: user entered with significant material deficit (<= -100cp)
+        # that persisted 4 plies into the endgame.
+        if (
+            user_material_imbalance is not None
+            and user_material_imbalance <= -_MATERIAL_ADVANTAGE_THRESHOLD
+            and user_material_imbalance_after is not None
+            and user_material_imbalance_after <= -_MATERIAL_ADVANTAGE_THRESHOLD
+        ):
             recov[endgame_class]["games"] += 1
             if outcome == "win":
                 recov[endgame_class]["wins"] += 1
@@ -742,9 +753,18 @@ async def get_conv_recov_timeline(
         recency_cutoff=None,
     )
 
-    # Split by material advantage direction
-    conversion_rows = [r for r in rows if r[3] is not None and r[3] >= _MATERIAL_ADVANTAGE_THRESHOLD]
-    recovery_rows = [r for r in rows if r[3] is not None and r[3] <= -_MATERIAL_ADVANTAGE_THRESHOLD]
+    # Split by material advantage direction — require persistence at entry AND 4 plies later.
+    # r[3] = user_material_imbalance (at entry), r[4] = user_material_imbalance_after (4 plies later)
+    conversion_rows = [
+        r for r in rows
+        if r[3] is not None and r[3] >= _MATERIAL_ADVANTAGE_THRESHOLD
+        and r[4] is not None and r[4] >= _MATERIAL_ADVANTAGE_THRESHOLD
+    ]
+    recovery_rows = [
+        r for r in rows
+        if r[3] is not None and r[3] <= -_MATERIAL_ADVANTAGE_THRESHOLD
+        and r[4] is not None and r[4] <= -_MATERIAL_ADVANTAGE_THRESHOLD
+    ]
 
     # Conversion rate: wins / total in window
     conversion_series = _compute_conv_recov_rolling_series(

--- a/frontend/src/components/charts/EndgameConvRecovChart.tsx
+++ b/frontend/src/components/charts/EndgameConvRecovChart.tsx
@@ -6,7 +6,7 @@
 import { ChartContainer, ChartTooltip, ChartLegend, ChartLegendContent } from '@/components/ui/chart';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { InfoPopover } from '@/components/ui/info-popover';
-import { MATERIAL_ADVANTAGE_POINTS } from '@/components/charts/EndgamePerformanceSection';
+import { MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
 import { GAUGE_SUCCESS } from '@/lib/theme';
 import type { EndgameCategoryStats } from '@/types/endgames';
 import type { ChartConfig } from '@/components/ui/chart';
@@ -48,12 +48,12 @@ export function EndgameConvRecovChart({ categories }: EndgameConvRecovChartProps
           Conversion &amp; Recovery by Endgame Type
           <InfoPopover ariaLabel="Conversion and Recovery info" testId="conv-recov-chart-info" side="top">
             <div className="space-y-2">
-            <p>
-                <strong>Conversion</strong>: your win rate when you entered an endgame sequence of this type with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} points.
-            </p>
-            <p>
-                <strong>Recovery</strong>: your draw+win rate when you entered an endgame sequence of this type with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} points.
-            </p>
+              <p>
+                <strong>Conversion</strong>: your win rate when you entered an endgame sequence of this type with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves.
+              </p>
+              <p>
+                <strong>Recovery</strong>: your draw+win rate when you entered an endgame sequence of this type with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves.
+              </p>
             </div>
           </InfoPopover>
         </span>

--- a/frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx
+++ b/frontend/src/components/charts/EndgameConvRecovTimelineChart.tsx
@@ -4,6 +4,7 @@ import { ChartContainer, ChartTooltip, ChartLegend, ChartLegendContent } from '@
 import { LineChart, Line, CartesianGrid, XAxis, YAxis } from 'recharts';
 import { GAUGE_SUCCESS } from '@/lib/theme';
 import { createDateTickFormatter, formatDateWithYear } from '@/lib/utils';
+import { MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
 import type { ConvRecovTimelineResponse } from '@/types/endgames';
 
 interface EndgameConvRecovTimelineChartProps {
@@ -78,11 +79,13 @@ export function EndgameConvRecovTimelineChart({ data }: EndgameConvRecovTimeline
             <div className="space-y-2">
               <p>
                 <strong>Conversion rate</strong>: your win rate in the last {data.window} games where you
-              entered an endgame sequence with a material advantage of at least 3 points.
+                entered an endgame sequence with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point
+                that persisted for at least {PERSISTENCE_MOVES} moves.
               </p>
               <p>
                 <strong>Recovery rate</strong>: your save rate (wins + draws) in the last {data.window} games
-              where you entered an endgame sequence with a material deficit of at least 3 points.
+                where you entered an endgame sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point
+                that persisted for at least {PERSISTENCE_MOVES} moves.
               </p>
             </div>
           </InfoPopover>

--- a/frontend/src/components/charts/EndgamePerformanceSection.tsx
+++ b/frontend/src/components/charts/EndgamePerformanceSection.tsx
@@ -10,8 +10,11 @@ import { WDLChartRow } from '@/components/charts/WDLChartRow';
 import { GAUGE_DANGER, GAUGE_WARNING, GAUGE_SUCCESS } from '@/lib/theme';
 import type { EndgamePerformanceResponse } from '@/types/endgames';
 
-// Material advantage/deficit threshold in pawn points (backend uses 300 centipawns)
-export const MATERIAL_ADVANTAGE_POINTS = 3;
+// Material advantage/deficit threshold in pawn points (backend uses 100 centipawns)
+export const MATERIAL_ADVANTAGE_POINTS = 1;
+
+// Persistence requirement in full moves (= 4 plies on the backend)
+export const PERSISTENCE_MOVES = 2;
 
 // Per-gauge zone definitions — thresholds differ per metric, colors from theme constants
 const CONVERSION_ZONES: GaugeZone[] = [
@@ -70,7 +73,7 @@ export function EndgamePerformanceSection({ data }: EndgamePerformanceSectionPro
           <div className="relative z-10 flex items-center gap-1 text-sm text-foreground text-center">
             <span>Conversion</span>
             <InfoPopover ariaLabel="Conversion info" testId="gauge-conversion-info" side="top">
-              Your win rate when entering an endgame sequence with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} points.
+              Your win rate when entering an endgame sequence with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
             </InfoPopover>
           </div>
           <EndgameGauge
@@ -86,7 +89,7 @@ export function EndgamePerformanceSection({ data }: EndgamePerformanceSectionPro
           <div className="relative z-10 flex items-center gap-1 text-sm text-foreground text-center">
             <span>Recovery</span>
             <InfoPopover ariaLabel="Recovery info" testId="gauge-recovery-info" side="top">
-              Your draw or win rate when entering an endgame sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} points.
+              Your draw or win rate when entering an endgame sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point that persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
             </InfoPopover>
           </div>
           <EndgameGauge

--- a/frontend/src/components/charts/EndgamePerformanceSection.tsx
+++ b/frontend/src/components/charts/EndgamePerformanceSection.tsx
@@ -24,9 +24,9 @@ const CONVERSION_ZONES: GaugeZone[] = [
 ];
 
 const RECOVERY_ZONES: GaugeZone[] = [
-  { from: 0,    to: 0.1,  color: GAUGE_DANGER },
-  { from: 0.1,  to: 0.3,  color: GAUGE_WARNING },
-  { from: 0.3,  to: 1.0,  color: GAUGE_SUCCESS },
+  { from: 0,    to: 0.15,  color: GAUGE_DANGER },
+  { from: 0.15,  to: 0.35, color: GAUGE_WARNING },
+  { from: 0.35, to: 1.0,  color: GAUGE_SUCCESS },
 ];
 
 const ENDGAME_SKILL_ZONES: GaugeZone[] = [

--- a/frontend/src/pages/Endgames.tsx
+++ b/frontend/src/pages/Endgames.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { FilterPanel } from '@/components/filters/FilterPanel';
 import { useFilterStore } from '@/hooks/useFilterStore';
 import { EndgameWDLChart } from '@/components/charts/EndgameWDLChart';
-import { EndgamePerformanceSection } from '@/components/charts/EndgamePerformanceSection';
+import { EndgamePerformanceSection, MATERIAL_ADVANTAGE_POINTS, PERSISTENCE_MOVES } from '@/components/charts/EndgamePerformanceSection';
 import { EndgameConvRecovChart } from '@/components/charts/EndgameConvRecovChart';
 import { EndgameTimelineChart } from '@/components/charts/EndgameTimelineChart';
 import { EndgameConvRecovTimelineChart } from '@/components/charts/EndgameConvRecovTimelineChart';
@@ -119,10 +119,13 @@ export function EndgamesPage() {
               </p>
               <p>
                 <strong>Conversion:</strong> your win rate when you entered an endgame sequence
-                with a material advantage of at least 3 points. <strong>Recovery:</strong> your
-                draw+win rate when you entered an endgame sequence with a material deficit of at
-                least 3 points. Since a game can pass through multiple endgame types, it can
-                contribute a conversion or recovery entry to each type independently.
+                with a material advantage of at least {MATERIAL_ADVANTAGE_POINTS} point that
+                persisted for at least {PERSISTENCE_MOVES} moves into the endgame.
+                {' '}<strong>Recovery:</strong> your draw+win rate when you entered an endgame
+                sequence with a material deficit of at least {MATERIAL_ADVANTAGE_POINTS} point
+                that persisted for at least {PERSISTENCE_MOVES} moves into the endgame. Since a
+                game can pass through multiple endgame types, it can contribute a conversion or
+                recovery entry to each type independently.
               </p>
               <p>
                 These rates reflect your performance against opponents at your current rating level.

--- a/tests/test_endgame_repository.py
+++ b/tests/test_endgame_repository.py
@@ -194,7 +194,7 @@ class TestQueryEndgameEntryRows:
         )
         # Should return exactly one row for this (game, rook) span
         assert len(rows) == 1
-        game_id, endgame_class, result, user_color, user_material_imbalance = rows[0]
+        game_id, endgame_class, result, user_color, user_material_imbalance, user_material_imbalance_after = rows[0]
         assert game_id == game.id
         assert endgame_class == 1  # rook
 
@@ -277,10 +277,13 @@ class TestQueryEndgameEntryRows:
             recency_cutoff=None,
         )
         assert len(rows) == 1
-        _game_id, _endgame_class, _result, user_color, user_material_imbalance = rows[0]
+        _game_id, _endgame_class, _result, user_color, user_material_imbalance, user_material_imbalance_after = rows[0]
         # For white user, user_material_imbalance = material_imbalance at entry ply (ply=20)
         assert user_color == "white"
         assert user_material_imbalance == 200  # from first ply of span
+        # user_material_imbalance_after = imbalance at ply=24 (entry+4 = ply 20+4)
+        # All plies 21-25 have imbalance=50, so after-value is 50
+        assert user_material_imbalance_after == 50
 
     @pytest.mark.asyncio
     async def test_time_control_filter(self, db_session: AsyncSession) -> None:

--- a/tests/test_endgame_service.py
+++ b/tests/test_endgame_service.py
@@ -88,8 +88,10 @@ class TestClassifyEndgameClass:
 class TestAggregateEndgameStats:
     """Unit tests for endgame stats aggregation logic.
 
-    Rows use the new shape: (game_id, endgame_class_int, result, user_color, user_material_imbalance)
+    Rows use the new shape: (game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after)
     where endgame_class_int is 1=rook, 2=minor_piece, 3=pawn, 4=queen, 5=mixed, 6=pawnless.
+    The 6th element (user_material_imbalance_after) is the imbalance 4 plies after entry — used
+    for the persistence check: both entry AND entry+4 must meet the threshold.
     """
 
     def test_empty_input_returns_empty(self):
@@ -102,11 +104,11 @@ class TestAggregateEndgameStats:
         # 1 rook game (endgame_class_int=1), 3 pawn games (endgame_class_int=3)
         rows = [
             # 1 rook game (win)
-            (1, 1, "1-0", "white", 100),
+            (1, 1, "1-0", "white", 100, 100),
             # 3 pawn games (2 wins, 1 loss)
-            (2, 3, "1-0", "white", 50),
-            (3, 3, "1-0", "white", 0),
-            (4, 3, "0-1", "white", -100),
+            (2, 3, "1-0", "white", 50, 50),
+            (3, 3, "1-0", "white", 0, 0),
+            (4, 3, "0-1", "white", -100, -100),
         ]
         result = _aggregate_endgame_stats(rows)
         # Pawn category has 3 games, rook has 1 — pawn should come first
@@ -118,9 +120,9 @@ class TestAggregateEndgameStats:
     def test_win_draw_loss_percentages(self):
         """Percentages computed correctly for 1W/1D/1L split."""
         rows = [
-            (1, 1, "1-0", "white", 0),       # rook win (endgame_class_int=1)
-            (2, 1, "1/2-1/2", "white", 0),   # rook draw
-            (3, 1, "0-1", "white", 0),        # rook loss
+            (1, 1, "1-0", "white", 0, 0),       # rook win (endgame_class_int=1)
+            (2, 1, "1/2-1/2", "white", 0, 0),   # rook draw
+            (3, 1, "0-1", "white", 0, 0),        # rook loss
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -131,17 +133,17 @@ class TestAggregateEndgameStats:
         assert abs(rook.win_pct - 33.3) < 1
 
     def test_conversion_pct_per_category(self):
-        """D-08: Conversion = win rate when user entered endgame with >= 300cp material advantage."""
+        """D-08: Conversion = win rate when user entered endgame with >= 100cp material advantage (persisted)."""
         rows = [
-            (1, 1, "1-0", "white", 500),      # rook, up 500cp, won → converted
-            (2, 1, "0-1", "white", 350),       # rook, up 350cp, lost → failed conversion
-            (3, 1, "1/2-1/2", "white", 300),   # rook, up 300cp (threshold), draw → draw conversion
-            (4, 1, "1-0", "white", 200),        # rook, up 200cp (below threshold) → NOT a conversion game
-            (5, 1, "1-0", "white", -400),       # rook, down, won → not a conversion game
+            (1, 1, "1-0", "white", 500, 500),     # rook, up 500cp, persisted, won → converted
+            (2, 1, "0-1", "white", 350, 350),      # rook, up 350cp, persisted, lost → failed conversion
+            (3, 1, "1/2-1/2", "white", 100, 100),  # rook, up 100cp (threshold), persisted, draw → draw conversion
+            (4, 1, "1-0", "white", 200, 50),        # rook, up 200cp at entry but only 50cp after → NOT conversion (didn't persist)
+            (5, 1, "1-0", "white", -400, -400),     # rook, down, won → not a conversion game
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
-        # 3 games >= 300cp up: 1 win, 1 draw, 1 loss → 33.3% conversion
+        # 3 games with persisted >= 100cp: 1 win, 1 draw, 1 loss → 33.3% conversion
         assert rook.conversion.conversion_games == 3
         assert rook.conversion.conversion_wins == 1
         assert rook.conversion.conversion_draws == 1
@@ -149,16 +151,16 @@ class TestAggregateEndgameStats:
         assert abs(rook.conversion.conversion_pct - 33.3) < 0.1
 
     def test_recovery_pct_per_category(self):
-        """D-09: Recovery = draw+win rate when user entered endgame with <= -300cp material deficit."""
+        """D-09: Recovery = draw+win rate when user entered endgame with <= -100cp material deficit (persisted)."""
         rows = [
-            (1, 1, "1-0", "white", -400),     # rook, down 400cp, won → recovery win
-            (2, 1, "1/2-1/2", "white", -500), # rook, down 500cp, draw → recovery draw
-            (3, 1, "0-1", "white", -300),      # rook, down 300cp (threshold), lost → not recovered
-            (4, 1, "0-1", "white", -200),      # rook, down 200cp (below threshold) → NOT a recovery game
+            (1, 1, "1-0", "white", -400, -400),    # rook, down 400cp, persisted, won → recovery win
+            (2, 1, "1/2-1/2", "white", -500, -500), # rook, down 500cp, persisted, draw → recovery draw
+            (3, 1, "0-1", "white", -100, -100),      # rook, down 100cp (threshold), persisted, lost → not recovered
+            (4, 1, "0-1", "white", -200, -50),       # rook, down 200cp but only -50cp after → NOT recovery (didn't persist)
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
-        # 3 games <= -300cp down, 2 saves (win + draw) → 66.7%
+        # 3 games with persisted <= -100cp, 2 saves (win + draw) → 66.7%
         assert rook.conversion.recovery_games == 3
         assert rook.conversion.recovery_wins == 1
         assert rook.conversion.recovery_draws == 1
@@ -168,7 +170,7 @@ class TestAggregateEndgameStats:
     def test_no_game_phase_breakdown(self):
         """D-11: Single aggregate per endgame type, no opening/middlegame/endgame sub-breakdown."""
         rows = [
-            (1, 1, "1-0", "white", 100),  # rook, endgame_class_int=1
+            (1, 1, "1-0", "white", 100, 100),  # rook, endgame_class_int=1
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -182,9 +184,9 @@ class TestAggregateEndgameStats:
     def test_multiple_categories_aggregated_correctly(self):
         """Multiple categories are computed independently, not mixed together."""
         rows = [
-            (1, 1, "1-0", "white", 0),     # rook win (endgame_class_int=1)
-            (2, 1, "0-1", "white", 0),      # rook loss
-            (3, 4, "1-0", "white", 0),      # queen win (endgame_class_int=4)
+            (1, 1, "1-0", "white", 0, 0),     # rook win (endgame_class_int=1)
+            (2, 1, "0-1", "white", 0, 0),      # rook loss
+            (3, 4, "1-0", "white", 0, 0),      # queen win (endgame_class_int=4)
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -198,8 +200,8 @@ class TestAggregateEndgameStats:
     def test_zero_conversion_games_returns_zero_pct(self):
         """When no games have material advantage, conversion_pct should be 0 (not a divide-by-zero error)."""
         rows = [
-            (1, 1, "1-0", "white", -100),   # rook, down, won → recovery only
-            (2, 1, "0-1", "white", 0),       # rook, equal, lost → neither
+            (1, 1, "1-0", "white", -100, -100),   # rook, down, won → recovery only
+            (2, 1, "0-1", "white", 0, 0),          # rook, equal, lost → neither
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -209,8 +211,8 @@ class TestAggregateEndgameStats:
     def test_zero_recovery_games_returns_zero_pct(self):
         """When no games have material disadvantage, recovery_pct should be 0."""
         rows = [
-            (1, 1, "1-0", "white", 200),    # rook, up, won → conversion only
-            (2, 1, "0-1", "white", 0),       # rook, equal, lost → neither
+            (1, 1, "1-0", "white", 200, 200),    # rook, up, won → conversion only
+            (2, 1, "0-1", "white", 0, 0),         # rook, equal, lost → neither
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -221,10 +223,10 @@ class TestAggregateEndgameStats:
         """A game_id appearing with two different endgame_class_int values contributes to both classes."""
         rows = [
             # Same game (game_id=1) in two classes: rook (1) and pawn (3)
-            (1, 1, "1-0", "white", 100),   # rook class for game 1
-            (1, 3, "1-0", "white", 50),    # pawn class for game 1
+            (1, 1, "1-0", "white", 100, 100),   # rook class for game 1
+            (1, 3, "1-0", "white", 50, 50),      # pawn class for game 1
             # Another game in rook only
-            (2, 1, "0-1", "white", 0),
+            (2, 1, "0-1", "white", 0, 0),
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -237,6 +239,38 @@ class TestAggregateEndgameStats:
         assert rook.losses == 1
         # Pawn: 1 win
         assert pawn.wins == 1
+
+    def test_persistence_filter_excludes_transient_imbalance(self):
+        """Imbalance must persist 4 plies after entry — transient trade imbalances are excluded."""
+        rows = [
+            # Entry imbalance 200cp but after 4 plies only 50cp -> NOT conversion (transient)
+            (1, 1, "1-0", "white", 200, 50),
+            # Entry imbalance -300cp but after 4 plies only -80cp -> NOT recovery (transient)
+            (2, 1, "0-1", "white", -300, -80),
+            # Entry 150cp, persisted at 120cp -> IS conversion (both >= 100)
+            (3, 1, "1-0", "white", 150, 120),
+            # Entry -200cp, persisted at -150cp -> IS recovery (both <= -100)
+            (4, 1, "1/2-1/2", "white", -200, -150),
+        ]
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        # Only game 3 qualifies for conversion
+        assert rook.conversion.conversion_games == 1
+        assert rook.conversion.conversion_wins == 1
+        # Only game 4 qualifies for recovery
+        assert rook.conversion.recovery_games == 1
+        assert rook.conversion.recovery_draws == 1
+
+    def test_persistence_none_after_value_excluded(self):
+        """If imbalance_after is None (shouldn't happen with ply threshold, but safety), exclude from conv/recov."""
+        rows = [
+            (1, 1, "1-0", "white", 200, None),
+            (2, 1, "0-1", "white", -200, None),
+        ]
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        assert rook.conversion.conversion_games == 0
+        assert rook.conversion.recovery_games == 0
 
 
 class TestGetEndgameStatsSmoke:
@@ -490,8 +524,11 @@ class TestEndgameGaugeCalculations:
     """Unit tests for gauge value formulas: aggregate conversion/recovery and endgame_skill."""
 
     def _entry_row(self, game_id: int, endgame_class_int: int, result: str, user_color: str, imbalance: int):
-        """Build a (game_id, endgame_class_int, result, user_color, user_material_imbalance) entry row."""
-        return (game_id, endgame_class_int, result, user_color, imbalance)
+        """Build a (game_id, endgame_class_int, result, user_color, user_material_imbalance, user_material_imbalance_after) entry row.
+
+        Sets imbalance_after equal to imbalance so the persistence check always passes in these gauge tests.
+        """
+        return (game_id, endgame_class_int, result, user_color, imbalance, imbalance)
 
     @pytest.mark.asyncio
     async def test_aggregate_conversion_uses_sum_of_raw_not_mean_of_percentages(self):


### PR DESCRIPTION
## Summary

- Add persistence filter for endgame conversion/recovery classification: material imbalance must persist for 4 plies after endgame entry to count, filtering out transient trade imbalances
- Lower conversion/recovery threshold from 3pt to 1pt for finer-grained detection
- Update frontend text (chart popovers, accordion descriptions) to reflect the 1pt threshold and persistence filtering
- Adjust recovery gauge zones for t=100 threshold

## Test plan

- [x] Backend unit tests updated and passing
- [x] Repository returns persistence field in query results
- [x] Service layer applies persistence check correctly
- [x] Frontend displays updated threshold/persistence text


🤖 Generated with [Claude Code](https://claude.com/claude-code)