### PR TITLE
Fix: seed openings table on DB reset and first local run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cp .env.example .env  # Edit with your settings
 bin/run_local.sh
 ```
 
-The script starts PostgreSQL (Docker), installs dependencies, runs migrations, and launches both backend and frontend. The API is at `http://localhost:8000` (docs at `/docs`), frontend at `http://localhost:5173`.
+The script starts PostgreSQL (Docker), installs dependencies, runs migrations, seeds the openings reference table, and launches both backend and frontend. The API is at `http://localhost:8000` (docs at `/docs`), frontend at `http://localhost:5173`.
 
 > **Note:** Google OAuth and Sentry are optional — the app works with email/password auth and without error monitoring. Leave those `.env` values empty to skip them.
 

--- a/bin/reset_db.sh
+++ b/bin/reset_db.sh
@@ -20,4 +20,7 @@ done
 echo "Running Alembic migrations..."
 uv run alembic upgrade head
 
+echo "Seeding openings table..."
+uv run python -m scripts.seed_openings
+
 echo "Done. Dev database has been reset."

--- a/bin/run_local.sh
+++ b/bin/run_local.sh
@@ -36,6 +36,13 @@ uv sync
 echo "Running migrations..."
 uv run alembic upgrade head
 
+# Seed openings if table is empty (first-time setup only — skips instantly otherwise)
+OPENINGS_COUNT=$(PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d flawchess -tAc "SELECT COUNT(*) FROM openings" 2>/dev/null || echo "0")
+if [ "$OPENINGS_COUNT" -eq 0 ]; then
+  echo "Seeding openings table..."
+  uv run python -m scripts.seed_openings
+fi
+
 # Start backend
 echo "Starting backend..."
 uv run uvicorn app.main:app --reload --port 8000 &


### PR DESCRIPTION
## Summary
- **`bin/reset_db.sh`** — always seeds openings after migrations (table is empty after reset)
- **`bin/run_local.sh`** — checks if `openings` table is empty, seeds on first run only (instant skip otherwise)
- **`README.md`** — updated Setup description to mention openings seeding

## Context
The `openings` table was empty after `bin/reset_db.sh`, causing the "most played openings" feature to return no results locally while working fine in production. The `query_top_openings_sql_wdl` query JOINs games to the `openings_dedup` view — with zero rows, the join produces nothing.

## Test plan
- [ ] Run `bin/reset_db.sh` — verify openings are seeded automatically
- [x] Run `bin/run_local.sh` on a fresh DB — verify openings are seeded
- [x] Run `bin/run_local.sh` again — verify it skips seeding (no "Seeding openings table..." message)
- [x] Import games and check that "Most Played Openings" section shows data

🤖 Generated with [Claude Code](https://claude.com/claude-code)