### PR TITLE
ui-tweaks: focus preservation on Import + rounded board corners

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -270,7 +270,7 @@ function MobileMoreDrawer({ open, onOpenChange }: { open: boolean; onOpenChange:
 // ─── Layout (protected pages) ─────────────────────────────────────────────────
 
 function ProtectedLayout() {
-  const { token, loginWithToken } = useAuth();
+  const { token, refreshAuthToken } = useAuth();
   const { data: profile } = useUserProfile();
   const location = useLocation();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -287,15 +287,18 @@ function ProtectedLayout() {
     }
   }, []);
 
-  // GUEST-05: Refresh guest JWT on each visit, resetting the 30-day expiry
+  // GUEST-05: Refresh guest JWT on each visit, resetting the 30-day expiry.
+  // Uses refreshAuthToken (not loginWithToken) to avoid clearing the query cache
+  // on the same user — otherwise useUserProfile refetches mid-keystroke on the
+  // Import page and the focused username input loses focus after the first char.
   useEffect(() => {
     if (profile?.is_guest && !refreshedRef.current) {
       refreshedRef.current = true;
       apiClient.post<{ access_token: string }>('/auth/guest/refresh')
-        .then((res) => loginWithToken(res.data.access_token))
+        .then((res) => refreshAuthToken(res.data.access_token))
         .catch(() => { /* token still valid, refresh is best-effort */ });
     }
-  }, [profile?.is_guest, loginWithToken]);
+  }, [profile?.is_guest, refreshAuthToken]);
 
   if (!token) {
     return <Navigate to="/login" replace />;

--- a/frontend/src/components/board/ChessBoard.tsx
+++ b/frontend/src/components/board/ChessBoard.tsx
@@ -240,12 +240,12 @@ export function ChessBoard({ position, onPieceDrop, flipped = false, lastMove, a
   return (
     <div ref={containerRef} className="w-full" data-testid="chessboard">
       {boardWidth > 0 && (
-      <div style={{ position: 'relative', width: boardWidth, height: boardWidth, touchAction: 'none' }}>
+      <div style={{ position: 'relative', width: boardWidth, height: boardWidth, touchAction: 'none', borderRadius: '0.5rem', overflow: 'hidden' }}>
         <Chessboard
           options={{
             position,
             boardOrientation: flipped ? 'black' : 'white',
-            boardStyle: { width: boardWidth, height: boardWidth },
+            boardStyle: { width: boardWidth, height: boardWidth, borderRadius: '0.5rem' },
             darkSquareStyle,
             lightSquareStyle,
             darkSquareNotationStyle: DARK_SQUARE_NOTATION,

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -14,6 +14,8 @@ interface AuthState {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
   loginWithToken: (token: string) => void;
+  /** Replace the stored token for the same user without clearing the query cache. */
+  refreshAuthToken: (token: string) => void;
   loginAsGuest: () => Promise<void>;
   register: (email: string, password: string) => Promise<void>;
   logout: () => void;
@@ -68,6 +70,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     queryClient.clear();
     setToken(externalToken);
     setUser(null);
+  }, []);
+
+  // Replace the stored token for the same user without clearing the query cache.
+  // Bug fix: the guest-JWT refresh on /import used loginWithToken, which cleared
+  // userProfile cache mid-keystroke. useUserProfile's isLoading flipped back to
+  // true, the Import page swapped the inputs for a "Loading profile..." placeholder,
+  // and the focused username input lost focus after the first character.
+  const refreshAuthToken = useCallback((externalToken: string): void => {
+    localStorage.setItem('auth_token', externalToken);
+    setToken(externalToken);
   }, []);
 
   const register = async (email: string, password: string): Promise<void> => {
@@ -134,7 +146,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // guest_token is preserved so RegisterForm can promote the guest account.
   }, []);
 
-  const value: AuthState = { user, token, isLoading, login, loginWithToken, loginAsGuest, register, logout, logoutForPromotion };
+  const value: AuthState = { user, token, isLoading, login, loginWithToken, refreshAuthToken, loginAsGuest, register, logout, logoutForPromotion };
 
   return React.createElement(AuthContext.Provider, { value }, children);
 }


### PR DESCRIPTION
## Summary
- Fix lost focus on the lichess username input during guest JWT refresh by adding `refreshAuthToken` (swaps token without clearing the query cache). `loginWithToken` still clears the cache for real user switches (guest create, OAuth, registration).
- Round chessboard corners to match the board controls bar.

## Test plan
- [ ] Type in the lichess username field on the Import page as a guest and confirm focus is preserved across JWT refresh
- [ ] Verify chessboard corners visually match the controls bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)