### PR TITLE
docs: add FlawChess quality assessment report

### DIFF
--- a/reports/flawchess_quality_assessment.md
+++ b/reports/flawchess_quality_assessment.md
@@ -1,0 +1,200 @@
+# Quality Assessment — `flawchess` Chess Analysis Platform
+
+| Field  | Value                                                                                       |
+|--------|---------------------------------------------------------------------------------------------|
+| Date   | 2026-04-13                                                                                  |
+| Scope  | `/Users/ws80/Projects/flawchess` (≈8,600 LOC backend Python, ≈13,400 LOC TypeScript/TSX, 32 pytest files / ≈14,000 LOC of tests) |
+| Author | Claude (Opus 4.6) on behalf of Adrian Imfeld                                                |
+
+**Context.** FlawChess (flawchess.com) is a free, open-source chess-analysis web app. Users import games from chess.com and lichess; the app indexes every half-move by Zobrist hash and surfaces win/draw/loss rates per board position, opening tracking, and endgame analytics. Stack: FastAPI 0.115 + Python 3.13 + SQLAlchemy async + asyncpg + Alembic on PostgreSQL 18; React 19 + TypeScript + Vite on the frontend; FastAPI-Users for auth (with chess.com/lichess background importers via `httpx.AsyncClient`). Single-box production deployment on Hetzner (4 vCPU / 7.6 GB RAM + 2 GB swap) behind Caddy, deployed via GitHub Actions. Sentry + structured Python logging are wired up across both halves.
+
+---
+
+## 1. Executive Summary
+
+| Dimension | Grade | One-line finding |
+|---|---|---|
+| Architecture | **A** | Clean router → service → repository layering with a single shared filter utility (`query_utils.apply_game_filters`) — the convention is followed everywhere |
+| Code duplication | **A−** | Shared filter / Zobrist / theme modules eliminate the obvious repetition; remaining noise is necessary SQLAlchemy ORM ceremony |
+| Error handling / Sentry | **B+** | Sentry initialised on both ends, retry loops capture only on the last attempt, but only 11 explicit `capture_exception()` sites in 8.6 k LOC and very few `set_context()` tags — grouping leans on stack traces alone |
+| Secrets / config | **A** | No hard-coded secrets in source; `change-me-in-production` placeholder for `SECRET_KEY` is the right pattern; production `.env` lives only on the server |
+| Code smells | **A** | Magic numbers extracted into named constants with rationale comments (e.g. `_BATCH_SIZE = 28`), no TODO/FIXME, no dead commented-out blocks |
+| Maintainability | **A−** | 32 test files, ≈14 k LOC of tests against a real PostgreSQL container in CI; Alembic migrations include downgrades; `ty` and `knip` gate the build |
+| Security | **A−** | OAuth state CSRF (CVE-2025-68481) patched with double-submit cookie + signed JWT + timing-safe compare; ORM-only queries; FastAPI-Users handles password hashing and session tokens |
+| Database design | **A** | Mandatory `ForeignKey(..., ondelete=...)`, multi-column unique constraints for natural keys, partial + covering indexes on `game_positions` for the Zobrist-hash hot path, `SmallInteger`/`BigInteger`/`Float(24)` chosen deliberately |
+| Frontend quality | **A−** | Strict TypeScript with `noUncheckedIndexedAccess`, theme tokens centralised in `lib/theme.ts`, `data-testid` discipline for browser automation, `knip` runs in CI |
+| Observability | **B+** | Sentry on both ends with a thoughtful `before_send` to fingerprint asyncpg connection drops; logging is plain `logging`, no JSON / no slow-query trace |
+
+**Bottom line:** this is a healthy, production-grade codebase that punches above its weight for a single-maintainer project. The architecture is disciplined, the tests are real (PostgreSQL container in CI, not mocks), the database schema is carefully thought through, and the only actively dangerous class of issues a reviewer normally finds — checked-in secrets, raw SQL with f-strings, unguarded auth — is absent. The remaining work is **refinement** rather than rescue: tighten Sentry context tags, formalise the error-handling pattern between services and routers, and add structured logging. There is no rewrite hiding in here.
+
+---
+
+## 2. What the App Actually Does — Operational Picture
+
+The data flow is worth stating because it frames the "why" of several design decisions:
+
+1. **Sign-up** via FastAPI-Users (email/password or Google OAuth, with a guest-session promotion path in `services/guest_service.py`).
+2. **Background import** kicks off (`services/import_service.py`):
+   - chess.com: monthly archives fetched sequentially with rate-limit delays via `httpx.AsyncClient` (`services/chesscom_client.py`).
+   - lichess: NDJSON stream consumed line-by-line (`services/lichess_client.py`), retried with exponential back-off (`_MAX_RETRIES = 3`).
+   - Both normalise to a unified schema (`services/normalization.py`, `schemas/normalization.py`).
+3. **Position indexing** (`services/zobrist.py`, `services/position_classifier.py`):
+   - For every half-move of every Standard-variant game, three 64-bit Zobrist hashes are computed (`white_hash`, `black_hash`, `full_hash`) and inserted into `game_positions` in batches of `_BATCH_SIZE = 28` games (~2,240 rows per batch, ~1.8 MB of memory — sized after the OOM incident on 2026-03-22).
+4. **Query path**: opening / move / endgame / stats requests go router → service → repository. All filters (time control, rated, platform, recency, opponent type, color) flow through `repositories/query_utils.apply_game_filters()` — one definition, six callers.
+5. **Frontend** (`frontend/src/`) renders an interactive board, fetches WDL data via TanStack Query, and reports its own Sentry events with a `sentryBeforeSend` hook that drops 401s and groups timeouts.
+6. **Deploy**: `bin/deploy.sh` triggers a GitHub Actions workflow (`.github/workflows/ci.yml`) that boots a Postgres-18 container, runs `ruff` → `ty` → `pytest` → frontend `knip` + tests, and on success ships to the Hetzner box where Caddy front-ends Uvicorn and Alembic migrations run on container start (`deploy/entrypoint.sh`).
+
+**Key insight:** the central architectural bet — Zobrist-hash equality lookups instead of FEN-string comparison — is what makes "compare my last 200 games against this position" tractable as an indexed BIGINT lookup rather than a full-table FEN scan. The schema, the indexes (`app/models/game_position.py:11-34`), and the import batching are all designed around that bet, and they hold up.
+
+---
+
+## 3. Code Quality Findings
+
+### 3.1 Architecture and layering
+
+The CLAUDE.md convention "routers do HTTP, services do logic, repositories do SQL" is followed without exceptions in the spot-checks performed.
+
+- **Single shared filter implementation.** `app/repositories/query_utils.py` (78 lines) is the only place that knows how to translate `time_control_bucket=['blitz','rapid'] + rated=true + platform='lichess' + recency='90d'` into `WHERE` clauses. All six repositories (`game`, `endgame`, `openings`, `position_bookmark`, `stats`, `import_job`) import from here. This is exactly the abstraction that the robots-nauman codebase lacks.
+- **Router prefix discipline.** Every router is declared `APIRouter(prefix="/resource", tags=["resource"])`, with relative paths in the decorators. No accidental `/openings/openings/...` URLs.
+- **Pure-function domain logic.** `services/position_classifier.py` and the endgame classifier in `services/endgame_service.py` (`classify_endgame_class` + `_INT_TO_CLASS` / `_CLASS_TO_INT` enums at lines ≈50-71) are deterministic, side-effect-free, and unit-testable in isolation — `tests/test_position_classifier.py` (496 lines) and `tests/test_endgame_service.py` (885 lines) lean on this.
+
+### 3.2 Error handling and Sentry coverage
+
+CLAUDE.md sets a clear rule (lines 228-240): every non-trivial `except` in `app/services/` and `app/routers/` must call `sentry_sdk.capture_exception()`, never embed variables in error messages, use `set_context()` / `set_tag()` for variable data, and capture only on the last retry attempt. The codebase mostly follows this — but coverage is thin.
+
+- **Bare `except:` is zero.** Verified — no bare excepts anywhere in `app/` or `tests/`. Compare this to robots-nauman where it was the dominant idiom.
+- **Only 11 explicit `capture_exception()` sites** across 8.6 k LOC of `app/`:
+  ```
+  app/routers/auth.py:136,319,391
+  app/routers/position_bookmarks.py:110
+  app/services/openings_service.py:337
+  app/services/zobrist.py:145
+  app/services/import_service.py:276,292,299,316,419
+  ```
+  That leaves repository code, `endgames` / `imports` / `openings` / `stats` / `users` routers, and the bulk of `endgame_service.py` / `stats_service.py` / `normalization.py` / `guest_service.py` relying entirely on the top-level handler in `app/main.py` to capture anything that propagates. That works for the unhandled case, but loses the chance to attach `set_context({'user_id': ..., 'hash': ..., 'filters': ...})` *before* the throw.
+- **Retry loops are correct.** `services/lichess_client.py` retries up to `_MAX_RETRIES = 3` with exponential back-off and only lets the final exception propagate — matching the CLAUDE.md guidance.
+- **`before_send` fingerprinting.** `app/main.py:22-38` defines a Sentry `before_send` that buckets `asyncpg.exceptions.ConnectionDoesNotExistError` and `CannotConnectNowError` under a single `db-connection-lost` fingerprint, preventing every transient pool drop from creating a new Sentry issue. This is a small detail and a genuinely good one.
+- **Frontend**: `frontend/src/instrument.ts` similarly drops 401s and groups timeouts/network errors before forwarding to Sentry; the global TanStack Query `QueryCache.onError` / `MutationCache.onError` (per CLAUDE.md line 244) means components don't need to re-capture, removing a big source of duplicate events.
+
+### 3.3 Secrets and configuration
+
+This is the dimension where the contrast with robots-nauman is starkest — there is nothing to rotate.
+
+- `app/core/config.py:8` sets `SECRET_KEY: str = "change-me-in-production"` as the default. The literal is obviously a placeholder, not a real key, and the production value is loaded from `/opt/flawchess/.env` (CLAUDE.md line 169). No `.env` file is checked in.
+- Google OAuth client ID/secret, database URL, and Sentry DSN all come from environment variables; no fallback contains a live value.
+- `Dockerfile` is a plain multi-stage build with no `ARG`-baked credentials; `deploy/entrypoint.sh` runs `alembic upgrade head` then starts Uvicorn with `--proxy-headers --forwarded-allow-ips='*'` (correct for Caddy reverse-proxying).
+- No 2Captcha-style API keys, no Slack webhooks, no shared user passwords anywhere in the tree.
+
+### 3.4 Code smells (or lack thereof)
+
+- **Magic numbers extracted with rationale.** `_BATCH_SIZE = 28` in `app/services/import_service.py:37` carries a multi-line comment explaining the OOM post-mortem (each batch ≈ 80 positions × 28 games × ~800 B ≈ 1.8 MB, safe within the 7.6 GB + 2 GB swap budget). `IMPORT_TIMEOUT_SECONDS = 3 * 60 * 60` at line 38 references the GSD ticket. `services/openings_service.py` has `ROLLING_WINDOW_SIZE`, `MIN_GAMES_FOR_TIMELINE`, `RECENCY_DELTAS`. `frontend/src/lib/theme.ts` carries WDL / gauge / glass-overlay tokens — no hex literals leak into components.
+- **No `TODO` / `FIXME` / `XXX`** found in `app/` or `frontend/src/`.
+- **No commented-out code blocks** of any meaningful size in spot-checks.
+- **Bug-fix comments at the fix site.** `app/routers/auth.py:85-88` documents the CVE-2025-68481 CSRF fix inline; `app/services/import_service.py:237-250` explains why `last_synced_at` is advanced even on no-op syncs. This is exactly the CLAUDE.md "comment bug fixes" rule (line 213).
+- **`# ty: ignore[…]` discipline.** The few suppression comments include the rule name, as required.
+
+### 3.5 Database design
+
+The `game_positions` table is the hot path (≈ 80 rows per game × N games × M users), and the schema reflects that.
+
+- **Mandatory FKs with explicit `ondelete`**:
+  - `models/game.py:29-30`: `ForeignKey("users.id", ondelete="CASCADE")`
+  - `models/game_position.py:38-40`: `ForeignKey("games.id", ondelete="CASCADE")`
+  - `models/import_job.py:14-16`: `ForeignKey("users.id", ondelete="CASCADE")`
+  - `oauth_account` and `position_bookmark` likewise.
+- **Natural-key uniqueness**:
+  - `models/game.py:25`: `UniqueConstraint("user_id", "platform", "platform_game_id")` — guarantees idempotent re-imports.
+  - `models/opening.py`: `UniqueConstraint("eco", "name", "pgn")` on the seeded openings table.
+- **Indexes on `game_positions`** (`models/game_position.py:11-34`): three Zobrist-hash indexes (one per hash variant), a covering index on `(user_id, full_hash, move_san)` for the next-moves aggregation, a partial index on `endgame_class` with `postgresql_where IS NOT NULL` to keep the endgame index small, and a covering index with `postgresql_include` for endgame-span queries. This is genuinely thoughtful index work.
+- **Column types chosen on purpose**: `SmallInteger` for ratings (range 0-4000), `BigInteger` for the 64-bit Zobrist hashes, `Float(24)` for `clock_seconds` (REAL, 4 bytes — half the storage of DOUBLE PRECISION).
+- **38 Alembic migrations**, each with a working `downgrade()`. Destructive transitions (e.g. the `result` / `user_color` / `termination` / `time_control_bucket` enum conversion in `20260408_155149_3e4018d62102_*.py:52-67`) carry explicit `USING` casts and reverse to VARCHAR on downgrade.
+
+### 3.6 Security
+
+- **OAuth state CSRF (CVE-2025-68481) is patched.** `app/routers/auth.py:85-96` generates `secrets.token_urlsafe(32)`, embeds it in a 600-second JWT signed with `SECRET_KEY` (audience `fastapi-users:oauth-state`), and sets a parallel `httpOnly` / `secure` (in non-dev) / `samesite=lax` cookie. The callback (lines 128-137) recovers both, validates the JWT, and uses a timing-safe comparison on the token. This is a textbook double-submit cookie + signed-state implementation.
+- **No raw SQL.** Every query in `app/repositories/` uses the SQLAlchemy 2.x `select()` API. The only f-string URL constructions are HTTP path joins in `services/lichess_client.py:71` and `services/chesscom_client.py`, both with usernames that have already been validated by Pydantic schemas. No f-string-into-SQL anywhere.
+- **Auth dependencies are uniformly applied.** Routers depend on `current_active_user` (the FastAPI-Users `Annotated` dependency); guest sessions are explicitly typed and routed through `services/guest_service.py`.
+- **CORS is dev-only.** `app/main.py:60-67` only mounts the CORS middleware for `localhost:5173` when `ENVIRONMENT == "development"`. In production Caddy serves backend and frontend from the same origin, so CORS is never needed.
+- **`send_default_pii=False`** on the Sentry init (`app/main.py:47-55`) — no automatic PII leak into Sentry events.
+
+### 3.7 Frontend quality
+
+- **Strict TypeScript with `noUncheckedIndexedAccess`.** Per CLAUDE.md (line 268), every array/Record index access must be narrowed. ≈ 37 `any` / `unknown` occurrences in 13.4 k LOC (~0.28 %), all in legitimate spots (TanStack Query cache contexts, `recharts` payload props, `catch (err: unknown)`). No `// @ts-ignore` anywhere.
+- **`data-testid` and `aria-label` discipline.** 37 of the ~50 `.tsx` component files carry `data-testid` attributes following the kebab-case `btn-…` / `nav-…` / `filter-…` / `board-btn-…` naming convention from CLAUDE.md (lines 281-298) — required for the Claude Chrome extension and any browser-automation testing.
+- **`knip` runs in CI.** `.github/workflows/ci.yml` invokes `npm run knip` and fails the build on dead exports / unused dependencies.
+- **Theme tokens centralised.** All WDL / gauge / glass-overlay colors live in `frontend/src/lib/theme.ts`; no hex literals in components (verified by grep).
+
+### 3.8 Testing
+
+- **32 pytest files, ≈14 k LOC of tests** for ≈8.6 k LOC of backend code. Even allowing for fixture overhead, that is a serious coverage ratio.
+- **Real PostgreSQL in CI.** `.github/workflows/ci.yml` boots a `postgres:18-alpine` service container and runs Alembic migrations against it (`tests/conftest.py:28-44`); test sessions are real `AsyncSession`s on a real DB, not mocks. This catches the class of "the mocks lied" bugs that the data-engineering memory file warns about (`MEMORY.md` — "Don't assume mock and prod are the same").
+- **HTTP clients are mocked.** `test_chesscom_client.py` and `test_lichess_client.py` use `unittest.mock.AsyncMock` to avoid real chess.com / lichess calls in CI — the right line to draw.
+- **Edge cases covered**: unique-constraint violations on registration (`test_auth.py`), OAuth CSRF token round-trip (`test_oauth_csrf.py`), the guest → Google promotion path (`test_guest_google_promotion.py`), the openings time-series (`test_openings_time_series.py`), the reclassification script (`test_reclassify.py`).
+- **Light spots**: import-pipeline error paths (timeout recovery, partial mid-batch crash) and OAuth callback edge cases (state-JWT expiry, CSRF mismatch under concurrent requests) are under-tested relative to their blast radius if they fail in production.
+
+### 3.9 Observability
+
+- **Sentry on both ends, configured well** (see §3.2). `traces_sample_rate` is configurable, `before_send` fingerprints noisy DB errors, and the frontend has parallel hooks.
+- **Logging is plain `logging`.** No JSON formatter, no per-request correlation ID, no slow-query log. Functional but limited if the operator ever wants to ship logs to a centralised aggregator. Not a blocker today.
+- **No request-timing metrics or import-progress milestones.** Import jobs persist `imported_count` / `last_synced_at` to the DB after each batch (`import_service.py:221-244`) — that's the closest thing to a progress feed and it's good — but there's nothing on the per-request path.
+
+### 3.10 Performance
+
+- **N+1 explicitly designed out.** `services/openings_service.py:112-118` notes "Batches all PGN fetches in a second query to avoid N+1 queries." Spot-checks of repositories show explicit `.join()` rather than relying on lazy relationship traversal.
+- **Async safety respected.** No `asyncio.gather()` over a single `AsyncSession` (CLAUDE.md line 251). All HTTP is `httpx.AsyncClient`. The only blocking I/O is `services/opening_lookup.py` reading `app/data/openings.tsv` at module import time, which is correct.
+- **OOM mitigated.** Post the 2026-03-22 incident, batch size dropped from 50 → 10 → settled at 28; 2 GB swap added; `IMPORT_TIMEOUT_SECONDS` caps a runaway import at 3 hours; partial progress is persisted so a crashed import resumes from the last batch boundary instead of restarting from zero.
+
+---
+
+## 4. Substantial Problems Worth Addressing
+
+These are concrete improvements, not blockers — there is nothing in this codebase that needs the equivalent of "rotate this tomorrow morning."
+
+1. **Tighten Sentry context.** Only 11 `capture_exception()` sites in 8.6 k LOC, and very few `set_context()` / `set_tag()` calls before them. Every long-running service entry point (`openings_service.analyze`, `endgame_service` aggregations, `position_bookmarks` suggestion path, `import_service.run_import`) should set `user_id`, the relevant filter dict, and (where applicable) `platform` / `source` tags so issues group by *what failed* rather than just *where it threw*. CLAUDE.md already documents this rule (lines 228-240); the pattern just isn't applied evenly yet.
+2. **Pick one error-handling pattern between services and routers.** Today some errors are captured in services (e.g. `import_service.py:276,292,299,316`) and some are left to propagate to the FastAPI top-level handler. Both are defensible; mixing them means a future reader has to figure out which convention applies in each file. A short paragraph in `CLAUDE.md` ("services capture and re-raise; routers let propagate") plus one round of cleanup would lock this in.
+3. **Add structured logging** (`python-json-logger` or equivalent) and a slow-query guard (warn when an SQLAlchemy query crosses, say, 500 ms). Cheap to add, immediately useful when the next perf incident happens.
+4. **Backfill tests for import error paths.** `import_service.py` has five `capture_exception()` sites covering `TimeoutError`, `Exception`, partial-batch failure, and post-import update failure — these are exactly the paths most likely to break silently in production. Mock the chess.com / lichess clients to raise, assert that progress is persisted and the job ends in the expected state.
+5. **OAuth callback edge-case tests.** Add tests for state-JWT expiry past the 600 s window, for cookie/JWT token mismatch, and for the case where the cookie is missing entirely. The CSRF defence is well written; the test surface should match.
+6. **Consider a top-level rate-limit / abuse guard.** Free + email-signup + background import that hits two third-party APIs is a tempting abuse target. There is currently no per-user rate limit on `POST /imports`. Not urgent (small user base), but worth a ticket.
+
+---
+
+## 5. What's Notably Good
+
+The reference robots-nauman report had nothing positive to say. This codebase deserves the opposite treatment, because several of the patterns here are worth keeping — and worth copying into other projects:
+
+- **Zobrist-hash position matching** as the central architectural bet is the right call: it converts an open-ended position-comparison problem into an indexed BIGINT equality lookup, and the schema, indexes, and import pipeline are all built around making that bet pay off.
+- **`apply_game_filters()` as the single filter source of truth** prevents exactly the kind of drift that bites every multi-repository codebase eventually.
+- **Real PostgreSQL container in CI.** Cheap to set up, expensive not to have. The MEMORY.md entry from the data-engineering project ("don't mock the database in these tests — we got burned…") could be the epigraph for this decision.
+- **`ty` + `ruff` + `knip` as build-blocking gates.** Type errors and dead exports cannot reach `main`. Few projects of this size enforce all three.
+- **Explicit `# ty: ignore[rule-name]`** with rule names — versus the more common `# type: ignore` shotgun — is a small habit that pays off whenever the type checker is upgraded.
+- **Bug fixes carry inline explanations.** `auth.py:85-88` (CVE), `import_service.py:237-250` (last-synced advancement) — future readers don't need to dig through `git blame` to understand why non-obvious code exists.
+- **Sentry `before_send` fingerprinting** of asyncpg connection drops avoids the failure mode where a 5-minute network blip creates 200 separate Sentry issues.
+- **Idempotent imports.** `UniqueConstraint("user_id", "platform", "platform_game_id")` plus the `last_synced_at` advancement on no-op syncs means re-running an import is always safe.
+
+---
+
+## 6. Recommended Actions
+
+### Immediate (this week — small, high signal)
+
+1. Add `sentry_sdk.set_context()` calls at the top of `openings_service.analyze()`, `endgame_service` aggregation entry points, the `position_bookmarks.get_suggestions` handler, and `import_service.run_import` — `user_id`, `filters`, `platform`. ≈ 1 hour.
+2. Add a `Sentry / error-handling pattern` paragraph to `CLAUDE.md` clarifying capture-vs-propagate. ≈ 30 minutes, prevents future drift.
+3. Backfill 3-5 import-error-path tests (timeout, transient HTTP failure mid-batch, retry exhaustion). ≈ 2 hours.
+
+### Short term (this month — quality-of-life)
+
+4. Replace stdlib `logging` configuration with `python-json-logger`; add a SQLAlchemy `before_cursor_execute` / `after_cursor_execute` hook that logs queries crossing a 500 ms threshold. ≈ 2-3 hours.
+5. Add OAuth-callback edge-case tests (expired state JWT, CSRF mismatch, missing cookie). ≈ 1 hour.
+6. Add a per-user rate limit on `POST /imports` (FastAPI middleware or `slowapi`) — even one import per minute would shut down the obvious abuse path. ≈ 1-2 hours.
+
+### Medium term (next quarter — only if needed)
+
+7. Once user count or import concurrency grows enough to feel the single-Hetzner-box ceiling, the natural next step is to extract the import pipeline into a separate worker process (or push it onto a queue like RQ / Arq) so an overloaded importer cannot affect API latency. The current design already isolates imports as background `asyncio` tasks, so the change is mechanical, not structural.
+8. Consider a read-replica for analytics queries if `game_positions` row count grows past tens of millions — the indexes are good but the table will eventually dominate cache.
+
+---
+
+## 7. Bottom Line
+
+FlawChess is the inverse of robots-nauman: a codebase a reviewer can read top-to-bottom in a morning and walk away from with confidence. The architectural bets (Zobrist hashing, async FastAPI + asyncpg, FastAPI-Users for auth) are sensible; the engineering discipline (real-DB tests, `ty` + `knip` in CI, FK-mandatory schema, no checked-in secrets, OAuth CVE patched) is at the level you'd expect from a production team rather than a single maintainer. There is no rewrite hiding in here, no class of issues that require an emergency response, and no design decision that visibly needs to be reversed. The remaining work is **observability polish + a handful of missing tests** — the kind of "make a good thing better" backlog that most projects would be lucky to be left with.


### PR DESCRIPTION
## Summary
- Adds `reports/flawchess_quality_assessment.md` — a 200-line quality/architecture review covering layering, maintainability, testing, database design, security, Sentry/observability, and frontend quality.
- Highlights strengths (Zobrist-hash schema, real-PostgreSQL CI, no checked-in secrets, mandatory FK + natural-key uniques) and flags refinement areas (sparser Sentry `set_context` tags, plain `logging` without JSON/slow-query trace, targeted edge-case test gaps).
- Documentation only — no code or schema changes.

## Test plan
- [ ] Skim the report for accuracy against current `main`
- [ ] Confirm file renders correctly on GitHub (tables, headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)