### PR TITLE
Phase 61: test suite hardening & DB reset

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -139,7 +139,7 @@ See [milestones/v1.9-ROADMAP.md](milestones/v1.9-ROADMAP.md) for full details.
 - [ ] **Phase 56: Endgame ELO — Backend + Breakdown Table** - Backend computation and per-(platform, time-control) table UI with filters
 - [ ] **Phase 57: Endgame ELO — Timeline Chart** - Rolling-window timeline chart tracking Endgame ELO over time per combination
 - [ ] **Phase 58: Opening Risk & Drawishness** - Risk and drawishness metrics per position in the move explorer
-- [ ] **Phase 61: Test Suite Hardening & DB Reset** - Truncate `flawchess_test` at pytest session start and add meaningful aggregation sanity tests closing gaps identified in the 2026-04-16 audit (WDL perspective, material tally, rolling windows, filter intersections, recency boundary, position dedup, endgame transitions, router known-numbers integration)
+- [x] **Phase 61: Test Suite Hardening & DB Reset** - Truncate `flawchess_test` at pytest session start and add meaningful aggregation sanity tests closing gaps identified in the 2026-04-16 audit (WDL perspective, material tally, rolling windows, filter intersections, recency boundary, position dedup, endgame transitions, router known-numbers integration) (completed 2026-04-16)
 
 ## Phase Details
 
@@ -315,9 +315,9 @@ Plans:
 **Plans**: 3 plans
 
 Plans:
-- [ ] 61-01-PLAN.md — Truncate fixture in `tests/conftest.py` + shared `seeded_user` module fixture in `tests/seed_fixtures.py`
-- [ ] 61-02-PLAN.md — Aggregation sanity tests (`tests/test_aggregation_sanity.py`) + material tally tests (`tests/test_material_tally.py`)
-- [ ] 61-03-PLAN.md — Router integration tests (`tests/test_integration_routers.py`) — known seed → known numbers via the shared fixture
+- [x] 61-01-PLAN.md — Truncate fixture in `tests/conftest.py` + shared `seeded_user` module fixture in `tests/seed_fixtures.py`
+- [x] 61-02-PLAN.md — Aggregation sanity tests (`tests/test_aggregation_sanity.py`) + material tally tests (`tests/test_material_tally.py`)
+- [x] 61-03-PLAN.md — Router integration tests (`tests/test_integration_routers.py`) — known seed → known numbers via the shared fixture
 **UI hint**: no
 
 ## Progress
@@ -385,7 +385,7 @@ Plans:
 | 58. Opening Risk & Drawishness | v1.10 | 0/? | Not started | - |
 | 59. Fix Endgame Conv/Even/Recov per-game stats | v1.10 | 3/3 | Complete    | 2026-04-13 |
 | 60. Opponent-based baseline for Endgame Conv/Even/Recov | v1.10 | 0/? | Not started | - |
-| 61. Test Suite Hardening & DB Reset | v1.10 | 0/3 | In progress | - |
+| 61. Test Suite Hardening & DB Reset | v1.10 | 3/3 | Complete    | 2026-04-16 |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -139,6 +139,7 @@ See [milestones/v1.9-ROADMAP.md](milestones/v1.9-ROADMAP.md) for full details.
 - [ ] **Phase 56: Endgame ELO — Backend + Breakdown Table** - Backend computation and per-(platform, time-control) table UI with filters
 - [ ] **Phase 57: Endgame ELO — Timeline Chart** - Rolling-window timeline chart tracking Endgame ELO over time per combination
 - [ ] **Phase 58: Opening Risk & Drawishness** - Risk and drawishness metrics per position in the move explorer
+- [ ] **Phase 61: Test Suite Hardening & DB Reset** - Truncate `flawchess_test` at pytest session start and add meaningful aggregation sanity tests closing gaps identified in the 2026-04-16 audit (WDL perspective, material tally, rolling windows, filter intersections, recency boundary, position dedup, endgame transitions, router known-numbers integration)
 
 ## Phase Details
 
@@ -299,6 +300,26 @@ Plans:
 - [ ] 60-02-PLAN.md — Frontend: TS type mirror, EndgameScoreGapSection rewrite (desktop + mobile, single neutral zone, muted state, peer-framing copy)
 **UI hint**: yes
 
+### Phase 61: Test Suite Hardening & DB Reset
+**Goal**: Running `uv run pytest` (a) starts from an empty `flawchess_test` so HTTP-path test data no longer accumulates across runs, and (b) covers the aggregation correctness gaps identified in the 2026-04-16 audit — WDL from the user's perspective (black), material tally direction on captures, rolling-window boundaries, platform × time-control filter intersection, recency cutoff boundary, within-game position dedup, endgame-class transitions, and router-layer "known seed → known numbers" integration coverage.
+**Depends on**: N/A (test-only, no coupling to feature phases)
+**Requirements**: N/A (improvement to existing testing infrastructure)
+**Success Criteria** (what must be TRUE):
+  1. `tests/conftest.py` truncates all non-reference public-schema tables in `flawchess_test` before any test runs, leaving `alembic_version` and `openings` intact. Data from the previous pytest run is wiped; data from the just-finished run remains for manual inspection.
+  2. A shared `seeded_user` module-scoped fixture (new file `tests/seed_fixtures.py`) registers an HTTP user, commits a deterministic ~15-game portfolio across white/black/chess.com/lichess/bullet/blitz/rapid/classical/wins/draws/losses with known endgame spans and shared opening hashes, and returns `{id, auth_headers, expected}`.
+  3. `tests/test_aggregation_sanity.py` exists and covers: WDL perspective when user plays black, material tally direction on capture, rolling window with fewer games than window size, platform × time-control filter intersection, recency cutoff boundary behavior (pinned), within-game position dedup, endgame-class transition counted in both classes.
+  4. `tests/test_material_tally.py` verifies `_compute_material_count` / `_compute_material_imbalance` / `_compute_material_signature` from `app/services/position_classifier.py` against `python-chess` boards (starting position, after captures).
+  5. `tests/test_integration_routers.py` uses the `seeded_user` fixture to hit `/api/stats/global`, `/api/endgames/overview`, and `/api/openings/next-moves` with auth and asserts exact integer counts (not just response shape).
+  6. Full `uv run pytest` remains green end-to-end, `uv run ty check app/ tests/` is zero-errors, `uv run ruff check .` is zero-errors, `uv run ruff format --check .` is clean.
+  7. No production code (under `app/`) is modified in this phase — only `tests/` and `.planning/`. If a new test reveals a genuine bug, the finding is documented in the PR description; the fix belongs to a follow-up phase.
+**Plans**: 3 plans
+
+Plans:
+- [ ] 61-01-PLAN.md — Truncate fixture in `tests/conftest.py` + shared `seeded_user` module fixture in `tests/seed_fixtures.py`
+- [ ] 61-02-PLAN.md — Aggregation sanity tests (`tests/test_aggregation_sanity.py`) + material tally tests (`tests/test_material_tally.py`)
+- [ ] 61-03-PLAN.md — Router integration tests (`tests/test_integration_routers.py`) — known seed → known numbers via the shared fixture
+**UI hint**: no
+
 ## Progress
 
 | Phase | Milestone | Plans Complete | Status | Completed |
@@ -364,6 +385,7 @@ Plans:
 | 58. Opening Risk & Drawishness | v1.10 | 0/? | Not started | - |
 | 59. Fix Endgame Conv/Even/Recov per-game stats | v1.10 | 3/3 | Complete    | 2026-04-13 |
 | 60. Opponent-based baseline for Endgame Conv/Even/Recov | v1.10 | 0/? | Not started | - |
+| 61. Test Suite Hardening & DB Reset | v1.10 | 0/3 | In progress | - |
 
 ## Backlog
 

--- a/.planning/phases/61-test-hardening/61-01-PLAN.md
+++ b/.planning/phases/61-test-hardening/61-01-PLAN.md
@@ -1,0 +1,499 @@
+---
+phase: 61-test-hardening
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - tests/conftest.py
+  - tests/seed_fixtures.py
+autonomous: true
+requirements: []
+tags: [backend, tests, infra]
+
+must_haves:
+  truths:
+    - "Running pytest truncates all non-reference tables in flawchess_test before any test executes"
+    - "alembic_version and openings are NEVER truncated"
+    - "tests/seed_fixtures.py exposes a module-scoped seeded_user fixture usable from any test file"
+    - "seeded_user registers an HTTP user via /api/auth/register, parses id from the JSON response, and commits a deterministic game portfolio visible to subsequent API calls through the patched async_session_maker"
+    - "Existing tests in tests/ continue to pass unmodified after the truncate + fixture additions"
+  artifacts:
+    - path: "tests/conftest.py"
+      provides: "_truncate_all_tables helper called from inside test_engine between alembic upgrade and yield"
+      contains: "TRUNCATE TABLE"
+    - path: "tests/seed_fixtures.py"
+      provides: "SeededUser dataclass + seeded_user module-scoped fixture with committed ~15-game portfolio and expected aggregates"
+      contains: "class SeededUser"
+---
+
+<objective>
+Close phase 61 success criteria #1 and #2. Make the test database start empty at the beginning of every pytest session (without disturbing the just-finished run's data while the suite is off), and introduce a single shared seeded_user fixture that commits a realistic, deterministic portfolio of games and positions for use by router-level integration tests.
+
+Output:
+- A ~15-line truncate helper called once at session start in `tests/conftest.py`.
+- A new file `tests/seed_fixtures.py` with `SeededUser` dataclass, expected-aggregate dict, and a `seeded_user` module-scoped pytest fixture that any test module can import.
+- Zero changes to production code under `app/`.
+- Full pytest run stays green; ty and ruff clean.
+</objective>
+
+<execution_context>
+Worktree: /home/aimfeld/Projects/Python/flawchess-tests (branch phase-61-test-hardening)
+Run all commands from the worktree root.
+</execution_context>
+
+<context>
+@.planning/phases/61-test-hardening/61-CONTEXT.md
+@tests/conftest.py
+@app/models/game.py
+@app/models/game_position.py
+@app/core/database.py
+@app/repositories/endgame_repository.py (ENDGAME_PLY_THRESHOLD)
+
+<interfaces>
+Current `tests/conftest.py:21-44` layout (do NOT refactor beyond adding the truncate call):
+
+```python
+@pytest.fixture(scope="session")
+def test_engine():
+    original_url = settings.DATABASE_URL
+    settings.DATABASE_URL = settings.TEST_DATABASE_URL
+
+    alembic_cfg = AlembicConfig("alembic.ini")
+    alembic_cfg.set_main_option("sqlalchemy.url", settings.TEST_DATABASE_URL)
+    alembic_command.upgrade(alembic_cfg, "head")
+
+    engine = create_async_engine(settings.TEST_DATABASE_URL, echo=False)
+    yield engine
+    engine.sync_engine.dispose()
+    settings.DATABASE_URL = original_url
+```
+
+Insertion point: between `alembic_command.upgrade(...)` and `engine = create_async_engine(...)`. Use `engine.sync_engine` after creation, or create a throwaway sync engine for the truncate. Preferred: use `engine.sync_engine` after `create_async_engine` so we reuse the same pool.
+
+Register response shape (fastapi-users `BaseUser[int]`):
+```json
+{"id": 42, "email": "...", "is_active": true, "is_superuser": false, "is_verified": false}
+```
+
+`app.core.database.async_session_maker` is patched by `override_get_async_session` (session-scoped autouse) to point at the test DB. Import it *inside* the fixture body (not at module top) to pick up the patched value.
+
+Game NOT-NULL columns: `user_id`, `platform`, `platform_game_id`, `pgn`, `result`, `user_color`, `rated`. `played_at` must be set explicitly (no server default, widely read).
+
+GamePosition NOT-NULL columns: `game_id`, `user_id`, `ply`, `full_hash`, `white_hash`, `black_hash`.
+
+`ENDGAME_PLY_THRESHOLD` is imported from `app.repositories.endgame_repository` (mirror `tests/test_endgames_router.py:65`).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Add _truncate_all_tables to tests/conftest.py, called inside test_engine</name>
+  <files>tests/conftest.py</files>
+  <read_first>
+    - tests/conftest.py (all 130 lines)
+    - .planning/phases/61-test-hardening/61-CONTEXT.md (Decision 1 and 2)
+  </read_first>
+  <behavior>
+    Before yielding `engine` from `test_engine`, discover all public-schema tables except `alembic_version` and `openings`, and issue a single `TRUNCATE TABLE <list> RESTART IDENTITY CASCADE` via a synchronous connection from the engine's underlying sync engine.
+
+    Observable effects:
+    - When pytest session starts, the test DB is empty EXCEPT for `alembic_version` (migration state) and `openings` (reference data, may be empty or may contain seeded rows — either way, left alone).
+    - After pytest session ends, data from the just-completed run REMAINS in the DB (teardown only disposes the engine, does not re-truncate).
+    - Subsequent pytest session starts clean again.
+  </behavior>
+  <action>
+1. Open `tests/conftest.py`. At the top of the file, just below the existing `sqlalchemy.ext.asyncio` import (line 15), add `from sqlalchemy import text`. Ruff import sorting will place it where appropriate — run `uv run ruff format tests/conftest.py` after editing if needed.
+
+2. Before the `@pytest.fixture(scope="session")` block that defines `test_engine` (i.e. above line 21), insert this module-level helper:
+
+```python
+# Tables that must NEVER be truncated during test-session reset:
+# - alembic_version: Alembic uses it to track migration state. Truncating forces
+#   a re-migration on next startup and breaks `alembic current`.
+# - openings: reference data populated by `scripts/seed_openings.py`. Currently
+#   empty in flawchess_test but excluded defensively so a future contributor who
+#   seeds it for opening-classification tests does not see their seed silently
+#   wiped on each pytest run.
+_TRUNCATE_EXCLUDE = frozenset({"alembic_version", "openings"})
+
+
+def _truncate_all_tables(sync_engine) -> None:
+    """Truncate every public-schema table except reference tables.
+
+    Called ONCE per pytest session, after alembic migrations run and before
+    the first test executes. Restarts identity columns so primary keys are
+    deterministic within a run. Data from the *previous* session is wiped;
+    data from the current session is preserved on teardown for inspection.
+    """
+    with sync_engine.begin() as conn:
+        rows = conn.execute(
+            text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+        )
+        tables = [r[0] for r in rows if r[0] not in _TRUNCATE_EXCLUDE]
+        if tables:
+            conn.execute(
+                text(f'TRUNCATE TABLE {", ".join(tables)} RESTART IDENTITY CASCADE')
+            )
+```
+
+3. Inside `test_engine`, insert the truncate call between `create_async_engine(...)` and `yield engine`:
+
+```python
+    # Create the async engine for the rest of the test session
+    engine = create_async_engine(settings.TEST_DATABASE_URL, echo=False)
+    # Phase 61: wipe residue from previous pytest runs before any test executes.
+    # Preserves alembic_version + openings; everything else goes.
+    _truncate_all_tables(engine.sync_engine)
+    yield engine
+```
+
+4. Do NOT modify the `override_get_async_session` fixture, `db_session` fixture, `ensure_test_user` helper, or anything else in conftest.py.
+
+5. Run formatting + linting to confirm the change is clean.
+  </action>
+  <verify>
+    <automated>uv run ruff check tests/conftest.py &amp;&amp; uv run ruff format --check tests/conftest.py &amp;&amp; uv run ty check tests/conftest.py &amp;&amp; uv run pytest -x --no-header -q tests/test_game_repository.py tests/test_zobrist.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -n "TRUNCATE TABLE" tests/conftest.py` returns exactly one match.
+    - `grep -n "_TRUNCATE_EXCLUDE" tests/conftest.py` returns at least two matches (definition + usage).
+    - `grep -n "_truncate_all_tables" tests/conftest.py` returns at least two matches.
+    - Manually verified: after running `uv run pytest -x` once, `docker compose -f docker-compose.dev.yml -p flawchess-dev exec db psql -U flawchess -d flawchess_test -c "SELECT count(*) FROM users;"` shows `>= 1` (data preserved on teardown). Re-running pytest and aborting immediately after session start (e.g. `uv run pytest --collect-only`) should not wipe, since truncate runs only when fixtures are actually resolved — that's acceptable.
+    - `uv run ty check tests/` exits 0.
+    - `uv run pytest tests/test_game_repository.py tests/test_zobrist.py -x` passes — spot-check that existing tests survive the truncate.
+  </acceptance_criteria>
+  <done>Truncate helper is defined and called exactly once at session start; ty + ruff clean; representative existing tests still pass.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Create tests/seed_fixtures.py with SeededUser dataclass + seeded_user module fixture</name>
+  <files>tests/seed_fixtures.py</files>
+  <read_first>
+    - .planning/phases/61-test-hardening/61-CONTEXT.md (Decisions 3, 5; Specifics — Seeded portfolio composition)
+    - tests/test_endgames_router.py:54-113 (existing _seed_game_with_endgame pattern for the endgame-span seeding)
+    - tests/test_stats_service.py:63-119 (existing _seed_game pattern for simple Game insertion)
+    - app/models/game.py (column list)
+    - app/models/game_position.py (column list)
+    - app/repositories/endgame_repository.py (ENDGAME_PLY_THRESHOLD import path)
+  </read_first>
+  <behavior>
+    Introduce a single authoritative seeded user for router integration tests. The fixture:
+    - Registers via HTTP (so JWT login works at test time).
+    - Extracts the `id` from the register response (fastapi-users returns BaseUser[int]).
+    - Obtains a bearer token via `/api/auth/jwt/login`.
+    - Seeds a fixed, hand-counted portfolio of ~15 games with committed positions.
+    - Returns a `SeededUser` dataclass with `id`, `email`, `auth_headers`, and `expected` aggregates.
+
+    Key invariants in the seeded data (used by Plan 61-03 assertions):
+
+    Games: 15 total.
+    | idx | platform   | time_control_bucket | user_color | result    | rated | notes                                      |
+    |----:|:-----------|:--------------------|:-----------|:----------|:------|:-------------------------------------------|
+    |   1 | chess.com  | blitz               | white      | 1-0       | True  | win                                        |
+    |   2 | chess.com  | blitz               | white      | 1-0       | True  | win                                        |
+    |   3 | chess.com  | blitz               | white      | 1/2-1/2   | True  | draw                                       |
+    |   4 | chess.com  | blitz               | black      | 0-1       | True  | user wins (0-1 = black wins)               |
+    |   5 | chess.com  | blitz               | black      | 1-0       | True  | user loses                                 |
+    |   6 | chess.com  | rapid               | white      | 0-1       | True  | user loses — endgame rook span             |
+    |   7 | chess.com  | rapid               | white      | 0-1       | True  | user loses — endgame rook span             |
+    |   8 | lichess    | blitz               | white      | 1-0       | True  | win                                        |
+    |   9 | lichess    | blitz               | white      | 1-0       | True  | win — endgame rook span                    |
+    |  10 | lichess    | bullet              | black      | 1/2-1/2   | True  | draw                                       |
+    |  11 | lichess    | bullet              | black      | 1/2-1/2   | True  | draw                                       |
+    |  12 | lichess    | classical           | white      | 1-0       | True  | win — endgame pawn span                    |
+    |  13 | lichess    | classical           | white      | 0-1       | True  | user loses                                 |
+    |  14 | lichess    | rapid               | white      | 1-0       | False | win — UNRATED                              |
+    |  15 | lichess    | rapid               | white      | 1/2-1/2   | True  | draw — endgame TRANSITION rook → pawn      |
+
+    Expected aggregates (derived, used as router assertions in Plan 61-03):
+    - Total games: 15
+    - Global WDL (user-perspective): wins=6, draws=5, losses=4
+      - Derivation: rows 1,2,4,8,9,12,14 are wins = 7 ... let me recompute
+      - White wins (result=1-0 + color=white): 1,2,8,9,12,14 = 6 wins
+      - Black wins (result=0-1 + color=black): 4 = 1 win
+      - Total wins: 7
+      - Draws (any row where result=1/2-1/2): 3,10,11,15 = 4 draws
+      - White losses (result=0-1 + color=white): 6,7,13 = 3 losses
+      - Black losses (result=1-0 + color=black): 5 = 1 loss
+      - Total losses: 4
+      - Check: 7 + 4 + 4 = 15 ✓
+    - Per platform: chess.com=7 (rows 1-7), lichess=8 (rows 8-15).
+    - Per time_control_bucket:
+      - bullet=2 (rows 10,11)
+      - blitz=5 (rows 1-5, and 8-9 — wait that's rows 1,2,3,4,5,8,9 = 7)
+      - Let me redo: blitz games are rows 1,2,3,4,5 (chess.com) + 8,9 (lichess) = 7
+      - rapid=3 (rows 6,7 chess.com + 14 lichess — but 14 is rated=False)
+      - classical=2 (rows 12,13)
+      - Totals: 2 + 7 + 3 + 2 = 14 ... but we have 15 games. Row 15 is lichess rapid. So rapid=4.
+      - Recount rapid: 6,7,14,15 = 4 games. Totals: 2+7+4+2 = 15 ✓
+    - Per color: white=11 (rows 1,2,3,6,7,8,9,12,13,14,15), black=4 (rows 4,5,10,11).
+      - White WDL from user perspective: result=1-0 → win, result=0-1 → loss, result=1/2-1/2 → draw
+        - Wins: 1,2,8,9,12,14 = 6
+        - Draws: 3,15 = 2
+        - Losses: 6,7,13 = 3
+        - Total white: 11 ✓
+      - Black WDL from user perspective: result=0-1 → win, result=1-0 → loss, result=1/2-1/2 → draw
+        - Wins: 4 = 1
+        - Draws: 10,11 = 2
+        - Losses: 5 = 1
+        - Total black: 4 ✓
+    - Rated-only total: 14 (all except row 14)
+    - Endgame spans:
+      - rook (endgame_class=1): rows 6, 7, 9, 15 (first half of 15) — 4 games with rook span
+      - pawn (endgame_class=3): rows 12, 15 (second half of 15) — 2 games with pawn span
+      - Distinct games with ANY endgame span: 6,7,9,12,15 = 5 games (row 15 has both classes but counts once by game_id)
+
+    Opening positions:
+    - All 15 games have a GamePosition at ply=0 with `full_hash = _STARTING_POSITION_HASH` (a fixed constant in the fixture module). This lets Plan 61-03 call `/api/openings/next-moves` for the starting position and expect 15 matching games.
+    - Each game additionally has a GamePosition at ply=1 with a game-specific hash (derived from game index) and a move_san (alternating "e4" for white-to-move, "e5" for black-to-move — chosen arbitrarily; the test just needs deterministic move_san presence).
+
+    Endgame span detail (for rows 6,7,9,12,15):
+    - Rows with rook span (1): insert `ENDGAME_PLY_THRESHOLD` consecutive positions starting at ply=30, all with `endgame_class=1`, `material_signature="KR_KR"`, `material_imbalance=0`, `piece_count=2`, `material_count=1000`.
+    - Row 12 (pawn span, class 3): plies 30..30+threshold, `endgame_class=3`, `material_signature="KPP_KP"`, `material_imbalance=100`.
+    - Row 15 (transition rook→pawn): plies 30..30+threshold-1 with class=1, then plies 30+threshold..30+2*threshold-1 with class=3. This exercises the multi-class-per-game path.
+
+    Implementation notes:
+    - `platform_game_id` must be unique per user+platform (UniqueConstraint). Use `f"seed-{idx:02d}"`.
+    - Use `played_at = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(days=idx)` for deterministic chronology.
+    - Use `time_control_str="600+0"` and `time_control_seconds=600` for all games; the bucket is what filter logic reads.
+  </behavior>
+  <action>
+1. Create `tests/seed_fixtures.py` with the structure below. All typing must be Pydantic/dataclass-compliant (ty-clean). Use `dataclasses.dataclass` for `SeededUser` because it's plain test-helper data.
+
+```python
+"""Shared seeded-user fixture for router integration tests (Phase 61).
+
+Provides a single authoritative test user with a deterministic portfolio of
+games and positions, committed to flawchess_test so HTTP endpoints can observe
+the data through the patched async_session_maker. The seeded_user fixture is
+module-scoped: register+seed cost is paid once per test module, not once per
+test function.
+
+Expected aggregates are computed by the fixture and returned alongside the
+user data so test assertions can reference them by name rather than hand-
+counting.
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest_asyncio
+
+from app.main import app
+from app.repositories.endgame_repository import ENDGAME_PLY_THRESHOLD
+
+# Deterministic Zobrist hash used for every game's ply=0 position so
+# /api/openings/next-moves queries at the starting position match all games.
+STARTING_POSITION_HASH: int = 0x0123456789ABCDEF
+
+
+@dataclass
+class SeededUser:
+    """Test user with a committed portfolio and derived expected aggregates."""
+
+    id: int
+    email: str
+    auth_headers: dict[str, str]
+    expected: dict[str, Any] = field(default_factory=dict)
+
+
+_GAMES_SPEC: list[dict[str, Any]] = [
+    # idx, platform, bucket, color, result, rated, endgame_class(es)
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1/2-1/2", "rated": True,  "endgame": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "black", "result": "0-1",     "rated": True,  "endgame": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "black", "result": "1-0",     "rated": True,  "endgame": None},
+    {"platform": "chess.com", "bucket": "rapid",     "color": "white", "result": "0-1",     "rated": True,  "endgame": [1]},
+    {"platform": "chess.com", "bucket": "rapid",     "color": "white", "result": "0-1",     "rated": True,  "endgame": [1]},
+    {"platform": "lichess",   "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None},
+    {"platform": "lichess",   "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": [1]},
+    {"platform": "lichess",   "bucket": "bullet",    "color": "black", "result": "1/2-1/2", "rated": True,  "endgame": None},
+    {"platform": "lichess",   "bucket": "bullet",    "color": "black", "result": "1/2-1/2", "rated": True,  "endgame": None},
+    {"platform": "lichess",   "bucket": "classical", "color": "white", "result": "1-0",     "rated": True,  "endgame": [3]},
+    {"platform": "lichess",   "bucket": "classical", "color": "white", "result": "0-1",     "rated": True,  "endgame": None},
+    {"platform": "lichess",   "bucket": "rapid",     "color": "white", "result": "1-0",     "rated": False, "endgame": None},
+    {"platform": "lichess",   "bucket": "rapid",     "color": "white", "result": "1/2-1/2", "rated": True,  "endgame": [1, 3]},  # transition
+]
+
+# Derived expected aggregates (hand-counted + unit-tested in Plan 61-02).
+# Keeping these explicit rather than computing from _GAMES_SPEC on the fly
+# makes regressions in the aggregation code loud and obvious.
+EXPECTED: dict[str, Any] = {
+    "total_games": 15,
+    "global_wdl": {"wins": 7, "draws": 4, "losses": 4},
+    "by_platform": {"chess.com": 7, "lichess": 8},
+    "by_time_control": {"bullet": 2, "blitz": 7, "rapid": 4, "classical": 2},
+    "by_color": {
+        "white": {"total": 11, "wins": 6, "draws": 2, "losses": 3},
+        "black": {"total": 4,  "wins": 1, "draws": 2, "losses": 1},
+    },
+    "rated_total": 14,
+    "endgame_games_distinct": 5,    # 6,7,9,12,15 — game 15 has two classes but one distinct game_id
+    "endgame_rook_games": 4,        # 6,7,9,15
+    "endgame_pawn_games": 2,        # 12,15
+    "starting_position_game_count": 15,  # every game has a ply=0 position at STARTING_POSITION_HASH
+}
+
+
+async def _register_and_login(client: httpx.AsyncClient) -> tuple[int, str, dict[str, str]]:
+    email = f"seed_{uuid.uuid4().hex[:10]}@example.com"
+    password = "seededuserpw123"
+    reg = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    reg.raise_for_status()
+    user_id = int(reg.json()["id"])
+
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": email, "password": password},
+    )
+    login.raise_for_status()
+    token = login.json()["access_token"]
+    return user_id, email, {"Authorization": f"Bearer {token}"}
+
+
+async def _seed_portfolio(user_id: int) -> None:
+    """Commit 15 games + their positions for the registered user.
+
+    Uses the patched async_session_maker (bound to flawchess_test by
+    tests/conftest.py override_get_async_session) directly, so the writes
+    land in the test DB and are visible to HTTP endpoints in the same run.
+    """
+    from app.core.database import async_session_maker
+    from app.models.game import Game
+    from app.models.game_position import GamePosition
+
+    base_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+
+    async with async_session_maker() as session:
+        for idx, spec in enumerate(_GAMES_SPEC, start=1):
+            game = Game(
+                user_id=user_id,
+                platform=spec["platform"],
+                platform_game_id=f"seed-{idx:02d}",
+                platform_url=f"https://example.com/game/{idx}",
+                pgn="1. e4 e5 *",
+                result=spec["result"],
+                user_color=spec["color"],
+                time_control_str="600+0",
+                time_control_bucket=spec["bucket"],
+                time_control_seconds=600,
+                rated=spec["rated"],
+                is_computer_game=False,
+                white_username="seededuser" if spec["color"] == "white" else "opponent",
+                black_username="opponent" if spec["color"] == "white" else "seededuser",
+                white_rating=1500,
+                black_rating=1510,
+            )
+            game.played_at = base_dt + datetime.timedelta(days=idx)
+            session.add(game)
+            await session.flush()
+
+            # Starting position (ply=0, shared hash across all 15 games)
+            session.add(GamePosition(
+                game_id=game.id,
+                user_id=user_id,
+                ply=0,
+                full_hash=STARTING_POSITION_HASH,
+                white_hash=STARTING_POSITION_HASH + 1,
+                black_hash=STARTING_POSITION_HASH + 2,
+                move_san="e4",
+            ))
+            # Game-specific ply=1 position
+            session.add(GamePosition(
+                game_id=game.id,
+                user_id=user_id,
+                ply=1,
+                full_hash=STARTING_POSITION_HASH + 1000 + idx,
+                white_hash=STARTING_POSITION_HASH + 2000 + idx,
+                black_hash=STARTING_POSITION_HASH + 3000 + idx,
+                move_san="e5",
+            ))
+
+            # Endgame spans per spec
+            if spec["endgame"] is not None:
+                span_ply = 30
+                for class_int in spec["endgame"]:
+                    sig = "KR_KR" if class_int == 1 else ("KPP_KP" if class_int == 3 else "KR_K")
+                    imbalance = 0 if class_int == 1 else 100
+                    for offset in range(ENDGAME_PLY_THRESHOLD):
+                        session.add(GamePosition(
+                            game_id=game.id,
+                            user_id=user_id,
+                            ply=span_ply + offset,
+                            full_hash=STARTING_POSITION_HASH + 10_000 + idx * 100 + offset,
+                            white_hash=STARTING_POSITION_HASH + 20_000 + idx * 100 + offset,
+                            black_hash=STARTING_POSITION_HASH + 30_000 + idx * 100 + offset,
+                            piece_count=2,
+                            material_count=1000,
+                            material_signature=sig,
+                            material_imbalance=imbalance,
+                            endgame_class=class_int,
+                        ))
+                    span_ply += ENDGAME_PLY_THRESHOLD
+
+        await session.commit()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def seeded_user() -> SeededUser:
+    """Register one user + commit the deterministic portfolio; return handle."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        user_id, email, auth_headers = await _register_and_login(client)
+    await _seed_portfolio(user_id)
+    return SeededUser(
+        id=user_id, email=email, auth_headers=auth_headers, expected=dict(EXPECTED)
+    )
+```
+
+2. Do not import from `tests/seed_fixtures.py` anywhere in this plan. Plans 61-02 and 61-03 are the consumers.
+
+3. Run ruff + ty + a quick pytest sanity run (collect-only) to verify the module imports cleanly.
+  </action>
+  <verify>
+    <automated>uv run ruff check tests/seed_fixtures.py &amp;&amp; uv run ruff format --check tests/seed_fixtures.py &amp;&amp; uv run ty check tests/ &amp;&amp; uv run pytest --collect-only -q &gt; /dev/null</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f tests/seed_fixtures.py` succeeds.
+    - `grep -n "class SeededUser" tests/seed_fixtures.py` returns exactly one match.
+    - `grep -n "async def seeded_user" tests/seed_fixtures.py` returns exactly one match.
+    - `grep -n "STARTING_POSITION_HASH" tests/seed_fixtures.py` returns at least 4 matches (constant + uses).
+    - `grep -n "_GAMES_SPEC" tests/seed_fixtures.py` returns at least 2 matches.
+    - `uv run ty check tests/` exits 0.
+    - `uv run ruff check tests/seed_fixtures.py` exits 0.
+    - `uv run pytest --collect-only -q` collects the existing test suite without import errors (seed_fixtures.py is imported lazily by consumers so collect won't exercise it, but the module itself must parse).
+  </acceptance_criteria>
+  <done>tests/seed_fixtures.py exists with SeededUser + seeded_user fixture + EXPECTED dict; ty/ruff clean; pytest collection still works.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run ty check app/ tests/` exits 0.
+- `uv run ruff check . && uv run ruff format --check .` exit 0.
+- `uv run pytest -x` passes end-to-end (no new test failures; existing tests unaffected by the truncate because each test seeds what it needs in its own `db_session` or module-local fixture).
+- Manual check: after the first pytest run, querying `flawchess_test.users` shows committed data from tests; running pytest again truncates before the first fixture runs and the DB is clean at that instant.
+</verification>
+
+<success_criteria>
+- Phase 61 success criterion #1 (DB reset) is met.
+- Phase 61 success criterion #2 (shared seeded_user fixture) is met.
+- No production code changed.
+- All existing tests still pass.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/61-test-hardening/61-01-SUMMARY.md`
+</output>

--- a/.planning/phases/61-test-hardening/61-02-PLAN.md
+++ b/.planning/phases/61-test-hardening/61-02-PLAN.md
@@ -1,0 +1,528 @@
+---
+phase: 61-test-hardening
+plan: 02
+type: execute
+wave: 2
+depends_on: [61-01]
+files_modified:
+  - tests/test_aggregation_sanity.py
+  - tests/test_material_tally.py
+autonomous: true
+requirements: []
+tags: [tests, stats, endgame, openings, material]
+
+must_haves:
+  truths:
+    - "A new test module tests/test_aggregation_sanity.py exercises 7 distinct aggregation-correctness gaps identified in the 2026-04-16 audit"
+    - "Each new test either passes (locking in correct behavior) or fails with a clear message citing the discovered bug — tests do not silently skip gaps"
+    - "tests/test_material_tally.py verifies _compute_material_count / _compute_material_imbalance / _compute_material_signature against python-chess boards from the starting position and after captures"
+    - "No production code under app/ is modified in this plan"
+    - "All new tests use db_session transaction rollback isolation and 700-series user IDs (no cross-test pollution)"
+  artifacts:
+    - path: "tests/test_aggregation_sanity.py"
+      provides: "TestWDLBlackPerspective, TestRollingWindowBoundaries, TestFilterIntersection, TestRecencyBoundary, TestPositionDedup, TestEndgameClassTransition aggregation sanity test classes"
+      contains: "class TestWDLBlackPerspective"
+    - path: "tests/test_material_tally.py"
+      provides: "TestMaterialCount, TestMaterialImbalance, TestMaterialSignature against python-chess boards"
+      contains: "class TestMaterialCount"
+---
+
+<objective>
+Close Phase 61 success criteria #3 and #4. Add targeted aggregation tests that would catch real regressions in the aggregation code paths, and lock in material-counting correctness at the source (the `position_classifier` pure functions).
+
+Each test encodes one concrete audit gap:
+
+1. **WDL perspective flip (black)** — user plays black, results need to be inverted from white's perspective.
+2. **Rolling window boundaries** — fewer games than `MIN_GAMES_FOR_TIMELINE`, single-game windows, exact window-size boundary.
+3. **Filter intersection** — `platform=chess.com AND time_control=blitz` returns only games matching BOTH, not union.
+4. **Recency cutoff boundary** — behavior at `played_at == cutoff` is pinned (inclusive per current code).
+5. **Position dedup within a game** — same `full_hash` at multiple plies in one game counts as 1 game, not N.
+6. **Endgame class transition** — one game with class-1 (rook) span then class-3 (pawn) span: both classes see +1 game, `endgame_wdl.total` still counts that game once.
+7. **Material tally direction** — starting material=7800; after `1. e4 d5 2. exd5`, white is up 100 cp (captured a pawn), material_count drops by 100 cp.
+
+Output: two new test modules; zero production code changes; all new tests pass on the current codebase OR fail loudly and point at a real bug for a follow-up phase.
+</objective>
+
+<execution_context>
+Worktree: /home/aimfeld/Projects/Python/flawchess-tests
+Run all commands from the worktree root. Plan 61-01 must be committed before this plan executes (the truncate fixture is orthogonal; the seeded_user fixture is NOT imported by this plan — Plan 61-03 is the consumer).
+</execution_context>
+
+<context>
+@.planning/phases/61-test-hardening/61-CONTEXT.md
+@app/services/stats_service.py
+@app/services/openings_service.py
+@app/services/endgame_service.py
+@app/services/position_classifier.py
+@app/repositories/query_utils.py
+@tests/test_stats_service.py (style reference)
+@tests/test_openings_time_series.py (style reference)
+
+<interfaces>
+- `stats_service.get_global_stats(session, user_id, recency, platform, *, opponent_type="human", opponent_strength="any") -> GlobalStatsResponse`. Response has `by_time_control: list[WDLByCategory]` and `by_color: list[WDLByCategory]` where each entry has `category, total, wins, draws, losses`.
+- `openings_service.get_time_series(session, user_id, request: TimeSeriesRequest) -> TimeSeriesResponse`. Rolling window = 50; `MIN_GAMES_FOR_TIMELINE = 10` filters out early partial-window points.
+- `openings_service.analyze(session, user_id, request: OpeningsRequest) -> OpeningsResponse`. For position dedup, this is the function that aggregates WDL per full_hash match.
+- `endgame_service.get_endgame_overview(session, user_id, time_control=None, platform=None, recency=None, rated=None, opponent_type="human", window=50, opponent_strength="any", elo_threshold=50) -> EndgameOverviewResponse`. Response `.performance.endgame_wdl.total` = distinct games with an endgame span; `.performance.endgame_per_type: dict[str, EndgameWDLSummary]` has per-class breakdown.
+- `query_utils.apply_game_filters(stmt, time_control, platform, rated, opponent_type, recency_cutoff, color=None, *, opponent_strength="any", elo_threshold=50)`. Accepts Sequence[str] for multi-value filters. Recency uses `>=` (inclusive per app/repositories/query_utils.py:55).
+- `position_classifier._compute_material_count(board: chess.Board) -> int` — total centipawns both sides.
+- `position_classifier._compute_material_imbalance(board: chess.Board) -> int` — white minus black, signed.
+- `position_classifier._compute_material_signature(board: chess.Board) -> str` — "KRPP_KRP" format, white pieces before '_'.
+- Starting material (verified from `_MATERIAL_VALUE_CP` × piece counts): 2 × (900 + 2×500 + 2×300 + 2×300 + 8×100) = **7800**. Starting imbalance: **0**. Starting signature: **"KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP"** (per existing test data in `test_import_service.py`).
+- TimeSeriesRequest / Bookmark shape: see `app/schemas/openings.py:112` and `136`. Needs `bookmarks: list[BookmarkInput]` with `target_hash: int`, `match_side: "full"|"white"|"black"`, `color: "white"|"black"|None`.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Create tests/test_aggregation_sanity.py with 6 test classes</name>
+  <files>tests/test_aggregation_sanity.py</files>
+  <read_first>
+    - .planning/phases/61-test-hardening/61-CONTEXT.md
+    - app/services/stats_service.py (full, for signatures)
+    - app/services/openings_service.py:190-280 (get_time_series + rolling logic)
+    - app/services/endgame_service.py:get_endgame_overview signature and return shape
+    - app/schemas/stats.py (GlobalStatsResponse shape)
+    - app/schemas/endgames.py (EndgameOverviewResponse shape, specifically .performance.endgame_wdl.total and endgame_per_type)
+    - app/schemas/openings.py:112-180 (TimeSeriesRequest, TimeSeriesResponse, OpeningsRequest shapes)
+    - tests/test_stats_service.py (fixture style: _seed_game, autouse _create_test_users at module scope with 700-series IDs)
+    - tests/test_openings_time_series.py (_seed_game_with_position pattern)
+  </read_first>
+  <behavior>
+    Each test seeds the minimum games needed via `db_session` (transaction rolled back per test), calls the service function directly, and asserts exact integers. No HTTP layer involved in this file — that belongs to Plan 61-03.
+
+    **TestWDLBlackPerspective** (user_id 701)
+    - `test_black_win_is_user_win`: seed 1 game, user_color=black, result="0-1". Call `get_global_stats`. Assert `by_color[black].wins == 1`, `.losses == 0`, `.draws == 0`.
+    - `test_black_loss_is_user_loss`: user_color=black, result="1-0". Assert `by_color[black].losses == 1`.
+    - `test_mixed_black_portfolio`: seed 3 black games (0-1, 1-0, 1/2-1/2). Assert by_color[black] = wins=1, draws=1, losses=1, total=3. Also assert by_color[white] is absent or total=0 (whatever the schema guarantees).
+    - `test_mixed_both_colors_does_not_cross_wires`: seed 2 white wins (1-0) + 2 black wins (0-1). Assert by_color[white].wins == 2 AND by_color[black].wins == 2. This test would FAIL if aggregation accidentally reported white perspective for black games.
+
+    **TestRollingWindowBoundaries** (user_id 702)
+    - `test_fewer_games_than_min_games_returns_empty_series`: seed 5 games all with the same full_hash, call get_time_series. `MIN_GAMES_FOR_TIMELINE=10`, so every point has game_count < 10, so `data == []`. Assert `len(response.series[0].data) == 0`.
+    - `test_exactly_min_games_emits_first_point`: seed 10 games with the same full_hash, played on 10 distinct calendar days. Assert `len(response.series[0].data) == 1` — only the last day's rolling window has `game_count >= 10`.
+    - `test_same_day_games_collapse_to_one_point`: seed 12 games with the same full_hash, all played on the SAME calendar day (different timestamps). Assert `len(response.series[0].data) == 1` — day-bucketing keeps only the last game's window per date.
+
+    **TestFilterIntersection** (user_id 703)
+    - `test_platform_and_time_control_intersection`: seed 4 games: (chess.com blitz), (chess.com rapid), (lichess blitz), (lichess rapid). Call `get_global_stats` with `platform="chess.com"` (and no time-control filter so we can assert blitz bucket within chess.com). Assert chess.com blitz bucket total=1, not 2 (union) or 0 (empty).
+    - A second test uses `apply_game_filters` directly with `platform=["chess.com"], time_control=["blitz"]` and a raw `select(Game.id)` to prove the SQL intersection at the query-utility layer too. Assert result length == 1.
+
+    **TestRecencyBoundary** (user_id 704)
+    - `test_recency_cutoff_is_inclusive_at_boundary`: seed one game with `played_at == cutoff_dt` exactly (microsecond precision). Call `get_global_stats` with that recency window. Assert the game is included (the apply_game_filters clause is `played_at >= recency_cutoff`, so the boundary is inclusive). Docstring pins this behavior.
+    - `test_recency_cutoff_excludes_one_microsecond_before`: same setup but `played_at = cutoff_dt - timedelta(microseconds=1)`. Assert the game is excluded. This is the complementary boundary test.
+
+    **TestPositionDedup** (user_id 705)
+    - `test_same_hash_multiple_plies_one_game_counted_once`: seed 1 game, insert 3 GamePosition rows all sharing the same `full_hash` at plies 0, 2, 4. Call `openings_service.analyze` with that hash and `match_side="full"`. Assert `response.stats.total == 1`, not 3. (This exercises the repository's DISTINCT game_id aggregation.)
+
+    **TestEndgameClassTransition** (user_id 706)
+    - `test_game_with_rook_then_pawn_span_counted_in_both_classes`: seed 1 game with ENDGAME_PLY_THRESHOLD consecutive positions of `endgame_class=1` (rook), then ENDGAME_PLY_THRESHOLD of `endgame_class=3` (pawn). Call `get_endgame_overview`. Assert `endgame_per_type["rook"].total == 1 AND endgame_per_type["pawn"].total == 1 AND performance.endgame_wdl.total == 1` (distinct games, not distinct class spans).
+
+    All tests use:
+    ```python
+    from tests.conftest import ensure_test_user
+    ```
+    and an autouse module-scoped fixture to pre-create the 700-series users.
+  </behavior>
+  <action>
+1. Create `tests/test_aggregation_sanity.py` with this top-of-file block:
+
+```python
+"""Aggregation sanity tests (Phase 61).
+
+These tests encode the audit gaps identified in the 2026-04-16 session — they
+either lock in correct behavior or fail loudly when the aggregation code
+regresses. Each test seeds the minimum games needed via db_session transaction
+rollback, calls the service function directly, and asserts exact integers.
+
+Coverage:
+- TestWDLBlackPerspective: user plays black, WDL must flip from white perspective
+- TestRollingWindowBoundaries: MIN_GAMES_FOR_TIMELINE cutoff, same-day bucketing
+- TestFilterIntersection: platform AND time_control AND'd, not OR'd
+- TestRecencyBoundary: played_at == cutoff is inclusive
+- TestPositionDedup: same hash at multiple plies in one game counts once
+- TestEndgameClassTransition: one game crossing two endgame classes counted in both per_type
+"""
+
+import datetime
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game import Game
+from app.models.game_position import GamePosition
+from app.repositories.endgame_repository import ENDGAME_PLY_THRESHOLD
+from app.repositories.query_utils import apply_game_filters
+from app.schemas.openings import OpeningsRequest, TimeSeriesRequest
+from app.services.endgame_service import get_endgame_overview
+from app.services.openings_service import analyze as openings_analyze
+from app.services.openings_service import get_time_series
+from app.services.stats_service import get_global_stats
+
+# 700-series IDs (no other test module uses these)
+_USER_BLACK = 701
+_USER_ROLLING = 702
+_USER_FILTER = 703
+_USER_RECENCY = 704
+_USER_DEDUP = 705
+_USER_ENDGAME_TRANS = 706
+_ALL_IDS = [_USER_BLACK, _USER_ROLLING, _USER_FILTER, _USER_RECENCY, _USER_DEDUP, _USER_ENDGAME_TRANS]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _create_users(db_session: AsyncSession) -> None:
+    from tests.conftest import ensure_test_user
+    for uid in _ALL_IDS:
+        await ensure_test_user(db_session, uid)
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _seed_game(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    result: str,
+    user_color: str,
+    platform: str = "chess.com",
+    time_control_bucket: str = "blitz",
+    played_at: datetime.datetime | None = None,
+    rated: bool = True,
+) -> Game:
+    game = Game(
+        user_id=user_id,
+        platform=platform,
+        platform_game_id=_uid(),
+        pgn="1. e4 e5 *",
+        result=result,
+        user_color=user_color,
+        time_control_str="600+0",
+        time_control_bucket=time_control_bucket,
+        time_control_seconds=600,
+        rated=rated,
+        is_computer_game=False,
+        white_rating=1500,
+        black_rating=1500,
+    )
+    game.played_at = played_at or datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    session.add(game)
+    await session.flush()
+    return game
+
+
+async def _seed_position(
+    session: AsyncSession,
+    *,
+    game_id: int,
+    user_id: int,
+    ply: int,
+    full_hash: int,
+    endgame_class: int | None = None,
+    material_signature: str | None = None,
+    material_imbalance: int | None = None,
+) -> GamePosition:
+    pos = GamePosition(
+        game_id=game_id,
+        user_id=user_id,
+        ply=ply,
+        full_hash=full_hash,
+        white_hash=full_hash + 1,
+        black_hash=full_hash + 2,
+        piece_count=2 if endgame_class else None,
+        material_count=1000 if endgame_class else None,
+        material_signature=material_signature,
+        material_imbalance=material_imbalance,
+        endgame_class=endgame_class,
+    )
+    session.add(pos)
+    await session.flush()
+    return pos
+
+
+def _by_category(categories, name: str) -> dict[str, int] | None:
+    for c in categories:
+        if c.category == name:
+            return {"total": c.total, "wins": c.wins, "draws": c.draws, "losses": c.losses}
+    return None
+```
+
+2. Add `TestWDLBlackPerspective` class with the 4 methods above. Example key assertion:
+
+```python
+class TestWDLBlackPerspective:
+    @pytest.mark.asyncio
+    async def test_mixed_black_portfolio(self, db_session: AsyncSession) -> None:
+        for result in ("0-1", "1-0", "1/2-1/2"):  # user wins, loses, draws
+            await _seed_game(db_session, user_id=_USER_BLACK, result=result, user_color="black")
+        await db_session.commit()
+
+        resp = await get_global_stats(
+            db_session, user_id=_USER_BLACK, recency=None, platform=None
+        )
+        black = _by_category(resp.by_color, "black")
+        assert black is not None
+        assert black == {"total": 3, "wins": 1, "draws": 1, "losses": 1}
+```
+
+3. Add `TestRollingWindowBoundaries`. Build `TimeSeriesRequest` correctly — check `app/schemas/openings.py:112` for the exact field list (`bookmarks`, `time_control`, `platform`, `rated`, `recency`, `opponent_type`, `opponent_strength`, `elo_threshold`). Example:
+
+```python
+class TestRollingWindowBoundaries:
+    @pytest.mark.asyncio
+    async def test_fewer_games_than_min_games_returns_empty_series(self, db_session):
+        hash_val = 99_701
+        base_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for i in range(5):
+            g = await _seed_game(db_session, user_id=_USER_ROLLING, result="1-0", user_color="white",
+                                 played_at=base_dt + datetime.timedelta(days=i))
+            await _seed_position(db_session, game_id=g.id, user_id=_USER_ROLLING, ply=1, full_hash=hash_val)
+        await db_session.commit()
+
+        req = TimeSeriesRequest(
+            bookmarks=[{"target_hash": hash_val, "match_side": "full", "color": None}],
+            # ... fill in defaults per schema
+        )
+        resp = await get_time_series(db_session, user_id=_USER_ROLLING, request=req)
+        assert len(resp.series) == 1
+        assert resp.series[0].data == []
+```
+
+    If the schema requires additional fields, read `app/schemas/openings.py:112` and fill them with their default values. Use the exact Pydantic model — no dict shortcuts if the validator rejects them.
+
+4. Add `TestFilterIntersection`:
+
+```python
+class TestFilterIntersection:
+    @pytest.mark.asyncio
+    async def test_query_utils_intersects_platform_and_time_control(self, db_session):
+        combos = [("chess.com", "blitz"), ("chess.com", "rapid"),
+                  ("lichess", "blitz"), ("lichess", "rapid")]
+        for platform, bucket in combos:
+            await _seed_game(db_session, user_id=_USER_FILTER, result="1-0", user_color="white",
+                             platform=platform, time_control_bucket=bucket)
+        await db_session.commit()
+
+        stmt = select(Game.id).where(Game.user_id == _USER_FILTER)
+        stmt = apply_game_filters(
+            stmt,
+            time_control=["blitz"],
+            platform=["chess.com"],
+            rated=None,
+            opponent_type="human",
+            recency_cutoff=None,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 1, f"platform ∩ time_control must intersect, got {len(rows)} rows"
+```
+
+5. Add `TestRecencyBoundary` — test with `played_at` at exact cutoff and one microsecond before. Use `recency="week"` or build a direct cutoff. Easier: call `apply_game_filters` directly with a constructed `recency_cutoff` dt so the test is hermetic.
+
+```python
+class TestRecencyBoundary:
+    @pytest.mark.asyncio
+    async def test_cutoff_is_inclusive_at_boundary(self, db_session):
+        cutoff = datetime.datetime(2026, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        await _seed_game(db_session, user_id=_USER_RECENCY, result="1-0", user_color="white",
+                         played_at=cutoff)
+        await db_session.commit()
+
+        stmt = apply_game_filters(
+            select(Game.id).where(Game.user_id == _USER_RECENCY),
+            time_control=None, platform=None, rated=None,
+            opponent_type="human", recency_cutoff=cutoff,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 1, "played_at == recency_cutoff must be inclusive (>=, not >)"
+
+    @pytest.mark.asyncio
+    async def test_cutoff_excludes_one_microsecond_earlier(self, db_session):
+        cutoff = datetime.datetime(2026, 2, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        await _seed_game(db_session, user_id=_USER_RECENCY, result="1-0", user_color="white",
+                         played_at=cutoff - datetime.timedelta(microseconds=1))
+        await db_session.commit()
+
+        stmt = apply_game_filters(
+            select(Game.id).where(Game.user_id == _USER_RECENCY),
+            time_control=None, platform=None, rated=None,
+            opponent_type="human", recency_cutoff=cutoff,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 0
+```
+
+6. Add `TestPositionDedup`. Build an `OpeningsRequest` matching `app/schemas/openings.py`. Seed ONE game with 3 positions at the same hash. The key assertion is `response.stats.total == 1`.
+
+7. Add `TestEndgameClassTransition`. Seed one game with ENDGAME_PLY_THRESHOLD plies of `endgame_class=1` starting at ply=30, then ENDGAME_PLY_THRESHOLD plies of `endgame_class=3` starting at ply=30+threshold. Call `get_endgame_overview`. Assert:
+   - `response.performance.endgame_wdl.total == 1` (distinct games)
+   - `response.performance.endgame_per_type["rook"].total == 1`
+   - `response.performance.endgame_per_type["pawn"].total == 1`
+   
+   (Exact keys for endgame_per_type may be "rook" / "pawn" strings or int-keyed — verify by reading `app/schemas/endgames.py`.)
+
+8. Run ty, ruff, and the new test file.
+
+If any test fails because it exposes a real bug in production code (not a test-code mistake), **do not fix the production code** in this plan. Leave the test failing, mark it with `@pytest.mark.xfail(strict=True, reason="<audit finding>, see Phase 61 PR")`, and note the finding in the phase summary for follow-up. This plan's scope is observation, not fix.
+  </action>
+  <verify>
+    <automated>uv run ruff check tests/test_aggregation_sanity.py &amp;&amp; uv run ruff format --check tests/test_aggregation_sanity.py &amp;&amp; uv run ty check tests/ &amp;&amp; uv run pytest tests/test_aggregation_sanity.py -v --no-header</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f tests/test_aggregation_sanity.py` succeeds.
+    - `grep -cn "^class Test" tests/test_aggregation_sanity.py` prints 6 (six test classes).
+    - `grep -cn "async def test_" tests/test_aggregation_sanity.py` prints >= 10 (at least 10 test methods across the 6 classes).
+    - `uv run pytest tests/test_aggregation_sanity.py -v` runs; every test either PASSES or is marked `xfail` (strict) with an explanatory reason referencing the audit finding.
+    - `uv run ty check tests/` exits 0.
+  </acceptance_criteria>
+  <done>All six aggregation-gap classes covered with concrete seed+assert tests; no production code touched; findings (if any) documented in the summary.</done>
+</task>
+
+<task type="auto" tdd="false">
+  <name>Task 2: Create tests/test_material_tally.py</name>
+  <files>tests/test_material_tally.py</files>
+  <read_first>
+    - app/services/position_classifier.py:30-200 (material constants and pure helpers)
+    - tests/test_position_classifier.py (existing test-style reference if present)
+  </read_first>
+  <behavior>
+    Verify the three material pure functions against python-chess boards:
+
+    **TestMaterialCount**
+    - `test_starting_position_is_7800`: `chess.Board()` → 7800.
+    - `test_empty_board_is_zero`: `chess.Board(); board.clear()` → 0.
+    - `test_after_white_captures_pawn`: starting board, push `e4 d5 exd5`. Expect 7700 (lost one black pawn = −100).
+
+    **TestMaterialImbalance**
+    - `test_starting_imbalance_is_zero`: starting board → 0.
+    - `test_white_up_a_pawn`: after `e4 d5 exd5` → +100 (white ahead by one pawn, 100 cp).
+    - `test_black_up_a_pawn`: after `e4 d5 exd5 Qxd5` (white pawn captured in return — NO that restores balance). Better: after `e4 Nf6 e5 Nd5 c4 Nxf4`... simpler: build a position via FEN with black up material explicitly. Use `chess.Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/1NBQKBNR w kq - 0 1")` (white missing the a1 rook → black up 500). Expect −500.
+    - `test_queen_for_queen_is_zero`: after `1. e4 d5 2. exd5 Qxd5 3. Nc3 Qxd1+ 4. Kxd1` → material equal, so 0.
+
+    **TestMaterialSignature**
+    - `test_starting_signature`: `_compute_material_signature(chess.Board())` → "KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP".
+    - `test_after_losing_white_queen`: FEN with white queen removed → signature's white half lacks Q.
+    - `test_white_before_black_in_format`: signature always has white pieces before `_`, black after.
+
+    No DB access. Pure python-chess + classifier functions.
+  </behavior>
+  <action>
+1. Create `tests/test_material_tally.py`. Structure:
+
+```python
+"""Material tally sanity tests (Phase 61).
+
+Verifies that position_classifier's pure functions correctly compute material
+metrics from python-chess boards. These tests catch regressions in piece
+values, sign conventions, and signature ordering before they reach the DB.
+"""
+
+import chess
+import pytest
+
+from app.services.position_classifier import (
+    _compute_material_count,
+    _compute_material_imbalance,
+    _compute_material_signature,
+)
+
+
+class TestMaterialCount:
+    def test_starting_position_is_7800(self) -> None:
+        """Starting material = 2 × (Q + 2R + 2B + 2N + 8P) = 2 × 3900 = 7800 cp."""
+        assert _compute_material_count(chess.Board()) == 7800
+
+    def test_empty_board_is_zero(self) -> None:
+        board = chess.Board()
+        board.clear()
+        assert _compute_material_count(board) == 0
+
+    def test_after_white_captures_pawn(self) -> None:
+        board = chess.Board()
+        for move in ("e4", "d5", "exd5"):
+            board.push_san(move)
+        assert _compute_material_count(board) == 7700  # lost one black pawn
+
+
+class TestMaterialImbalance:
+    def test_starting_is_zero(self) -> None:
+        assert _compute_material_imbalance(chess.Board()) == 0
+
+    def test_white_up_a_pawn(self) -> None:
+        board = chess.Board()
+        for move in ("e4", "d5", "exd5"):
+            board.push_san(move)
+        assert _compute_material_imbalance(board) == 100  # white ahead by a pawn
+
+    def test_black_up_a_rook(self) -> None:
+        # Remove white's a1 rook via FEN; black is up one rook = +500 for black = -500 imbalance.
+        board = chess.Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/1NBQKBNR w Kkq - 0 1")
+        assert _compute_material_imbalance(board) == -500
+
+    def test_queen_for_queen_restores_equality(self) -> None:
+        board = chess.Board()
+        for move in ("e4", "d5", "exd5", "Qxd5", "Nc3", "Qxd1+", "Kxd1"):
+            board.push_san(move)
+        assert _compute_material_imbalance(board) == 0
+
+
+class TestMaterialSignature:
+    def test_starting_signature(self) -> None:
+        sig = _compute_material_signature(chess.Board())
+        assert sig == "KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP"
+
+    def test_white_before_black(self) -> None:
+        sig = _compute_material_signature(chess.Board())
+        assert "_" in sig
+        white, black = sig.split("_")
+        assert white == black  # symmetric starting position
+        assert white.startswith("K")
+
+    def test_missing_white_queen(self) -> None:
+        # Remove white queen via FEN
+        board = chess.Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1")
+        sig = _compute_material_signature(board)
+        white, _ = sig.split("_")
+        assert "Q" not in white
+```
+
+2. Run ty + ruff + the new test file.
+
+If signature ordering or sign conventions in the code differ from what the tests assume, update the test's expected value to match REALITY first (verify by running and inspecting output), then document the convention in the test docstring. Never silently invert an assertion to make it pass.
+  </action>
+  <verify>
+    <automated>uv run ruff check tests/test_material_tally.py &amp;&amp; uv run ruff format --check tests/test_material_tally.py &amp;&amp; uv run ty check tests/ &amp;&amp; uv run pytest tests/test_material_tally.py -v --no-header</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f tests/test_material_tally.py` succeeds.
+    - `grep -cn "^class Test" tests/test_material_tally.py` prints 3.
+    - `grep -cn "def test_" tests/test_material_tally.py` prints >= 9.
+    - All tests pass (all three helpers should already behave correctly; any failure here indicates a regression in position_classifier that is out of scope for this phase — xfail and document).
+    - `uv run ty check tests/` exits 0.
+  </acceptance_criteria>
+  <done>Material tally tests cover count, imbalance (both signs and parity), and signature ordering; no production changes.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run ty check app/ tests/` exits 0.
+- `uv run ruff check . && uv run ruff format --check .` exit 0.
+- `uv run pytest tests/test_aggregation_sanity.py tests/test_material_tally.py -v` — all tests PASS or are `xfail(strict=True)` with a reason referring to the audit.
+- Full `uv run pytest` remains green (no collateral damage to existing tests).
+</verification>
+
+<success_criteria>
+- Phase 61 success criterion #3 (aggregation sanity tests) is met.
+- Phase 61 success criterion #4 (material tally tests) is met.
+- No production code changed.
+- Any audit-reveal failures are captured as xfail with detailed reason strings so they surface in CI output for the next phase to pick up.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/61-test-hardening/61-02-SUMMARY.md` listing:
+- tests added per class
+- any xfail findings (bug candidates) with file:line references to the suspected production code
+- runtime of the new test file
+</output>

--- a/.planning/phases/61-test-hardening/61-03-PLAN.md
+++ b/.planning/phases/61-test-hardening/61-03-PLAN.md
@@ -1,0 +1,358 @@
+---
+phase: 61-test-hardening
+plan: 03
+type: execute
+wave: 3
+depends_on: [61-01, 61-02]
+files_modified:
+  - tests/test_integration_routers.py
+autonomous: true
+requirements: []
+tags: [tests, integration, router, stats, endgame, openings]
+
+must_haves:
+  truths:
+    - "tests/test_integration_routers.py exists and uses the seeded_user fixture from tests/seed_fixtures.py"
+    - "Each test hits a real FastAPI endpoint via httpx.AsyncClient+ASGITransport with the seeded_user's auth_headers"
+    - "Assertions compare the JSON response against the EXPECTED aggregate dict from tests/seed_fixtures.py (exact integers, not just response shape)"
+    - "At least one test verifies WDL from the user's perspective is correct for BOTH white and black buckets"
+    - "At least one test verifies the Phase 59 invariant (material_rows sum == endgame_wdl.total) at the router layer with real seeded data"
+  artifacts:
+    - path: "tests/test_integration_routers.py"
+      provides: "TestGlobalStatsRouter, TestEndgamesOverviewRouter, TestOpeningsNextMovesRouter integration tests"
+      contains: "from tests.seed_fixtures import seeded_user"
+---
+
+<objective>
+Close Phase 61 success criterion #5. Add router-level integration tests that prove the full stack — HTTP → router → service → repository → DB — produces the expected numbers for a known seeded portfolio. These catch regressions that unit tests miss: serialization bugs, JWT/user-id coupling bugs, routing bugs, and filter wiring bugs.
+
+The tests rely on the `seeded_user` fixture from Plan 61-01. Register → seed → call → assert exact numbers.
+
+Output: one new test file, zero production code changes, all tests pass on the current codebase.
+</objective>
+
+<execution_context>
+Worktree: /home/aimfeld/Projects/Python/flawchess-tests
+Plans 61-01 and 61-02 must be committed first. The seeded_user fixture (from Plan 61-01) is the data source. Plan 61-02's tests are not prerequisites but verify the aggregation primitives the router ultimately calls.
+</execution_context>
+
+<context>
+@.planning/phases/61-test-hardening/61-CONTEXT.md
+@.planning/phases/61-test-hardening/61-01-PLAN.md (for EXPECTED dict contents)
+@tests/seed_fixtures.py (created in Plan 61-01)
+@tests/test_stats_router.py (pattern reference)
+@tests/test_endgames_router.py (pattern reference)
+@app/routers/stats.py
+@app/routers/endgames.py
+@app/routers/openings.py
+@app/schemas/openings.py (NextMovesRequest shape)
+
+<interfaces>
+Endpoints under test (all prefixed with `/api`):
+
+- `GET /api/stats/global` — accepts `recency`, `platform`, `opponent_type`, etc. as query params; returns `GlobalStatsResponse` with `by_time_control` (list of `{category, total, wins, draws, losses}`) and `by_color` (same shape).
+
+- `GET /api/endgames/overview` — accepts `time_control` (repeatable), `platform` (repeatable), `recency`, `rated`, `opponent_type`, `window`, `opponent_strength`, `elo_threshold` as query params; returns `EndgameOverviewResponse` with `performance.endgame_wdl.total`, `performance.endgame_per_type: dict[str, EndgameWDLSummary]`, and `score_gap_material.material_rows: list[MaterialRow]` (length 3).
+
+- `POST /api/openings/next-moves` — body is `NextMovesRequest` (see `app/schemas/openings.py`). Needs `target_hash`, `match_side`, plus standard filter fields. Returns `NextMovesResponse` with a `moves: list[MoveStats]` where each has `move_san`, `total`, `wins`, `draws`, `losses`.
+
+EXPECTED aggregates (from Plan 61-01 seed portfolio of 15 games):
+```
+total_games: 15
+global_wdl: wins=7, draws=4, losses=4
+by_platform: chess.com=7, lichess=8
+by_time_control: bullet=2, blitz=7, rapid=4, classical=2
+by_color:
+  white: total=11 wins=6 draws=2 losses=3
+  black: total=4  wins=1 draws=2 losses=1
+rated_total: 14
+endgame_games_distinct: 5
+endgame_rook_games: 4
+endgame_pawn_games: 2
+starting_position_game_count: 15
+```
+
+Auth pattern: take `seeded_user.auth_headers` and `seeded_user.id`. Use httpx `AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test")`.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="false">
+  <name>Task 1: Create tests/test_integration_routers.py</name>
+  <files>tests/test_integration_routers.py</files>
+  <read_first>
+    - tests/seed_fixtures.py (produced by Plan 61-01 — fixture name, SeededUser shape, EXPECTED keys)
+    - .planning/phases/61-01-PLAN.md (for the portfolio table if seed_fixtures.py is inspected first)
+    - app/schemas/stats.py (GlobalStatsResponse shape)
+    - app/schemas/endgames.py (EndgameOverviewResponse shape, per_type keys: verify they are lowercase string labels like "rook"/"pawn" — check `app/services/endgame_service.py` classify_endgame_class return)
+    - app/schemas/openings.py (NextMovesRequest + NextMovesResponse shapes)
+    - tests/test_stats_router.py:29-46 (auth fixture pattern — but we reuse seeded_user's auth_headers, so this is reference only)
+  </read_first>
+  <behavior>
+    **TestGlobalStatsRouter**
+    - `test_totals_match_expected_wdl`: GET /api/stats/global with seeded_user auth. Sum `by_time_control` totals. Assert == 15 = EXPECTED["total_games"]. Also assert sum of wins/draws/losses across by_color matches EXPECTED["global_wdl"].
+    - `test_by_time_control_has_expected_counts`: for each bucket in `{bullet, blitz, rapid, classical}`, find the entry in `response["by_time_control"]` and assert `total == EXPECTED["by_time_control"][bucket]`.
+    - `test_by_color_black_perspective_wins`: find the black row in `by_color`. Assert `wins == EXPECTED["by_color"]["black"]["wins"] == 1` (the single 0-1 game where user played black). This is the key regression-catcher for the black-perspective flip at the router layer.
+    - `test_by_color_white_counts`: same shape for white.
+    - `test_platform_filter_chess_com_returns_7_games`: pass `?platform=chess.com`. Sum by_time_control totals → 7.
+    - `test_platform_filter_lichess_returns_8_games`: same for lichess → 8.
+
+    **TestEndgamesOverviewRouter**
+    - `test_endgame_wdl_total_is_5`: GET /api/endgames/overview. Assert `response["performance"]["endgame_wdl"]["total"] == 5`.
+    - `test_per_type_rook_is_4_games`: `response["performance"]["endgame_per_type"]["rook"]["total"] == 4`.
+    - `test_per_type_pawn_is_2_games`: same key "pawn" → 2.
+    - `test_material_rows_sum_equals_endgame_total`: sum `response["score_gap_material"]["material_rows"][i]["games"]` for i in 0..2. Assert sum == `response["performance"]["endgame_wdl"]["total"]` == 5. This is Phase 59's invariant verified at the router layer with real seeded data — if it ever regresses, this test catches it.
+
+    **TestOpeningsNextMovesRouter**
+    - `test_starting_position_matches_all_15_games`: POST `/api/openings/next-moves` with body containing `target_hash=STARTING_POSITION_HASH`, `match_side="full"`. Import the constant from seed_fixtures. Assert the response's aggregate stats sum (wins + draws + losses across matching moves) equals 15. The exact schema field containing this may be `response["stats"]["total"]` or similar — read the schema first.
+
+    Each test uses the `seeded_user` fixture as the single source of truth for both user_id and expected numbers. Import `from tests.seed_fixtures import seeded_user, STARTING_POSITION_HASH`. Do NOT redefine EXPECTED locally — read it from `seeded_user.expected`.
+  </behavior>
+  <action>
+1. Create `tests/test_integration_routers.py`:
+
+```python
+"""Router-level integration tests (Phase 61).
+
+Uses the shared seeded_user fixture to prove that the full stack
+HTTP → router → service → repository → DB produces the expected numbers
+for a known deterministic portfolio. Each test asserts exact integers
+against the EXPECTED aggregate dict committed alongside the seed spec.
+"""
+
+import httpx
+import pytest
+
+from app.main import app
+from tests.seed_fixtures import STARTING_POSITION_HASH, SeededUser, seeded_user  # noqa: F401 — re-exports fixture
+
+_BASE = "http://test"
+
+
+def _find_category(items: list[dict], name: str) -> dict | None:
+    for c in items:
+        if c.get("category") == name:
+            return c
+    return None
+
+
+class TestGlobalStatsRouter:
+    @pytest.mark.asyncio
+    async def test_totals_match_expected_games(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["total_games"]
+
+    @pytest.mark.asyncio
+    async def test_by_time_control_buckets_have_expected_counts(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        for bucket, expected_total in seeded_user.expected["by_time_control"].items():
+            cat = _find_category(data["by_time_control"], bucket)
+            assert cat is not None, f"missing bucket {bucket!r} in response"
+            assert cat["total"] == expected_total, (
+                f"{bucket}: got {cat['total']} expected {expected_total}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_by_color_black_perspective(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        black = _find_category(data["by_color"], "black")
+        assert black is not None
+        exp = seeded_user.expected["by_color"]["black"]
+        assert black["total"] == exp["total"]
+        assert black["wins"] == exp["wins"]
+        assert black["draws"] == exp["draws"]
+        assert black["losses"] == exp["losses"]
+
+    @pytest.mark.asyncio
+    async def test_by_color_white_perspective(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        white = _find_category(data["by_color"], "white")
+        assert white is not None
+        exp = seeded_user.expected["by_color"]["white"]
+        assert white["total"] == exp["total"]
+        assert white["wins"] == exp["wins"]
+        assert white["draws"] == exp["draws"]
+        assert white["losses"] == exp["losses"]
+
+    @pytest.mark.asyncio
+    async def test_platform_filter_chess_com(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/stats/global?platform=chess.com", headers=seeded_user.auth_headers
+            )
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["by_platform"]["chess.com"]
+
+    @pytest.mark.asyncio
+    async def test_platform_filter_lichess(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/stats/global?platform=lichess", headers=seeded_user.auth_headers
+            )
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["by_platform"]["lichess"]
+
+
+class TestEndgamesOverviewRouter:
+    @pytest.mark.asyncio
+    async def test_endgame_wdl_total(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/endgames/overview", headers=seeded_user.auth_headers
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["performance"]["endgame_wdl"]["total"] == (
+            seeded_user.expected["endgame_games_distinct"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_per_type_rook_count(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/endgames/overview", headers=seeded_user.auth_headers
+            )
+        data = resp.json()
+        per_type = data["performance"]["endgame_per_type"]
+        # per_type keys are the lowercase EndgameClass labels: "rook", "pawn", etc.
+        assert "rook" in per_type, f"missing rook in {list(per_type)}"
+        assert per_type["rook"]["total"] == seeded_user.expected["endgame_rook_games"]
+
+    @pytest.mark.asyncio
+    async def test_per_type_pawn_count(self, seeded_user):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/endgames/overview", headers=seeded_user.auth_headers
+            )
+        data = resp.json()
+        per_type = data["performance"]["endgame_per_type"]
+        assert "pawn" in per_type
+        assert per_type["pawn"]["total"] == seeded_user.expected["endgame_pawn_games"]
+
+    @pytest.mark.asyncio
+    async def test_material_rows_sum_equals_endgame_total(self, seeded_user):
+        """Phase 59 invariant verified at the router layer with real seeded data."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/endgames/overview", headers=seeded_user.auth_headers
+            )
+        data = resp.json()
+        rows_sum = sum(r["games"] for r in data["score_gap_material"]["material_rows"])
+        assert rows_sum == data["performance"]["endgame_wdl"]["total"]
+
+
+class TestOpeningsNextMovesRouter:
+    @pytest.mark.asyncio
+    async def test_starting_position_matches_all_seeded_games(self, seeded_user):
+        """Every seeded game has a ply=0 GamePosition at STARTING_POSITION_HASH."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.post(
+                "/api/openings/next-moves",
+                headers=seeded_user.auth_headers,
+                json={
+                    "target_hash": STARTING_POSITION_HASH,
+                    "match_side": "full",
+                    "color": None,
+                    "time_control": None,
+                    "platform": None,
+                    "rated": None,
+                    "opponent_type": "human",
+                    "recency": None,
+                    "opponent_strength": "any",
+                    "elo_threshold": 50,
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # Schema shape may vary; adapt to the actual NextMovesResponse by reading
+        # app/schemas/openings.py:: NextMovesResponse. Two likely shapes:
+        #   (a) {"stats": {"total": N, ...}, "moves": [...]}
+        #   (b) {"moves": [{"move_san": "e4", "total": N, ...}, ...]}
+        # Sum "moves[*].total" for shape (b). If shape (a), assert stats.total directly.
+        if "stats" in data:
+            total = data["stats"]["total"]
+        else:
+            total = sum(m["total"] for m in data["moves"])
+        assert total == seeded_user.expected["starting_position_game_count"]
+```
+
+2. **Before running**, read `app/schemas/openings.py::NextMovesResponse` and adapt the JSON body + assertion to the exact schema. If the field is `target_hash: int | None = None`, `match_side: Literal["full","white","black"] = "full"`, and there is no `stats` top-level object, sum `moves[*].total` and assert equals 15.
+
+3. If `TestEndgamesOverviewRouter::test_per_type_rook_count` fails because per_type keys are integers (IntEnum values) rather than string labels, adapt the lookup. Prefer string labels — check `app/schemas/endgames.py::EndgamePerformanceResponse.endgame_per_type` for the exact declared type.
+
+4. Run the new test file standalone, then the full suite to confirm no collateral damage.
+  </action>
+  <verify>
+    <automated>uv run ruff check tests/test_integration_routers.py &amp;&amp; uv run ruff format --check tests/test_integration_routers.py &amp;&amp; uv run ty check tests/ &amp;&amp; uv run pytest tests/test_integration_routers.py -v --no-header</automated>
+  </verify>
+  <acceptance_criteria>
+    - `test -f tests/test_integration_routers.py` succeeds.
+    - `grep -cn "^class Test" tests/test_integration_routers.py` prints 3.
+    - `grep -cn "async def test_" tests/test_integration_routers.py` prints >= 9.
+    - `grep -n "from tests.seed_fixtures import" tests/test_integration_routers.py` returns exactly one match.
+    - `grep -n "seeded_user.expected" tests/test_integration_routers.py` returns >= 6 matches (each exact-integer assertion pulls from expected).
+    - All tests pass on current codebase. Any failure → investigate, fix the TEST code to match reality, or xfail with a reason (same rule as Plan 61-02 — do not touch production code in this phase).
+    - `uv run ty check tests/` exits 0.
+  </acceptance_criteria>
+  <done>Router integration tests live under `tests/test_integration_routers.py`, reference the shared seeded_user fixture, and assert exact integer counts from EXPECTED. No production code changed.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `uv run ty check app/ tests/` exits 0.
+- `uv run ruff check . && uv run ruff format --check .` exit 0.
+- `uv run pytest tests/test_integration_routers.py -v` — all tests PASS.
+- Full `uv run pytest` green end-to-end.
+- Manual check: re-running `uv run pytest` from a clean shell wipes prior data via the Plan 61-01 truncate, the seeded_user fixture re-seeds once per test module, and all router assertions still hit the expected numbers.
+</verification>
+
+<success_criteria>
+- Phase 61 success criterion #5 (router integration tests) is met.
+- Invariant sum(material_rows.games) == endgame_wdl.total is verified at the router layer with real data.
+- WDL black perspective is verified end-to-end.
+- No production code changed.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/61-test-hardening/61-03-SUMMARY.md` listing:
+- test classes + methods added
+- total new tests passing
+- any xfails with reason strings
+- runtime of the new file (HTTP register+seed is ~1-2s once per module)
+</output>

--- a/.planning/phases/61-test-hardening/61-CONTEXT.md
+++ b/.planning/phases/61-test-hardening/61-CONTEXT.md
@@ -1,0 +1,203 @@
+# Phase 61: Test Suite Hardening & DB Reset — Context
+
+**Gathered:** 2026-04-16
+**Status:** Ready for execution
+**Mode:** Direct (user approved scope inline; no separate discuss pass)
+
+<domain>
+## Phase Boundary
+
+Two related quality-of-life improvements for the pytest suite:
+
+1. **Test DB reset at session start.** Today `tests/conftest.py` runs `alembic upgrade head` against `flawchess_test` but never wipes data. HTTP-path tests (those using `httpx.AsyncClient(transport=ASGITransport(app=app))`) commit via the session-scoped `override_get_async_session` fixture, so `users`, `oauth_account`, `position_bookmarks`, `games`, and `game_positions` accumulate indefinitely across local and CI runs. We add a session-scoped TRUNCATE that wipes everything except `alembic_version` (and `openings` if populated) before the first test runs. Data from the just-finished run is preserved for inspection; the next run starts clean.
+
+2. **Meaningful aggregation sanity tests.** The audit in the session preceding this phase identified gaps: no end-to-end verification that WDL counts are correct from the user's perspective when they play black, no verification that material tallies move in the right direction on capture, no rolling-window boundary coverage, no platform×time-control intersection coverage, no recency-cutoff boundary test, no position-dedup within-game test, no endgame-class-transition test, and no router-level "seed N games → assert response.json has these exact numbers" test. This phase closes those gaps.
+
+In scope:
+- `tests/conftest.py` — truncate fixture
+- `tests/seed_fixtures.py` (new) — shared realistic `seeded_user` fixture with committed data, reusable by router integration tests
+- `tests/test_aggregation_sanity.py` (new) — unit-level aggregation tests using `db_session` rollback isolation
+- `tests/test_integration_routers.py` (new) — router-level integration tests (register → seed for that user_id → call API → assert numbers)
+
+Out of scope:
+- Frontend test harness changes
+- CI config changes (truncate runs per pytest session; CI uses ephemeral Postgres container so truncate is a no-op there but still correct)
+- Rewriting existing tests — we only ADD new tests and ONE conftest fixture; existing tests are not touched
+- Any production-code change. If a test discovers a real bug, flag it in the PR description rather than fixing it in this phase.
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### 1. Truncate vs schema drop/recreate → TRUNCATE
+
+Use `TRUNCATE TABLE <all_public_tables_except_excluded> RESTART IDENTITY CASCADE` at session start, not `DROP SCHEMA` + re-run Alembic.
+
+**Why:** TRUNCATE is one order of magnitude faster, doesn't rebuild indexes, and preserves the schema we just verified with `alembic upgrade head` immediately prior. Schema drop/recreate would work but adds ~1-2s to every local pytest startup for no benefit — the schema is already correct.
+
+**Implementation:** Discover tables via `SELECT tablename FROM pg_tables WHERE schemaname='public'`, exclude `{'alembic_version', 'openings'}`. Runs ONCE per pytest session, right after `alembic upgrade head` and before `test_engine` yields. Uses the sync engine because TRUNCATE in a single transaction doesn't need async.
+
+### 2. Truncate exclusions → alembic_version + openings
+
+- `alembic_version` is managed by Alembic; truncating it breaks migration tracking.
+- `openings` is a reference table populated by `scripts/seed_openings.py`. Today `flawchess_test` probably has zero rows here (nothing in the test setup seeds it), so truncate is effectively a no-op. But IF a future contributor seeds it (e.g. to test opening classification paths end-to-end), we don't want TRUNCATE to wipe that reference data silently. Exclude it defensively.
+
+All other tables (users, games, game_positions, position_bookmarks, import_jobs, oauth_account, guest_sessions, etc.) are truncated.
+
+### 3. Shared seeded_user fixture → module-scoped, committed, HTTP-registered
+
+The router integration tests need a user that:
+- Has a real JWT (so `/api/auth/jwt/login` works)
+- Has `user_id` known to test code (so we can insert games for that exact ID)
+- Has committed game data (so it's visible to API requests going through `override_get_async_session`)
+
+Approach: one `seeded_user` fixture at **module scope** in `tests/seed_fixtures.py`:
+1. Register via `POST /api/auth/register` with a uuid-prefixed email. Parse `response.json()["id"]` — fastapi-users `BaseUser[int]` schema exposes `id` as int.
+2. Login via `/api/auth/jwt/login`, capture bearer token.
+3. Open a fresh `AsyncSession` via `app.core.database.async_session_maker` (which is patched to the test DB by `override_get_async_session`'s session-scoped setup — confirmed in conftest.py:69) and seed a deterministic portfolio (see Plan 61-01 for exact counts).
+4. Commit.
+5. Yield `SeededUser(id=..., email=..., auth_headers={"Authorization": f"Bearer {token}"}, expected=<dict of expected aggregates>)`.
+
+Module scope avoids re-seeding per test (expensive — ~15 inserts per user) but keeps isolation between router test modules. The data persists for the whole suite thanks to the session-start truncate.
+
+**Alternative considered — function-scoped db_session seeding:** would require the HTTP path to see rolled-back data, which it cannot. Rejected.
+
+**Alternative considered — seed at session scope:** module-scoped is safer because test modules can add supplementary data without colliding with sibling modules.
+
+### 4. Unit-level aggregation tests → db_session rollback, user_id 700-series
+
+For aggregation sanity tests that exercise service/repo code directly (not via HTTP), use the existing `db_session` transaction-rollback fixture. Each test picks a unique user_id in the 700-series (no current test module uses these) and the FK helper `ensure_test_user`. This matches the convention already established by `test_stats_service.py` (800-series), `test_openings_time_series.py` (900-series), `test_stats_repository.py` (99999).
+
+### 5. Router integration tests → assert exact numbers, not just shape
+
+New file `tests/test_integration_routers.py` verifies:
+- `GET /api/stats/global` — seeded portfolio returns the expected WDL counts per time control AND per color (including black perspective flip)
+- `GET /api/endgames/overview` — seeded portfolio returns the expected endgame_wdl counts and the Conv/Even/Recov material_rows sum equals endgame total (Phase 59 invariant, but at the router layer)
+- `POST /api/openings/next-moves` — seeded portfolio with several games passing through the starting position returns the expected per-move WDL totals
+
+Each test asserts exact integers. If seeding drifts out of sync with expectations the test fails loudly, which is the goal — "known seed → known numbers."
+
+### 6. Material tally tests → use position_classifier directly, not DB
+
+`app/services/position_classifier.py` exposes pure functions (`_compute_material_count`, `_compute_material_signature`, `_compute_material_imbalance`). These are the source of truth for the values stored in `GamePosition`. Testing them directly with `python-chess` board instances (e.g. starting position, after `1. e4`, after `1. e4 e5 2. exd5`) is much simpler and more targeted than seeding games and reading back material columns. Material tally tests land in a new `tests/test_material_tally.py` file so the existing `test_position_classifier.py` structure isn't disrupted.
+
+### Folded todos
+
+None — this phase originates from a live audit conversation, not a backlog item.
+</decisions>
+
+<code_context>
+## Existing Code Insights
+
+- **`tests/conftest.py:21-44`** — `test_engine` fixture runs `alembic upgrade head` at session start. That's where the truncate call goes, **after** migrations but **before** `yield engine`. Uses the sync engine via `engine.sync_engine` (already available for the teardown dispose).
+- **`tests/conftest.py:47-83`** — `override_get_async_session` is session-scoped autouse and patches `app.core.database.async_session_maker` to the test DB. HTTP-path tests commit through this maker. For the `seeded_user` fixture, we import `async_session_maker` from `app.core.database` AFTER conftest patches it, so our seeding lands in `flawchess_test`.
+- **`tests/conftest.py:101-109`** — `ensure_test_user(session, user_id)` creates a minimal User row with FK-valid id. Used when seeding games for IDs that aren't HTTP-registered.
+- **Game model (`app/models/game.py`)** — NOT-NULL columns are `user_id`, `platform`, `platform_game_id`, `pgn`, `result`, `user_color`, `rated`. Everything else is nullable. `played_at` has NO server default but is widely read — always set it explicitly. `time_control_bucket` is a Postgres ENUM (`bullet|blitz|rapid|classical`). `result` is a Postgres ENUM (`1-0|0-1|1/2-1/2`). `user_color` is `white|black`. Unique constraint on `(user_id, platform, platform_game_id)`.
+- **GamePosition model (`app/models/game_position.py`)** — NOT-NULL columns are `game_id`, `user_id` (denormalized for query perf), `ply`, `full_hash`, `white_hash`, `black_hash`. All analytics columns (`material_count`, `material_signature`, `material_imbalance`, `endgame_class`, `piece_count`, `clock_seconds`, `eval_cp`, etc.) are nullable.
+- **`user_material_imbalance_after` is computed, not stored.** The repository `app/repositories/endgame_repository.py:239` derives it via window function. For seeding, we just need consecutive plies with `material_imbalance` set; the service reads `imbalance_after` as the imbalance at ply+4.
+- **Router prefixes (`app/main.py:71-77`)** — everything mounts under `/api`. So the paths are `/api/stats/global`, `/api/endgames/overview`, `/api/openings/next-moves` (POST).
+- **`ENDGAME_PLY_THRESHOLD`** (app/repositories/endgame_repository.py) — a span must have ≥ this many consecutive plies of the same `endgame_class` to qualify. The existing `test_endgames_router.py:96` seeds `range(30, 30 + ENDGAME_PLY_THRESHOLD)`. Same pattern applies here.
+- **fastapi-users register response** exposes `id: int` directly (`BaseUser[int]` in `app/routers/auth.py:42`). `response.json()["id"]` is the authoritative source for the registered user's id.
+- **`derive_user_result(result, user_color)`** in `app/services/openings_service.py` is the canonical WDL-perspective conversion. When we assert from the user's perspective (especially when user plays black), expected numbers must be built with this function in mind.
+- **`apply_game_filters`** in `app/repositories/query_utils.py` centralizes filter logic. Testing intersection correctness is as simple as seeding games that straddle filter boundaries and asserting the filtered query returns exactly what we expect.
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- **Truncate implementation sketch:**
+  ```python
+  from sqlalchemy import text
+
+  _TRUNCATE_EXCLUDE = frozenset({"alembic_version", "openings"})
+
+  def _truncate_all_tables(sync_engine) -> None:
+      with sync_engine.begin() as conn:
+          rows = conn.execute(text(
+              "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+          ))
+          tables = [r[0] for r in rows if r[0] not in _TRUNCATE_EXCLUDE]
+          if tables:
+              conn.execute(text(
+                  f'TRUNCATE TABLE {", ".join(tables)} RESTART IDENTITY CASCADE'
+              ))
+  ```
+  Called from inside `test_engine` between `alembic_command.upgrade` and `create_async_engine`.
+
+- **Seeded portfolio composition** (deterministic, ~15 games):
+  - 3 chess.com blitz as white: 2W 1D 0L
+  - 2 chess.com blitz as black: 1W (0-1) 0D 1L (1-0)
+  - 2 chess.com rapid as white: 0W 0D 2L (both 0-1, user loses)
+  - 2 lichess blitz as white: 2W 0D 0L
+  - 2 lichess bullet as black: 0W 2D 0L
+  - 2 lichess classical as white: 1W 0D 1L
+  - 2 lichess rapid as white, 1 rated + 1 unrated
+  - Opening positions: several games share the starting Zobrist hash so `/next-moves` has real material
+  - Endgame spans: at least 3 games get ENDGAME_PLY_THRESHOLD+ consecutive plies with `endgame_class=1` (rook), plus 1 game with two class transitions (rook→pawn)
+  - Total: 15 games; expected WDL from user's perspective: wins=6, draws=3, losses=6 — but verify by computing deterministically in the fixture rather than hand-counting.
+
+- **Filter intersection test fixture**:
+  - Seed 4 games: (chess.com, blitz), (chess.com, rapid), (lichess, blitz), (lichess, rapid). Assert the filter `platform=["chess.com"] AND time_control=["blitz"]` returns exactly 1 game, not 3 (union) or 0.
+
+- **Recency boundary test**:
+  - Seed one game at `played_at == cutoff_dt` (to the microsecond). Assert whether `apply_game_filters` includes or excludes it — then document the actual behavior in the test's docstring. If the behavior is inclusive, call it `test_recency_cutoff_inclusive_at_boundary`. This is a behavioral-pinning test, not a correctness assertion.
+
+- **Position dedup test**:
+  - Seed one game with 3 GamePosition rows all sharing the same `full_hash` at plies 0, 2, 4 (impossible in real chess but valid for testing the dedup logic). Call the openings analyze service with that hash. Assert total==1, not 3.
+
+- **Endgame transition test**:
+  - Seed one game with 6+ plies of `endgame_class=1` then 6+ plies of `endgame_class=3`. Call the endgame overview service. Assert per-type breakdown shows BOTH rook AND pawn classes with 1 game each; total is still 1 distinct game_id via `endgame_wdl.total`.
+
+- **WDL-from-black-perspective test**:
+  - Seed 3 games with `user_color="black"`: (result="0-1" → user wins), (result="1-0" → user loses), (result="1/2-1/2" → draw). Call `get_global_stats`. Assert the black bucket has wins=1, losses=1, draws=1.
+
+- **Material tally tests** (no DB):
+  ```python
+  import chess
+  from app.services.position_classifier import _compute_material_count, _compute_material_imbalance
+
+  def test_starting_position_material():
+      board = chess.Board()
+      assert _compute_material_count(board) == 7800  # both sides full
+      assert _compute_material_imbalance(board) == 0
+
+  def test_after_white_captures_central_pawn():
+      board = chess.Board()
+      board.push_san("e4")
+      board.push_san("d5")
+      board.push_san("exd5")  # white captures black pawn
+      assert _compute_material_imbalance(board) == 100  # +1 pawn = +100cp for white
+      assert _compute_material_count(board) == 7700
+  ```
+  These catch a regression in the material constants or sign conventions.
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **ECO / opening_name double-match test** — needs the `openings` reference table to be populated in the test DB. Out of scope until we decide whether tests should seed reference data. Flag in final summary.
+- **Rolling window edge cases** beyond what Plan 61-02 covers — e.g. timeline behavior under a 1-game window, or a window larger than total games. Add if cheap during execution, otherwise log as follow-up.
+- **Opponent-type and opponent-strength filter intersection** — Phase 60 reworks some of this; we stick to platform × time_control for now.
+</deferred>
+
+<canonical_refs>
+## Canonical References
+
+- `tests/conftest.py` — edit target for Plan 61-01 Task 1 (truncate)
+- `tests/seed_fixtures.py` — new file for Plan 61-01 Task 2 (seeded_user module fixture)
+- `tests/test_aggregation_sanity.py` — new file for Plan 61-02
+- `tests/test_integration_routers.py` — new file for Plan 61-03
+- `tests/test_material_tally.py` — new file for Plan 61-02 (material tests)
+- `app/core/database.py` — `async_session_maker` used by seed fixture
+- `app/main.py:71-77` — router mount prefixes (all `/api`)
+- `app/routers/auth.py:42` — register router exposes `id: int`
+- `app/services/stats_service.py` — `get_global_stats`, `_rows_to_wdl_categories`
+- `app/services/endgame_service.py` — `get_endgame_overview`, `_compute_score_gap_material`
+- `app/services/openings_service.py` — `derive_user_result`, `get_next_moves`
+- `app/services/position_classifier.py` — material helpers
+- `app/repositories/query_utils.py` — `apply_game_filters`
+- `app/repositories/endgame_repository.py` — `ENDGAME_PLY_THRESHOLD`, entry-row query
+- `tests/test_endgames_router.py:54-113` — `_seed_game_with_endgame` pattern to mirror
+- `tests/test_stats_service.py:63-119` — `_seed_game` pattern to mirror
+- Phase 59 `59-01-PLAN.md` — reference format for plan structure, invariant assertions style
+</canonical_refs>

--- a/.planning/phases/61-test-hardening/61-VERIFICATION.md
+++ b/.planning/phases/61-test-hardening/61-VERIFICATION.md
@@ -9,11 +9,11 @@
 | # | Criterion | Status | Evidence |
 |---|-----------|--------|----------|
 | 1 | `tests/conftest.py` truncates all non-reference tables at session start, keeping `alembic_version` and `openings` intact | VERIFIED | `conftest.py:27-61` — `_TRUNCATE_EXCLUDE = {'alembic_version', 'openings'}` + `_truncate_all_tables` creates a throwaway async engine via `asyncio.run`, runs `SELECT tablename FROM pg_tables WHERE schemaname='public'` and issues `TRUNCATE TABLE ... RESTART IDENTITY CASCADE`. Manually verified: after a pytest run, `openings` retains 3641 rows, `alembic_version` retains 1, all other user-owned tables reset to 0. |
-| 2 | Shared module-scoped `seeded_user` fixture in `tests/seed_fixtures.py` | VERIFIED | `seed_fixtures.py` defines `SeededUser` dataclass, `_GAMES_SPEC` (15 games), `EXPECTED` aggregate dict, registers/logins via API, commits portfolio through the patched `async_session_maker`. Registered as a pytest plugin in `conftest.py:21-24`. |
+| 2 | Shared module-scoped `seeded_user` fixture in `tests/seed_fixtures.py` | VERIFIED | `seed_fixtures.py` defines `SeededUser` dataclass, `_GAMES_SPEC` (25 games — expanded from 15 in follow-up commit `3a648a0`), `EXPECTED` aggregate dict with a `_verify_expected_matches_spec()` self-check at import time to prevent spec/expected drift, registers/logins via API, commits portfolio through the patched `async_session_maker`. Registered as a pytest plugin in `conftest.py:21-24`. |
 | 3 | `tests/test_aggregation_sanity.py` covers 7 audit gaps | VERIFIED | 12 tests across 6 classes all passing: WDL-black-perspective (4), rolling-window-boundaries (3), filter intersection (1), recency boundary (2), position dedup (1), endgame class transition (1). |
 | 4 | `tests/test_material_tally.py` verifies material pure functions | VERIFIED | 10 tests across 3 classes — starting material = 7800 cp, capture reduces count by 100 cp, signed imbalance (+100 white-up-pawn / -500 black-up-rook / 0 starting / 0 both-missing-queen), signature format `KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP`. All passing. |
-| 5 | `tests/test_integration_routers.py` hits real routers with exact-integer assertions | VERIFIED | 11 tests across 3 classes: global stats totals + time-control buckets + by-color perspective + platform filters (6 tests), endgame overview distinct total + per-type rook/pawn counts + Phase 59 material-rows invariant (4 tests), openings next-moves 15-game starting-position count (1 test). All passing. |
-| 6 | `uv run pytest` remains green; `uv run ty check app/ tests/` is zero-errors; `uv run ruff check .` is zero-errors | VERIFIED | Full suite: **755 passed, 1 skipped** (was 722 before Phase 61 — net +33 tests). `ty`: all checks passed. `ruff check`: all checks passed. `ruff format --check` on all 5 Phase-61 files: clean. |
+| 5 | `tests/test_integration_routers.py` hits real routers with exact-integer assertions | VERIFIED | 18 tests across 5 classes: global stats totals + time-control buckets + by-color perspective + platform filters (6 tests), endgame overview distinct total + per-type rook/pawn counts + Phase 59 material-rows invariant + all-six-endgame-classes coverage (5 tests), clock-pressure router only-blitz + row-shape + net_timeout_rate math (3 tests), time-pressure chart 10-bucket series + totals-match + per-bucket sums (3 tests), openings next-moves 25-game starting-position count (1 test). All passing. |
+| 6 | `uv run pytest` remains green; `uv run ty check app/ tests/` is zero-errors; `uv run ruff check .` is zero-errors | VERIFIED | Full suite: **762 passed, 1 skipped** (was 722 before Phase 61 — net +40 tests, incl. the follow-up time-pressure expansion). `ty`: all checks passed. `ruff check`: all checks passed. `ruff format --check` on all Phase-61 files: clean. |
 | 7 | No production code (`app/`) modified | VERIFIED | `git diff main -- app/` is empty. Only `tests/`, `.planning/`, and `.planning/phases/61-test-hardening/` were touched. |
 
 ## Test count delta
@@ -22,12 +22,14 @@
 |------|------------:|--------|
 | `tests/test_aggregation_sanity.py` | 12 | all passing |
 | `tests/test_material_tally.py` | 10 | all passing |
-| `tests/test_integration_routers.py` | 11 | all passing |
-| **Total** | **33** | **all passing** |
+| `tests/test_integration_routers.py` | 18 | all passing |
+| **Total** | **40** | **all passing** |
 
 ## Commits
 
 ```
+3a648a0 test(phase-61): expand seeded portfolio to 25 games + add time-pressure router tests
+94a66cf docs(phase-61): verification + mark phase complete in ROADMAP
 cf2101e test(phase-61-03): router integration tests + fixture plugin registration
 a71b02f test(phase-61-02): aggregation sanity + material tally tests
 2b60de2 test(phase-61-01): truncate flawchess_test at session start + seeded_user fixture
@@ -38,5 +40,6 @@ a71b02f test(phase-61-02): aggregation sanity + material tally tests
 
 - Zero production code (`app/`) changes — this phase purely added test coverage and test infrastructure. No audit-gap turned out to be a real bug; every new assertion passes against current behavior.
 - The `seeded_user` fixture is registered once at module scope per consumer (currently just `test_integration_routers.py`). Register+seed cost is ~200 ms once per that module.
+- Follow-up commit `3a648a0` expanded the seed to 25 games (originally 15) to unlock time-pressure router coverage: 11 blitz endgame games with `clock_seconds` populated (crossing `MIN_GAMES_FOR_CLOCK_STATS=10`), all 6 endgame classes represented, and 3 timeout terminations (2 user wins, 1 loss) for a non-zero `net_timeout_rate`. Added `_verify_expected_matches_spec()` self-check at module import to crash pytest collection if `EXPECTED` drifts from `_GAMES_SPEC`.
 - The in-codebase warning about HMAC key length (<32 bytes) already existed and is unrelated to Phase 61.
 - `tests/seed_fixtures.py` is intentionally kept as a vanilla test helper module (not under `app/`) so it doesn't ship in the production image.

--- a/.planning/phases/61-test-hardening/61-VERIFICATION.md
+++ b/.planning/phases/61-test-hardening/61-VERIFICATION.md
@@ -1,0 +1,42 @@
+# Phase 61 — Verification
+
+**Date:** 2026-04-16
+**Branch:** `phase-61-test-hardening`
+**Worktree:** `/home/aimfeld/Projects/Python/flawchess-tests`
+
+## Success criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | `tests/conftest.py` truncates all non-reference tables at session start, keeping `alembic_version` and `openings` intact | VERIFIED | `conftest.py:27-61` — `_TRUNCATE_EXCLUDE = {'alembic_version', 'openings'}` + `_truncate_all_tables` creates a throwaway async engine via `asyncio.run`, runs `SELECT tablename FROM pg_tables WHERE schemaname='public'` and issues `TRUNCATE TABLE ... RESTART IDENTITY CASCADE`. Manually verified: after a pytest run, `openings` retains 3641 rows, `alembic_version` retains 1, all other user-owned tables reset to 0. |
+| 2 | Shared module-scoped `seeded_user` fixture in `tests/seed_fixtures.py` | VERIFIED | `seed_fixtures.py` defines `SeededUser` dataclass, `_GAMES_SPEC` (15 games), `EXPECTED` aggregate dict, registers/logins via API, commits portfolio through the patched `async_session_maker`. Registered as a pytest plugin in `conftest.py:21-24`. |
+| 3 | `tests/test_aggregation_sanity.py` covers 7 audit gaps | VERIFIED | 12 tests across 6 classes all passing: WDL-black-perspective (4), rolling-window-boundaries (3), filter intersection (1), recency boundary (2), position dedup (1), endgame class transition (1). |
+| 4 | `tests/test_material_tally.py` verifies material pure functions | VERIFIED | 10 tests across 3 classes — starting material = 7800 cp, capture reduces count by 100 cp, signed imbalance (+100 white-up-pawn / -500 black-up-rook / 0 starting / 0 both-missing-queen), signature format `KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP`. All passing. |
+| 5 | `tests/test_integration_routers.py` hits real routers with exact-integer assertions | VERIFIED | 11 tests across 3 classes: global stats totals + time-control buckets + by-color perspective + platform filters (6 tests), endgame overview distinct total + per-type rook/pawn counts + Phase 59 material-rows invariant (4 tests), openings next-moves 15-game starting-position count (1 test). All passing. |
+| 6 | `uv run pytest` remains green; `uv run ty check app/ tests/` is zero-errors; `uv run ruff check .` is zero-errors | VERIFIED | Full suite: **755 passed, 1 skipped** (was 722 before Phase 61 — net +33 tests). `ty`: all checks passed. `ruff check`: all checks passed. `ruff format --check` on all 5 Phase-61 files: clean. |
+| 7 | No production code (`app/`) modified | VERIFIED | `git diff main -- app/` is empty. Only `tests/`, `.planning/`, and `.planning/phases/61-test-hardening/` were touched. |
+
+## Test count delta
+
+| File | Tests added | Status |
+|------|------------:|--------|
+| `tests/test_aggregation_sanity.py` | 12 | all passing |
+| `tests/test_material_tally.py` | 10 | all passing |
+| `tests/test_integration_routers.py` | 11 | all passing |
+| **Total** | **33** | **all passing** |
+
+## Commits
+
+```
+cf2101e test(phase-61-03): router integration tests + fixture plugin registration
+a71b02f test(phase-61-02): aggregation sanity + material tally tests
+2b60de2 test(phase-61-01): truncate flawchess_test at session start + seeded_user fixture
+1cbb6c0 plan(phase-61): test suite hardening & DB reset
+```
+
+## Notes / follow-ups
+
+- Zero production code (`app/`) changes — this phase purely added test coverage and test infrastructure. No audit-gap turned out to be a real bug; every new assertion passes against current behavior.
+- The `seeded_user` fixture is registered once at module scope per consumer (currently just `test_integration_routers.py`). Register+seed cost is ~200 ms once per that module.
+- The in-codebase warning about HMAC key length (<32 bytes) already existed and is unrelated to Phase 61.
+- `tests/seed_fixtures.py` is intentionally kept as a vanilla test helper module (not under `app/`) so it doesn't ship in the production image.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 # Disable Sentry before any app imports — must precede app.core.config which
@@ -11,11 +12,48 @@ import pytest_asyncio
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from collections.abc import AsyncGenerator
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
 from app.models.user import User
+
+# Tables NEVER to truncate during test-session reset:
+# - alembic_version: Alembic migration state. Truncating forces a re-migration
+#   on next startup and breaks `alembic current`.
+# - openings: reference data populated by scripts/seed_openings.py. Currently
+#   empty in flawchess_test but excluded defensively so a future contributor
+#   who seeds it for opening-classification tests does not see their seed
+#   silently wiped on each pytest run.
+_TRUNCATE_EXCLUDE = frozenset({"alembic_version", "openings"})
+
+
+async def _truncate_all_tables(db_url: str) -> None:
+    """Truncate every public-schema table except reference tables.
+
+    Called ONCE per pytest session, after alembic migrations run and before
+    the first test executes. Restarts identity columns so primary keys are
+    deterministic within a run. Data from the *previous* session is wiped;
+    data from the current session remains after teardown for inspection.
+
+    Creates and disposes its own throwaway async engine inside the asyncio
+    event loop spawned by asyncio.run() in the caller. This is required
+    because asyncpg's connection pool is event-loop-bound — sharing the
+    test session's engine here would attach it to a dead loop.
+    """
+    truncate_engine = create_async_engine(db_url, echo=False)
+    try:
+        async with truncate_engine.begin() as conn:
+            rows = await conn.execute(
+                text("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")
+            )
+            tables = [r[0] for r in rows if r[0] not in _TRUNCATE_EXCLUDE]
+            if tables:
+                await conn.execute(
+                    text(f'TRUNCATE TABLE {", ".join(tables)} RESTART IDENTITY CASCADE')
+                )
+    finally:
+        await truncate_engine.dispose()
 
 
 @pytest.fixture(scope="session")
@@ -35,6 +73,13 @@ def test_engine():
     alembic_cfg = AlembicConfig("alembic.ini")
     alembic_cfg.set_main_option("sqlalchemy.url", settings.TEST_DATABASE_URL)
     alembic_command.upgrade(alembic_cfg, "head")
+
+    # Phase 61: wipe residue from previous pytest runs before any test executes.
+    # Preserves alembic_version + openings; everything else is truncated.
+    # Runs in a throwaway event loop via asyncio.run(); the truncate helper
+    # creates and disposes its own engine inside that loop because asyncpg
+    # pools are event-loop-bound — reusing an engine across loops corrupts it.
+    asyncio.run(_truncate_all_tables(settings.TEST_DATABASE_URL))
 
     # Create the async engine for the rest of the test session
     engine = create_async_engine(settings.TEST_DATABASE_URL, echo=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from app.core.config import settings
 from app.models.user import User
 
+# Phase 61: expose the seeded_user fixture without requiring test modules to
+# import it by name (import + parameter-name pytest fixture use triggers
+# ruff F811 "redefined unused import" otherwise).
+pytest_plugins = ["tests.seed_fixtures"]
+
 # Tables NEVER to truncate during test-session reset:
 # - alembic_version: Alembic migration state. Truncating forces a re-migration
 #   on next startup and breaks `alembic current`.
@@ -50,7 +55,7 @@ async def _truncate_all_tables(db_url: str) -> None:
             tables = [r[0] for r in rows if r[0] not in _TRUNCATE_EXCLUDE]
             if tables:
                 await conn.execute(
-                    text(f'TRUNCATE TABLE {", ".join(tables)} RESTART IDENTITY CASCADE')
+                    text(f"TRUNCATE TABLE {', '.join(tables)} RESTART IDENTITY CASCADE")
                 )
     finally:
         await truncate_engine.dispose()
@@ -128,7 +133,6 @@ def override_get_async_session(test_engine):
     activity_module.async_session_maker = original_activity_session_maker
 
 
-
 @pytest.fixture
 def starting_board() -> chess.Board:
     """Return a fresh starting-position chess board."""
@@ -150,7 +154,9 @@ async def ensure_test_user(session: AsyncSession, user_id: int) -> None:
     """
     existing = (await session.execute(select(User).where(User.id == user_id))).unique()
     if existing.scalar_one_or_none() is None:
-        session.add(User(id=user_id, email=f"test-{user_id}@example.com", hashed_password="fakehash"))
+        session.add(
+            User(id=user_id, email=f"test-{user_id}@example.com", hashed_password="fakehash")
+        )
         await session.flush()
 
 

--- a/tests/seed_fixtures.py
+++ b/tests/seed_fixtures.py
@@ -6,8 +6,19 @@ the data through the patched async_session_maker. The seeded_user fixture is
 module-scoped: register+seed cost is paid once per test module, not once per
 test function.
 
+Portfolio (25 games):
+- 15 "base" games covering platforms × time controls × colors × WDL, a
+  rook→pawn endgame-class transition (game 15), and one unrated game.
+- 10 additional chess.com blitz endgame games with clock_seconds populated
+  (games 16–25). These take the blitz endgame-game count to 11 — enough to
+  cross MIN_GAMES_FOR_CLOCK_STATS=10 so the clock-pressure and time-pressure
+  router endpoints have data to return. They also diversify the endgame
+  classes so all six (rook, pawn, minor_piece, queen, mixed, pawnless) are
+  represented in stats.categories.
+
 Expected aggregates are computed once and returned alongside the user data so
-test assertions can reference them by name rather than hand-counting.
+test assertions can reference them by name rather than hand-counting. The
+`EXPECTED` dict is verified against the spec at module import time.
 """
 
 from __future__ import annotations
@@ -27,6 +38,39 @@ from app.repositories.endgame_repository import ENDGAME_PLY_THRESHOLD
 # /api/openings/next-moves queries at the starting position match all games.
 STARTING_POSITION_HASH: int = 0x0123456789ABCDEF
 
+# Base clock (starting time in seconds) per time control bucket. Used as
+# Game.base_time_seconds AND as the scaling denominator for clock_seconds
+# on endgame-entry plies.
+_BASE_TIME_SECONDS: dict[str, int] = {
+    "bullet": 60,
+    "blitz": 600,
+    "rapid": 1800,
+    "classical": 3600,
+}
+
+# Default (signature, imbalance) per endgame_class int. Games that want a
+# different signature/imbalance can override via the spec's `endgame_overrides`.
+# Class ints follow the IntEnum in position_classifier: 1=rook, 2=minor_piece,
+# 3=pawn, 4=queen, 5=mixed, 6=pawnless.
+_CLASS_DEFAULT: dict[int, tuple[str, int]] = {
+    1: ("KR_KR", 0),  # rook
+    2: ("KN_KN", 0),  # minor_piece
+    3: ("KPP_KP", 100),  # pawn — white up a pawn
+    4: ("KQ_KQ", 0),  # queen
+    5: ("KRBP_KRP", 0),  # mixed (rook + minor + pawn, both sides have pawns)
+    6: ("KRN_KR", 300),  # pawnless (rook + minor, no pawns)
+}
+
+# String label for each class int (must match classify_endgame_class output).
+_CLASS_LABEL: dict[int, str] = {
+    1: "rook",
+    2: "minor_piece",
+    3: "pawn",
+    4: "queen",
+    5: "mixed",
+    6: "pawnless",
+}
+
 
 @dataclass
 class SeededUser:
@@ -38,150 +82,178 @@ class SeededUser:
     expected: dict[str, Any] = field(default_factory=dict)
 
 
-# Portfolio spec: 15 games across platforms, time controls, colors, results.
-# Hand-counted aggregates live in EXPECTED below and must be kept in sync with
-# this list — Plan 61-02's router tests assert against EXPECTED directly.
-_GAMES_SPEC: list[dict[str, Any]] = [
-    # platform,       bucket,       color,    result,    rated, endgame
-    {
-        "platform": "chess.com",
-        "bucket": "blitz",
-        "color": "white",
-        "result": "1-0",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "blitz",
-        "color": "white",
-        "result": "1-0",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "blitz",
-        "color": "white",
-        "result": "1/2-1/2",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "blitz",
-        "color": "black",
-        "result": "0-1",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "blitz",
-        "color": "black",
-        "result": "1-0",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "rapid",
-        "color": "white",
-        "result": "0-1",
-        "rated": True,
-        "endgame": [1],
-    },
-    {
-        "platform": "chess.com",
-        "bucket": "rapid",
-        "color": "white",
-        "result": "0-1",
-        "rated": True,
-        "endgame": [1],
-    },
-    {
-        "platform": "lichess",
-        "bucket": "blitz",
-        "color": "white",
-        "result": "1-0",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "lichess",
-        "bucket": "blitz",
-        "color": "white",
-        "result": "1-0",
-        "rated": True,
-        "endgame": [1],
-    },
-    {
-        "platform": "lichess",
-        "bucket": "bullet",
-        "color": "black",
-        "result": "1/2-1/2",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "lichess",
-        "bucket": "bullet",
-        "color": "black",
-        "result": "1/2-1/2",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "lichess",
-        "bucket": "classical",
-        "color": "white",
-        "result": "1-0",
-        "rated": True,
-        "endgame": [3],
-    },
-    {
-        "platform": "lichess",
-        "bucket": "classical",
-        "color": "white",
-        "result": "0-1",
-        "rated": True,
-        "endgame": None,
-    },
-    {
-        "platform": "lichess",
-        "bucket": "rapid",
-        "color": "white",
-        "result": "1-0",
-        "rated": False,
-        "endgame": None,
-    },
-    {
-        "platform": "lichess",
-        "bucket": "rapid",
-        "color": "white",
-        "result": "1/2-1/2",
-        "rated": True,
-        "endgame": [1, 3],
-    },  # transition
-]
+# -----------------------------------------------------------------------------
+# Portfolio spec
+# -----------------------------------------------------------------------------
+#
+# Each game dict carries:
+#   platform, bucket, color, result, rated                    (always required)
+#   endgame:       None | list[int]                           (class ints per span)
+#   clocks:        None | (user_entry_clock, opp_entry_clock) (seconds, optional)
+#   termination:   None | str                                 ("timeout", "checkmate", etc.)
+#
+# Ply-parity rule the service uses: at position ply N, clock_seconds is the
+# clock of the player who just moved, so:
+#   - even ply (30, 32, 34) → white's clock
+#   - odd  ply (31, 33, 35) → black's clock
+# At ply=30 (span entry), the first even-ply clock is white's and the first
+# odd-ply clock is black's. For the user_color="black" games below, I swap
+# the seeded (white_clock, black_clock) so user_entry_clock correctly maps
+# to the ply-parity matching the user.
 
-# Expected aggregates derived from _GAMES_SPEC. Kept explicit so the router
-# tests read as "portfolio → known numbers" rather than recomputing from spec.
+_GAMES_SPEC: list[dict[str, Any]] = [
+    # --- Games 1-15: base portfolio (no clocks except where noted) ------------
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "white", "result": "1/2-1/2", "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "black", "result": "0-1",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "chess.com", "bucket": "blitz",     "color": "black", "result": "1-0",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "chess.com", "bucket": "rapid",     "color": "white", "result": "0-1",     "rated": True,  "endgame": [1],    "clocks": (900, 880),   "termination": None},
+    {"platform": "chess.com", "bucket": "rapid",     "color": "white", "result": "0-1",     "rated": True,  "endgame": [1],    "clocks": (850, 870),   "termination": None},
+    {"platform": "lichess",   "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "lichess",   "bucket": "blitz",     "color": "white", "result": "1-0",     "rated": True,  "endgame": [1],    "clocks": (400, 390),   "termination": None},
+    {"platform": "lichess",   "bucket": "bullet",    "color": "black", "result": "1/2-1/2", "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "lichess",   "bucket": "bullet",    "color": "black", "result": "1/2-1/2", "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "lichess",   "bucket": "classical", "color": "white", "result": "1-0",     "rated": True,  "endgame": [3],    "clocks": (2400, 2350), "termination": None},
+    {"platform": "lichess",   "bucket": "classical", "color": "white", "result": "0-1",     "rated": True,  "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "lichess",   "bucket": "rapid",     "color": "white", "result": "1-0",     "rated": False, "endgame": None,   "clocks": None,         "termination": None},
+    {"platform": "lichess",   "bucket": "rapid",     "color": "white", "result": "1/2-1/2", "rated": True,  "endgame": [1, 3], "clocks": (950, 900),   "termination": None},
+    # --- Games 16-25: chess.com blitz endgame with clocks for time-pressure ---
+    # Chosen to cover: all 6 endgame classes × varied user-vs-opp clock pairs
+    # × 3 timeout terminations (2 wins, 1 loss → non-zero net timeout rate).
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "1-0",     "rated": True, "endgame": [1], "clocks": (300, 310), "termination": "timeout"},      # 16 user win via timeout
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "0-1",     "rated": True, "endgame": [1], "clocks": (50, 200),  "termination": "timeout"},      # 17 user loss via timeout
+    {"platform": "chess.com", "bucket": "blitz", "color": "black", "result": "0-1",     "rated": True, "endgame": [1], "clocks": (200, 50),  "termination": "timeout"},      # 18 user win via timeout (opp flagged)
+    {"platform": "chess.com", "bucket": "blitz", "color": "black", "result": "1-0",     "rated": True, "endgame": [3], "clocks": (250, 260), "termination": None},           # 19 user loss
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "1/2-1/2", "rated": True, "endgame": [2], "clocks": (400, 400), "termination": None},           # 20 minor_piece
+    {"platform": "chess.com", "bucket": "blitz", "color": "black", "result": "1/2-1/2", "rated": True, "endgame": [2], "clocks": (200, 210), "termination": None},           # 21 minor_piece black
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "1-0",     "rated": True, "endgame": [4], "clocks": (350, 340), "termination": None},           # 22 queen
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "0-1",     "rated": True, "endgame": [5], "clocks": (100, 250), "termination": None},           # 23 mixed, user in pressure
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "0-1",     "rated": True, "endgame": [6], "clocks": (150, 200), "termination": None},           # 24 pawnless
+    {"platform": "chess.com", "bucket": "blitz", "color": "white", "result": "1-0",     "rated": True, "endgame": [4], "clocks": (380, 370), "termination": None},           # 25 queen
+]  # fmt: skip
+
+
+# -----------------------------------------------------------------------------
+# EXPECTED aggregates (hand-maintained; verified against spec at import time)
+# -----------------------------------------------------------------------------
+
 EXPECTED: dict[str, Any] = {
-    "total_games": 15,
-    "global_wdl": {"wins": 7, "draws": 4, "losses": 4},
-    "by_platform": {"chess.com": 7, "lichess": 8},
-    "by_time_control": {"bullet": 2, "blitz": 7, "rapid": 4, "classical": 2},
+    "total_games": 25,
+    "global_wdl": {"wins": 11, "draws": 6, "losses": 8},
+    "by_platform": {"chess.com": 17, "lichess": 8},
+    "by_time_control": {"bullet": 2, "blitz": 17, "rapid": 4, "classical": 2},
     "by_color": {
-        "white": {"total": 11, "wins": 6, "draws": 2, "losses": 3},
-        "black": {"total": 4, "wins": 1, "draws": 2, "losses": 1},
+        "white": {"total": 18, "wins": 9, "draws": 3, "losses": 6},
+        "black": {"total": 7, "wins": 2, "draws": 3, "losses": 2},
     },
-    "rated_total": 14,
-    "endgame_games_distinct": 5,  # games 6,7,9,12,15 — game 15 has two classes but counts once
-    "endgame_rook_games": 4,  # games 6,7,9,15
-    "endgame_pawn_games": 2,  # games 12,15
-    "starting_position_game_count": 15,
+    "rated_total": 24,
+    # Endgame: 15 distinct games have at least one span (6,7,9,12,15,16–25).
+    # Per-class counts are distinct-game counts; game 15 appears in both rook
+    # and pawn because it has a class-1→class-3 transition.
+    "endgame_games_distinct": 15,
+    "endgame_by_class": {
+        "rook": 7,  # 6, 7, 9, 15, 16, 17, 18
+        "pawn": 3,  # 12, 15, 19
+        "minor_piece": 2,  # 20, 21
+        "queen": 2,  # 22, 25
+        "mixed": 1,  # 23
+        "pawnless": 1,  # 24
+    },
+    # Back-compat aliases used by existing router tests.
+    "endgame_rook_games": 7,
+    "endgame_pawn_games": 3,
+    # Clock pressure: MIN_GAMES_FOR_CLOCK_STATS = 10 (endgame_service.py).
+    # Only the blitz bucket clears it (11 blitz endgame games with clocks);
+    # rapid has 3 (games 6, 7, 15), classical has 1 (game 12), bullet has 0.
+    "clock_pressure_qualifying_buckets": ["blitz"],
+    "clock_pressure_blitz_games": 11,  # 9, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25
+    "clock_pressure_blitz_timeout_wins": 2,  # games 16, 18
+    "clock_pressure_blitz_timeout_losses": 1,  # game 17
+    # Starting-position hash match — every game has a ply=0 position at the shared hash.
+    "starting_position_game_count": 25,
 }
+
+
+def _verify_expected_matches_spec() -> None:
+    """Recompute spec-derivable aggregates and cross-check EXPECTED.
+
+    Runs at module import so any drift between _GAMES_SPEC and EXPECTED
+    crashes pytest collection loudly rather than silently producing a
+    misleading router-test failure.
+    """
+    games = _GAMES_SPEC
+    assert len(games) == EXPECTED["total_games"], (
+        f"spec has {len(games)} games, EXPECTED declares {EXPECTED['total_games']}"
+    )
+
+    # Platform totals
+    from collections import Counter
+
+    plat = Counter(g["platform"] for g in games)
+    assert dict(plat) == EXPECTED["by_platform"], (
+        f"platform mismatch: spec={dict(plat)} vs EXPECTED={EXPECTED['by_platform']}"
+    )
+
+    # Time-control totals
+    tc = Counter(g["bucket"] for g in games)
+    assert dict(tc) == EXPECTED["by_time_control"], (
+        f"time_control mismatch: spec={dict(tc)} vs EXPECTED={EXPECTED['by_time_control']}"
+    )
+
+    # Rated total
+    assert sum(1 for g in games if g["rated"]) == EXPECTED["rated_total"]
+
+    # Per-color WDL from the user's perspective
+    def _outcome(result: str, color: str) -> str:
+        if result == "1/2-1/2":
+            return "draw"
+        white_won = result == "1-0"
+        user_is_white = color == "white"
+        return "win" if (white_won == user_is_white) else "loss"
+
+    for col in ("white", "black"):
+        col_games = [g for g in games if g["color"] == col]
+        wdl = Counter(_outcome(g["result"], g["color"]) for g in col_games)
+        expected_col = EXPECTED["by_color"][col]
+        assert len(col_games) == expected_col["total"], f"{col} total mismatch"
+        assert wdl["win"] == expected_col["wins"], f"{col} wins mismatch"
+        assert wdl["draw"] == expected_col["draws"], f"{col} draws mismatch"
+        assert wdl["loss"] == expected_col["losses"], f"{col} losses mismatch"
+
+    # Endgame distinct count
+    endgame_games = [g for g in games if g["endgame"] is not None]
+    assert len(endgame_games) == EXPECTED["endgame_games_distinct"]
+
+    # Endgame-by-class (distinct games per class label)
+    by_class: dict[str, int] = {}
+    for g in endgame_games:
+        for class_int in g["endgame"]:
+            by_class[_CLASS_LABEL[class_int]] = by_class.get(_CLASS_LABEL[class_int], 0) + 1
+    assert by_class == EXPECTED["endgame_by_class"], (
+        f"endgame_by_class mismatch: spec={by_class} vs EXPECTED={EXPECTED['endgame_by_class']}"
+    )
+
+    # Clock-pressure qualifying buckets: buckets with >= 10 endgame games that
+    # have clock data. The service's threshold is MIN_GAMES_FOR_CLOCK_STATS=10.
+    bucket_clock_games: dict[str, int] = {}
+    for g in endgame_games:
+        if g["clocks"] is not None:
+            bucket_clock_games[g["bucket"]] = bucket_clock_games.get(g["bucket"], 0) + 1
+    qualifying = sorted(b for b, n in bucket_clock_games.items() if n >= 10)
+    assert qualifying == EXPECTED["clock_pressure_qualifying_buckets"], (
+        f"clock_pressure qualifying buckets mismatch: "
+        f"spec={qualifying} vs EXPECTED={EXPECTED['clock_pressure_qualifying_buckets']}"
+    )
+    assert bucket_clock_games.get("blitz", 0) == EXPECTED["clock_pressure_blitz_games"]
+
+
+_verify_expected_matches_spec()
+
+
+# -----------------------------------------------------------------------------
+# Registration + seeding
+# -----------------------------------------------------------------------------
 
 
 async def _register_and_login(
@@ -205,8 +277,38 @@ async def _register_and_login(
     return user_id, email, {"Authorization": f"Bearer {token}"}
 
 
+def _clock_series_for_span(
+    span_start_ply: int,
+    user_color: str,
+    user_entry_clock: float,
+    opp_entry_clock: float,
+) -> list[float]:
+    """Return ENDGAME_PLY_THRESHOLD clock values for a span starting at
+    `span_start_ply`, with the user/opp entry clocks landing on the correct
+    ply parities.
+
+    Ply convention (from app/services/zobrist.py:158 — ply 0 stores clock
+    from move 1 = white's move): even ply → white's clock, odd ply → black's.
+    So for user_color="white", user clocks sit at even plies; for "black",
+    at odd plies. Clocks decay by 5s per ply to keep realistic monotone.
+    """
+    series: list[float] = []
+    user_parity = 0 if user_color == "white" else 1
+    user_ticks = 0  # how many user-side plies seen so far in this span
+    opp_ticks = 0
+    for offset in range(ENDGAME_PLY_THRESHOLD):
+        ply = span_start_ply + offset
+        if ply % 2 == user_parity:
+            series.append(max(0.0, user_entry_clock - 5.0 * user_ticks))
+            user_ticks += 1
+        else:
+            series.append(max(0.0, opp_entry_clock - 5.0 * opp_ticks))
+            opp_ticks += 1
+    return series
+
+
 async def _seed_portfolio(user_id: int) -> None:
-    """Commit 15 games + their positions for the registered user.
+    """Commit all _GAMES_SPEC games + their positions for the registered user.
 
     Uses the patched async_session_maker (bound to flawchess_test by
     tests/conftest.py override_get_async_session) directly, so the writes
@@ -221,6 +323,8 @@ async def _seed_portfolio(user_id: int) -> None:
     async with async_session_maker() as session:
         for idx, spec in enumerate(_GAMES_SPEC, start=1):
             color = spec["color"]
+            bucket = spec["bucket"]
+            base_time = _BASE_TIME_SECONDS[bucket]
             game = Game(
                 user_id=user_id,
                 platform=spec["platform"],
@@ -229,21 +333,23 @@ async def _seed_portfolio(user_id: int) -> None:
                 pgn="1. e4 e5 *",
                 result=spec["result"],
                 user_color=color,
-                time_control_str="600+0",
-                time_control_bucket=spec["bucket"],
-                time_control_seconds=600,
+                time_control_str=f"{base_time}+0",
+                time_control_bucket=bucket,
+                time_control_seconds=base_time,
+                base_time_seconds=base_time,
                 rated=spec["rated"],
                 is_computer_game=False,
                 white_username="seededuser" if color == "white" else "opponent",
                 black_username="opponent" if color == "white" else "seededuser",
                 white_rating=1500,
                 black_rating=1510,
+                termination=spec["termination"],
             )
             game.played_at = base_dt + datetime.timedelta(days=idx)
             session.add(game)
             await session.flush()
 
-            # Starting position (ply=0, shared hash across all 15 games)
+            # Starting position (ply=0, shared hash across all games)
             session.add(
                 GamePosition(
                     game_id=game.id,
@@ -270,32 +376,44 @@ async def _seed_portfolio(user_id: int) -> None:
 
             # Endgame spans (if specified). Each class span covers
             # ENDGAME_PLY_THRESHOLD consecutive plies starting at ply=30.
-            if spec["endgame"] is not None:
-                span_start_ply = 30
-                for class_int in spec["endgame"]:
-                    if class_int == 1:
-                        sig, imbalance = "KR_KR", 0
-                    elif class_int == 3:
-                        sig, imbalance = "KPP_KP", 100
-                    else:
-                        sig, imbalance = "KR_K", 0
-                    for offset in range(ENDGAME_PLY_THRESHOLD):
-                        session.add(
-                            GamePosition(
-                                game_id=game.id,
-                                user_id=user_id,
-                                ply=span_start_ply + offset,
-                                full_hash=STARTING_POSITION_HASH + 10_000 + idx * 100 + offset,
-                                white_hash=STARTING_POSITION_HASH + 20_000 + idx * 100 + offset,
-                                black_hash=STARTING_POSITION_HASH + 30_000 + idx * 100 + offset,
-                                piece_count=2,
-                                material_count=1000,
-                                material_signature=sig,
-                                material_imbalance=imbalance,
-                                endgame_class=class_int,
-                            )
+            if spec["endgame"] is None:
+                continue
+            span_start_ply = 30
+            clocks_spec = spec.get("clocks")
+            for class_int in spec["endgame"]:
+                sig, imbalance = _CLASS_DEFAULT[class_int]
+                # Build the clock series only for the FIRST span of each game
+                # (that's where endgame entry lies — _extract_entry_clocks only
+                # reads entry plies, and query_clock_stats_rows collapses
+                # multi-span to the earliest span).
+                clock_series: list[float | None] = [None] * ENDGAME_PLY_THRESHOLD
+                if clocks_spec is not None and span_start_ply == 30:
+                    user_ec, opp_ec = clocks_spec
+                    clock_series = [
+                        float(v)
+                        for v in _clock_series_for_span(
+                            span_start_ply, color, user_ec, opp_ec
                         )
-                    span_start_ply += ENDGAME_PLY_THRESHOLD
+                    ]
+
+                for offset in range(ENDGAME_PLY_THRESHOLD):
+                    session.add(
+                        GamePosition(
+                            game_id=game.id,
+                            user_id=user_id,
+                            ply=span_start_ply + offset,
+                            full_hash=STARTING_POSITION_HASH + 10_000 + idx * 100 + offset,
+                            white_hash=STARTING_POSITION_HASH + 20_000 + idx * 100 + offset,
+                            black_hash=STARTING_POSITION_HASH + 30_000 + idx * 100 + offset,
+                            piece_count=2,
+                            material_count=1000,
+                            material_signature=sig,
+                            material_imbalance=imbalance,
+                            endgame_class=class_int,
+                            clock_seconds=clock_series[offset],
+                        )
+                    )
+                span_start_ply += ENDGAME_PLY_THRESHOLD
 
         await session.commit()
 

--- a/tests/seed_fixtures.py
+++ b/tests/seed_fixtures.py
@@ -1,0 +1,316 @@
+"""Shared seeded-user fixture for router integration tests (Phase 61).
+
+Provides a single authoritative test user with a deterministic portfolio of
+games and positions, committed to flawchess_test so HTTP endpoints can observe
+the data through the patched async_session_maker. The seeded_user fixture is
+module-scoped: register+seed cost is paid once per test module, not once per
+test function.
+
+Expected aggregates are computed once and returned alongside the user data so
+test assertions can reference them by name rather than hand-counting.
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import pytest_asyncio
+
+from app.main import app
+from app.repositories.endgame_repository import ENDGAME_PLY_THRESHOLD
+
+# Deterministic Zobrist hash used for every game's ply=0 position so
+# /api/openings/next-moves queries at the starting position match all games.
+STARTING_POSITION_HASH: int = 0x0123456789ABCDEF
+
+
+@dataclass
+class SeededUser:
+    """Test user with a committed portfolio and derived expected aggregates."""
+
+    id: int
+    email: str
+    auth_headers: dict[str, str]
+    expected: dict[str, Any] = field(default_factory=dict)
+
+
+# Portfolio spec: 15 games across platforms, time controls, colors, results.
+# Hand-counted aggregates live in EXPECTED below and must be kept in sync with
+# this list — Plan 61-02's router tests assert against EXPECTED directly.
+_GAMES_SPEC: list[dict[str, Any]] = [
+    # platform,       bucket,       color,    result,    rated, endgame
+    {
+        "platform": "chess.com",
+        "bucket": "blitz",
+        "color": "white",
+        "result": "1-0",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "blitz",
+        "color": "white",
+        "result": "1-0",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "blitz",
+        "color": "white",
+        "result": "1/2-1/2",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "blitz",
+        "color": "black",
+        "result": "0-1",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "blitz",
+        "color": "black",
+        "result": "1-0",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "rapid",
+        "color": "white",
+        "result": "0-1",
+        "rated": True,
+        "endgame": [1],
+    },
+    {
+        "platform": "chess.com",
+        "bucket": "rapid",
+        "color": "white",
+        "result": "0-1",
+        "rated": True,
+        "endgame": [1],
+    },
+    {
+        "platform": "lichess",
+        "bucket": "blitz",
+        "color": "white",
+        "result": "1-0",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "lichess",
+        "bucket": "blitz",
+        "color": "white",
+        "result": "1-0",
+        "rated": True,
+        "endgame": [1],
+    },
+    {
+        "platform": "lichess",
+        "bucket": "bullet",
+        "color": "black",
+        "result": "1/2-1/2",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "lichess",
+        "bucket": "bullet",
+        "color": "black",
+        "result": "1/2-1/2",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "lichess",
+        "bucket": "classical",
+        "color": "white",
+        "result": "1-0",
+        "rated": True,
+        "endgame": [3],
+    },
+    {
+        "platform": "lichess",
+        "bucket": "classical",
+        "color": "white",
+        "result": "0-1",
+        "rated": True,
+        "endgame": None,
+    },
+    {
+        "platform": "lichess",
+        "bucket": "rapid",
+        "color": "white",
+        "result": "1-0",
+        "rated": False,
+        "endgame": None,
+    },
+    {
+        "platform": "lichess",
+        "bucket": "rapid",
+        "color": "white",
+        "result": "1/2-1/2",
+        "rated": True,
+        "endgame": [1, 3],
+    },  # transition
+]
+
+# Expected aggregates derived from _GAMES_SPEC. Kept explicit so the router
+# tests read as "portfolio → known numbers" rather than recomputing from spec.
+EXPECTED: dict[str, Any] = {
+    "total_games": 15,
+    "global_wdl": {"wins": 7, "draws": 4, "losses": 4},
+    "by_platform": {"chess.com": 7, "lichess": 8},
+    "by_time_control": {"bullet": 2, "blitz": 7, "rapid": 4, "classical": 2},
+    "by_color": {
+        "white": {"total": 11, "wins": 6, "draws": 2, "losses": 3},
+        "black": {"total": 4, "wins": 1, "draws": 2, "losses": 1},
+    },
+    "rated_total": 14,
+    "endgame_games_distinct": 5,  # games 6,7,9,12,15 — game 15 has two classes but counts once
+    "endgame_rook_games": 4,  # games 6,7,9,15
+    "endgame_pawn_games": 2,  # games 12,15
+    "starting_position_game_count": 15,
+}
+
+
+async def _register_and_login(
+    client: httpx.AsyncClient,
+) -> tuple[int, str, dict[str, str]]:
+    email = f"seed_{uuid.uuid4().hex[:10]}@example.com"
+    password = "seededuserpw123"
+    reg = await client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password},
+    )
+    reg.raise_for_status()
+    user_id = int(reg.json()["id"])
+
+    login = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": email, "password": password},
+    )
+    login.raise_for_status()
+    token = login.json()["access_token"]
+    return user_id, email, {"Authorization": f"Bearer {token}"}
+
+
+async def _seed_portfolio(user_id: int) -> None:
+    """Commit 15 games + their positions for the registered user.
+
+    Uses the patched async_session_maker (bound to flawchess_test by
+    tests/conftest.py override_get_async_session) directly, so the writes
+    land in the test DB and are visible to HTTP endpoints in the same run.
+    """
+    from app.core.database import async_session_maker
+    from app.models.game import Game
+    from app.models.game_position import GamePosition
+
+    base_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+
+    async with async_session_maker() as session:
+        for idx, spec in enumerate(_GAMES_SPEC, start=1):
+            color = spec["color"]
+            game = Game(
+                user_id=user_id,
+                platform=spec["platform"],
+                platform_game_id=f"seed-{idx:02d}",
+                platform_url=f"https://example.com/game/{idx}",
+                pgn="1. e4 e5 *",
+                result=spec["result"],
+                user_color=color,
+                time_control_str="600+0",
+                time_control_bucket=spec["bucket"],
+                time_control_seconds=600,
+                rated=spec["rated"],
+                is_computer_game=False,
+                white_username="seededuser" if color == "white" else "opponent",
+                black_username="opponent" if color == "white" else "seededuser",
+                white_rating=1500,
+                black_rating=1510,
+            )
+            game.played_at = base_dt + datetime.timedelta(days=idx)
+            session.add(game)
+            await session.flush()
+
+            # Starting position (ply=0, shared hash across all 15 games)
+            session.add(
+                GamePosition(
+                    game_id=game.id,
+                    user_id=user_id,
+                    ply=0,
+                    full_hash=STARTING_POSITION_HASH,
+                    white_hash=STARTING_POSITION_HASH + 1,
+                    black_hash=STARTING_POSITION_HASH + 2,
+                    move_san="e4",
+                )
+            )
+            # Game-specific ply=1 position (deterministic per-game hashes)
+            session.add(
+                GamePosition(
+                    game_id=game.id,
+                    user_id=user_id,
+                    ply=1,
+                    full_hash=STARTING_POSITION_HASH + 1000 + idx,
+                    white_hash=STARTING_POSITION_HASH + 2000 + idx,
+                    black_hash=STARTING_POSITION_HASH + 3000 + idx,
+                    move_san="e5",
+                )
+            )
+
+            # Endgame spans (if specified). Each class span covers
+            # ENDGAME_PLY_THRESHOLD consecutive plies starting at ply=30.
+            if spec["endgame"] is not None:
+                span_start_ply = 30
+                for class_int in spec["endgame"]:
+                    if class_int == 1:
+                        sig, imbalance = "KR_KR", 0
+                    elif class_int == 3:
+                        sig, imbalance = "KPP_KP", 100
+                    else:
+                        sig, imbalance = "KR_K", 0
+                    for offset in range(ENDGAME_PLY_THRESHOLD):
+                        session.add(
+                            GamePosition(
+                                game_id=game.id,
+                                user_id=user_id,
+                                ply=span_start_ply + offset,
+                                full_hash=STARTING_POSITION_HASH + 10_000 + idx * 100 + offset,
+                                white_hash=STARTING_POSITION_HASH + 20_000 + idx * 100 + offset,
+                                black_hash=STARTING_POSITION_HASH + 30_000 + idx * 100 + offset,
+                                piece_count=2,
+                                material_count=1000,
+                                material_signature=sig,
+                                material_imbalance=imbalance,
+                                endgame_class=class_int,
+                            )
+                        )
+                    span_start_ply += ENDGAME_PLY_THRESHOLD
+
+        await session.commit()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def seeded_user() -> SeededUser:
+    """Register one user + commit the deterministic portfolio; return handle."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        user_id, email, auth_headers = await _register_and_login(client)
+    await _seed_portfolio(user_id)
+    return SeededUser(
+        id=user_id,
+        email=email,
+        auth_headers=auth_headers,
+        expected=dict(EXPECTED),
+    )

--- a/tests/test_aggregation_sanity.py
+++ b/tests/test_aggregation_sanity.py
@@ -1,0 +1,505 @@
+"""Aggregation sanity tests (Phase 61).
+
+Encodes the audit gaps identified in the 2026-04-16 session. Each test seeds
+the minimum games needed via db_session (transaction rolled back per test),
+calls the service function directly, and asserts exact integers.
+
+Coverage:
+- TestWDLBlackPerspective: user plays black, WDL flips correctly from white perspective
+- TestRollingWindowBoundaries: MIN_GAMES_FOR_TIMELINE cutoff, same-day bucketing
+- TestFilterIntersection: platform AND time_control (intersection, not union)
+- TestRecencyBoundary: played_at == cutoff is inclusive (>=)
+- TestPositionDedup: same hash at multiple plies in one game counts once
+- TestEndgameClassTransition: one game crossing two endgame classes counted in both categories
+"""
+
+import datetime
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game import Game
+from app.models.game_position import GamePosition
+from app.repositories.endgame_repository import ENDGAME_PLY_THRESHOLD
+from app.repositories.query_utils import apply_game_filters
+from app.schemas.openings import (
+    OpeningsRequest,
+    TimeSeriesBookmarkParam,
+    TimeSeriesRequest,
+)
+from app.services.endgame_service import get_endgame_overview
+from app.services.openings_service import analyze as openings_analyze
+from app.services.openings_service import get_time_series
+from app.services.stats_service import get_global_stats
+
+# 700-series IDs (no other test module uses these)
+_USER_BLACK = 701
+_USER_BOTH_COLORS = 702
+_USER_ROLLING = 703
+_USER_ROLLING_SAMEDAY = 704
+_USER_FILTER = 705
+_USER_RECENCY = 706
+_USER_DEDUP = 707
+_USER_ENDGAME_TRANS = 708
+_ALL_IDS = [
+    _USER_BLACK,
+    _USER_BOTH_COLORS,
+    _USER_ROLLING,
+    _USER_ROLLING_SAMEDAY,
+    _USER_FILTER,
+    _USER_RECENCY,
+    _USER_DEDUP,
+    _USER_ENDGAME_TRANS,
+]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _create_users(db_session: AsyncSession) -> None:
+    from tests.conftest import ensure_test_user
+
+    for uid in _ALL_IDS:
+        await ensure_test_user(db_session, uid)
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+async def _seed_game(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    result: str,
+    user_color: str,
+    platform: str = "chess.com",
+    time_control_bucket: str = "blitz",
+    played_at: datetime.datetime | None = None,
+    rated: bool = True,
+) -> Game:
+    game = Game(
+        user_id=user_id,
+        platform=platform,
+        platform_game_id=_uid(),
+        pgn="1. e4 e5 *",
+        result=result,
+        user_color=user_color,
+        time_control_str="600+0",
+        time_control_bucket=time_control_bucket,
+        time_control_seconds=600,
+        rated=rated,
+        is_computer_game=False,
+        white_rating=1500,
+        black_rating=1500,
+    )
+    game.played_at = played_at or datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    session.add(game)
+    await session.flush()
+    return game
+
+
+async def _seed_position(
+    session: AsyncSession,
+    *,
+    game_id: int,
+    user_id: int,
+    ply: int,
+    full_hash: int,
+    endgame_class: int | None = None,
+    material_signature: str | None = None,
+    material_imbalance: int | None = None,
+) -> GamePosition:
+    pos = GamePosition(
+        game_id=game_id,
+        user_id=user_id,
+        ply=ply,
+        full_hash=full_hash,
+        white_hash=full_hash + 1,
+        black_hash=full_hash + 2,
+        piece_count=2 if endgame_class else None,
+        material_count=1000 if endgame_class else None,
+        material_signature=material_signature,
+        material_imbalance=material_imbalance,
+        endgame_class=endgame_class,
+    )
+    session.add(pos)
+    await session.flush()
+    return pos
+
+
+def _by_category(categories: list, name: str) -> dict | None:
+    """Find a WDLByCategory row by its label and return the count fields."""
+    for c in categories:
+        if c.label == name:
+            return {
+                "total": c.total,
+                "wins": c.wins,
+                "draws": c.draws,
+                "losses": c.losses,
+            }
+    return None
+
+
+# -----------------------------------------------------------------------------
+# TestWDLBlackPerspective
+# -----------------------------------------------------------------------------
+
+
+class TestWDLBlackPerspective:
+    """User plays black — results must flip from white's perspective."""
+
+    @pytest.mark.asyncio
+    async def test_black_win_is_user_win(self, db_session: AsyncSession) -> None:
+        await _seed_game(db_session, user_id=_USER_BLACK, result="0-1", user_color="black")
+        await db_session.commit()
+        resp = await get_global_stats(db_session, user_id=_USER_BLACK, recency=None, platform=None)
+        black = _by_category(resp.by_color, "Black")
+        assert black == {"total": 1, "wins": 1, "draws": 0, "losses": 0}
+
+    @pytest.mark.asyncio
+    async def test_black_loss_is_user_loss(self, db_session: AsyncSession) -> None:
+        await _seed_game(db_session, user_id=_USER_BLACK, result="1-0", user_color="black")
+        await db_session.commit()
+        resp = await get_global_stats(db_session, user_id=_USER_BLACK, recency=None, platform=None)
+        black = _by_category(resp.by_color, "Black")
+        assert black == {"total": 1, "wins": 0, "draws": 0, "losses": 1}
+
+    @pytest.mark.asyncio
+    async def test_mixed_black_portfolio(self, db_session: AsyncSession) -> None:
+        """3 black games: user wins, loses, draws → (1, 1, 1)."""
+        for result in ("0-1", "1-0", "1/2-1/2"):
+            await _seed_game(db_session, user_id=_USER_BLACK, result=result, user_color="black")
+        await db_session.commit()
+        resp = await get_global_stats(db_session, user_id=_USER_BLACK, recency=None, platform=None)
+        black = _by_category(resp.by_color, "Black")
+        assert black == {"total": 3, "wins": 1, "draws": 1, "losses": 1}
+
+    @pytest.mark.asyncio
+    async def test_mixed_both_colors_does_not_cross_wires(self, db_session: AsyncSession) -> None:
+        """Seed 2 white wins + 2 black wins. Ensures the per-color aggregator
+        doesn't accidentally report white perspective for black games or vice versa.
+        """
+        for _ in range(2):
+            await _seed_game(
+                db_session,
+                user_id=_USER_BOTH_COLORS,
+                result="1-0",
+                user_color="white",
+            )
+        for _ in range(2):
+            await _seed_game(
+                db_session,
+                user_id=_USER_BOTH_COLORS,
+                result="0-1",
+                user_color="black",
+            )
+        await db_session.commit()
+        resp = await get_global_stats(
+            db_session, user_id=_USER_BOTH_COLORS, recency=None, platform=None
+        )
+        white = _by_category(resp.by_color, "White")
+        black = _by_category(resp.by_color, "Black")
+        assert white == {"total": 2, "wins": 2, "draws": 0, "losses": 0}
+        assert black == {"total": 2, "wins": 2, "draws": 0, "losses": 0}
+
+
+# -----------------------------------------------------------------------------
+# TestRollingWindowBoundaries
+# -----------------------------------------------------------------------------
+
+
+class TestRollingWindowBoundaries:
+    """get_time_series rolling-window edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_fewer_games_than_min_games_returns_empty_series(
+        self, db_session: AsyncSession
+    ) -> None:
+        """MIN_GAMES_FOR_TIMELINE=10, so 5 games must produce 0 timeline points."""
+        hash_val = 99_701
+        base_dt = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        for i in range(5):
+            g = await _seed_game(
+                db_session,
+                user_id=_USER_ROLLING,
+                result="1-0",
+                user_color="white",
+                played_at=base_dt + datetime.timedelta(days=i),
+            )
+            await _seed_position(
+                db_session,
+                game_id=g.id,
+                user_id=_USER_ROLLING,
+                ply=1,
+                full_hash=hash_val,
+            )
+        await db_session.commit()
+        req = TimeSeriesRequest(
+            bookmarks=[
+                TimeSeriesBookmarkParam(bookmark_id=1, target_hash=hash_val, match_side="full")
+            ]
+        )
+        resp = await get_time_series(db_session, user_id=_USER_ROLLING, request=req)
+        assert len(resp.series) == 1
+        assert resp.series[0].data == []
+        assert resp.series[0].total_games == 5
+
+    @pytest.mark.asyncio
+    async def test_exactly_min_games_emits_first_point(self, db_session: AsyncSession) -> None:
+        """10 games on 10 distinct days → only the last day's window has game_count>=10."""
+        hash_val = 99_702
+        base_dt = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+        for i in range(10):
+            g = await _seed_game(
+                db_session,
+                user_id=_USER_ROLLING,
+                result="1-0",
+                user_color="white",
+                played_at=base_dt + datetime.timedelta(days=i),
+            )
+            await _seed_position(
+                db_session,
+                game_id=g.id,
+                user_id=_USER_ROLLING,
+                ply=1,
+                full_hash=hash_val,
+            )
+        await db_session.commit()
+        req = TimeSeriesRequest(
+            bookmarks=[
+                TimeSeriesBookmarkParam(bookmark_id=2, target_hash=hash_val, match_side="full")
+            ]
+        )
+        resp = await get_time_series(db_session, user_id=_USER_ROLLING, request=req)
+        assert len(resp.series[0].data) == 1
+        assert resp.series[0].data[0].game_count == 10
+        assert resp.series[0].data[0].win_rate == 1.0  # all wins
+
+    @pytest.mark.asyncio
+    async def test_same_day_games_collapse_to_one_point(self, db_session: AsyncSession) -> None:
+        """12 games on the same calendar day keep only the last game's window per date."""
+        hash_val = 99_703
+        base_dt = datetime.datetime(2026, 3, 1, 8, 0, 0, tzinfo=datetime.timezone.utc)
+        for i in range(12):
+            g = await _seed_game(
+                db_session,
+                user_id=_USER_ROLLING_SAMEDAY,
+                result="1-0",
+                user_color="white",
+                played_at=base_dt + datetime.timedelta(minutes=5 * i),
+            )
+            await _seed_position(
+                db_session,
+                game_id=g.id,
+                user_id=_USER_ROLLING_SAMEDAY,
+                ply=1,
+                full_hash=hash_val,
+            )
+        await db_session.commit()
+        req = TimeSeriesRequest(
+            bookmarks=[
+                TimeSeriesBookmarkParam(bookmark_id=3, target_hash=hash_val, match_side="full")
+            ]
+        )
+        resp = await get_time_series(db_session, user_id=_USER_ROLLING_SAMEDAY, request=req)
+        # Single date → single point (the last game's rolling window)
+        assert len(resp.series[0].data) == 1
+        assert resp.series[0].data[0].game_count == 12
+
+
+# -----------------------------------------------------------------------------
+# TestFilterIntersection
+# -----------------------------------------------------------------------------
+
+
+class TestFilterIntersection:
+    """platform AND time_control must intersect (not union)."""
+
+    @pytest.mark.asyncio
+    async def test_query_utils_intersects_platform_and_time_control(
+        self, db_session: AsyncSession
+    ) -> None:
+        combos = [
+            ("chess.com", "blitz"),
+            ("chess.com", "rapid"),
+            ("lichess", "blitz"),
+            ("lichess", "rapid"),
+        ]
+        for platform, bucket in combos:
+            await _seed_game(
+                db_session,
+                user_id=_USER_FILTER,
+                result="1-0",
+                user_color="white",
+                platform=platform,
+                time_control_bucket=bucket,
+            )
+        await db_session.commit()
+
+        stmt = select(Game.id).where(Game.user_id == _USER_FILTER)
+        stmt = apply_game_filters(
+            stmt,
+            time_control=["blitz"],
+            platform=["chess.com"],
+            rated=None,
+            opponent_type="human",
+            recency_cutoff=None,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 1, (
+            "platform ∩ time_control must intersect; got "
+            f"{len(rows)} rows (expected exactly 1 for chess.com+blitz)"
+        )
+
+
+# -----------------------------------------------------------------------------
+# TestRecencyBoundary
+# -----------------------------------------------------------------------------
+
+
+class TestRecencyBoundary:
+    """apply_game_filters uses >= for recency_cutoff — boundary is inclusive."""
+
+    @pytest.mark.asyncio
+    async def test_cutoff_is_inclusive_at_boundary(self, db_session: AsyncSession) -> None:
+        cutoff = datetime.datetime(2026, 1, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        await _seed_game(
+            db_session,
+            user_id=_USER_RECENCY,
+            result="1-0",
+            user_color="white",
+            played_at=cutoff,
+        )
+        await db_session.commit()
+        stmt = apply_game_filters(
+            select(Game.id).where(Game.user_id == _USER_RECENCY),
+            time_control=None,
+            platform=None,
+            rated=None,
+            opponent_type="human",
+            recency_cutoff=cutoff,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 1, "played_at == recency_cutoff must be inclusive (>=)"
+
+    @pytest.mark.asyncio
+    async def test_cutoff_excludes_one_microsecond_earlier(self, db_session: AsyncSession) -> None:
+        cutoff = datetime.datetime(2026, 2, 15, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        await _seed_game(
+            db_session,
+            user_id=_USER_RECENCY,
+            result="1-0",
+            user_color="white",
+            played_at=cutoff - datetime.timedelta(microseconds=1),
+        )
+        await db_session.commit()
+        stmt = apply_game_filters(
+            select(Game.id).where(Game.user_id == _USER_RECENCY),
+            time_control=None,
+            platform=None,
+            rated=None,
+            opponent_type="human",
+            recency_cutoff=cutoff,
+        )
+        rows = (await db_session.execute(stmt)).scalars().all()
+        assert len(rows) == 0, "game played 1µs before cutoff must be excluded"
+
+
+# -----------------------------------------------------------------------------
+# TestPositionDedup
+# -----------------------------------------------------------------------------
+
+
+class TestPositionDedup:
+    """Same full_hash at multiple plies within one game: count game once."""
+
+    @pytest.mark.asyncio
+    async def test_same_hash_multiple_plies_one_game_counted_once(
+        self, db_session: AsyncSession
+    ) -> None:
+        hash_val = 99_801
+        game = await _seed_game(db_session, user_id=_USER_DEDUP, result="1-0", user_color="white")
+        for ply in (0, 2, 4):
+            await _seed_position(
+                db_session,
+                game_id=game.id,
+                user_id=_USER_DEDUP,
+                ply=ply,
+                full_hash=hash_val,
+            )
+        await db_session.commit()
+
+        req = OpeningsRequest(target_hash=hash_val, match_side="full")
+        resp = await openings_analyze(db_session, user_id=_USER_DEDUP, request=req)
+        assert resp.stats.total == 1, (
+            "one game with 3 positions sharing the same hash must count as 1 game, "
+            f"got total={resp.stats.total}"
+        )
+        assert resp.stats.wins == 1
+        assert resp.matched_count == 1
+
+
+# -----------------------------------------------------------------------------
+# TestEndgameClassTransition
+# -----------------------------------------------------------------------------
+
+
+class TestEndgameClassTransition:
+    """One game with rook span then pawn span: both categories see +1 game."""
+
+    @pytest.mark.asyncio
+    async def test_game_with_rook_then_pawn_span_counted_in_both_classes(
+        self, db_session: AsyncSession
+    ) -> None:
+        game = await _seed_game(
+            db_session,
+            user_id=_USER_ENDGAME_TRANS,
+            result="1-0",
+            user_color="white",
+            time_control_bucket="rapid",
+        )
+        base_ply = 30
+        # Rook span (endgame_class=1)
+        for offset in range(ENDGAME_PLY_THRESHOLD):
+            await _seed_position(
+                db_session,
+                game_id=game.id,
+                user_id=_USER_ENDGAME_TRANS,
+                ply=base_ply + offset,
+                full_hash=100_000 + offset,
+                endgame_class=1,
+                material_signature="KR_KR",
+                material_imbalance=0,
+            )
+        # Pawn span (endgame_class=3)
+        for offset in range(ENDGAME_PLY_THRESHOLD):
+            await _seed_position(
+                db_session,
+                game_id=game.id,
+                user_id=_USER_ENDGAME_TRANS,
+                ply=base_ply + ENDGAME_PLY_THRESHOLD + offset,
+                full_hash=200_000 + offset,
+                endgame_class=3,
+                material_signature="KPP_KP",
+                material_imbalance=100,
+            )
+        await db_session.commit()
+
+        resp = await get_endgame_overview(
+            db_session,
+            user_id=_USER_ENDGAME_TRANS,
+            time_control=None,
+            platform=None,
+            rated=None,
+            opponent_type="human",
+            recency=None,
+        )
+        # Distinct-game count (one game, regardless of multi-class)
+        assert resp.performance.endgame_wdl.total == 1
+
+        # Per-category breakdown: both rook and pawn see this game
+        by_class = {c.endgame_class: c.total for c in resp.stats.categories}
+        assert by_class.get("rook") == 1, f"categories={by_class}"
+        assert by_class.get("pawn") == 1, f"categories={by_class}"

--- a/tests/test_integration_routers.py
+++ b/tests/test_integration_routers.py
@@ -174,6 +174,151 @@ class TestEndgamesOverviewRouter:
         rows_sum = sum(r["games"] for r in data["score_gap_material"]["material_rows"])
         assert rows_sum == data["performance"]["endgame_wdl"]["total"]
 
+    @pytest.mark.asyncio
+    async def test_all_six_endgame_classes_present(self, seeded_user: SeededUser) -> None:
+        """stats.categories includes every class from EXPECTED with the right totals."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        by_class = {c["endgame_class"]: c["total"] for c in data["stats"]["categories"]}
+        expected_by_class = seeded_user.expected["endgame_by_class"]
+        for klass, expected_total in expected_by_class.items():
+            assert by_class.get(klass) == expected_total, (
+                f"class {klass!r}: got {by_class.get(klass)} expected {expected_total} "
+                f"(full stats.categories={by_class})"
+            )
+
+
+# -----------------------------------------------------------------------------
+# TestClockPressureRouter — Phase 54 time-pressure table
+# -----------------------------------------------------------------------------
+
+
+class TestClockPressureRouter:
+    """GET /api/endgames/overview → clock_pressure sub-payload.
+
+    Only the `blitz` bucket meets MIN_GAMES_FOR_CLOCK_STATS=10 in the seeded
+    portfolio (11 blitz endgame games carry clock_seconds; rapid has 3,
+    classical has 1, bullet has 0). So `rows` must have length 1.
+    """
+
+    @pytest.mark.asyncio
+    async def test_only_blitz_bucket_qualifies(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        rows = data["clock_pressure"]["rows"]
+        buckets = sorted(r["time_control"] for r in rows)
+        assert buckets == seeded_user.expected["clock_pressure_qualifying_buckets"], (
+            f"clock_pressure buckets={buckets} "
+            f"expected={seeded_user.expected['clock_pressure_qualifying_buckets']}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_blitz_row_shape_and_counts(self, seeded_user: SeededUser) -> None:
+        """The single blitz row carries the expected game counts and a
+        well-formed average clock (between 0 and base_time_seconds=600).
+        """
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        rows = data["clock_pressure"]["rows"]
+        blitz = next((r for r in rows if r["time_control"] == "blitz"), None)
+        assert blitz is not None, f"no blitz row in {rows}"
+        assert blitz["label"] == "Blitz"
+        assert blitz["total_endgame_games"] == seeded_user.expected["clock_pressure_blitz_games"]
+        assert blitz["clock_games"] == seeded_user.expected["clock_pressure_blitz_games"]
+        # Averages must be present (clocks are fully populated) and within
+        # reasonable bounds — the 11 user/opp clocks all sit in [50, 400].
+        assert blitz["user_avg_seconds"] is not None
+        assert 0 < blitz["user_avg_seconds"] < 600
+        assert blitz["opp_avg_seconds"] is not None
+        assert 0 < blitz["opp_avg_seconds"] < 600
+        assert blitz["user_avg_pct"] is not None
+        assert 0 < blitz["user_avg_pct"] < 100
+
+    @pytest.mark.asyncio
+    async def test_net_timeout_rate_reflects_seeded_terminations(
+        self, seeded_user: SeededUser
+    ) -> None:
+        """Seed has 2 timeout wins + 1 timeout loss in blitz → net rate = +1/11 ≈ 9.09%."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        blitz = next(r for r in data["clock_pressure"]["rows"] if r["time_control"] == "blitz")
+        wins = seeded_user.expected["clock_pressure_blitz_timeout_wins"]
+        losses = seeded_user.expected["clock_pressure_blitz_timeout_losses"]
+        games = seeded_user.expected["clock_pressure_blitz_games"]
+        expected_rate = (wins - losses) / games * 100
+        assert abs(blitz["net_timeout_rate"] - expected_rate) < 0.01, (
+            f"net_timeout_rate={blitz['net_timeout_rate']} expected≈{expected_rate}"
+        )
+
+
+# -----------------------------------------------------------------------------
+# TestTimePressureChartRouter — Phase 55 time-pressure performance chart
+# -----------------------------------------------------------------------------
+
+
+class TestTimePressureChartRouter:
+    """GET /api/endgames/overview → time_pressure_chart sub-payload.
+
+    Pooled across all time controls that passed MIN_GAMES_FOR_CLOCK_STATS —
+    in the seed that is just blitz (11 games). Each of user_series and
+    opp_series has 10 bucket points (0-10%, 10-20%, ..., 90-100%).
+    """
+
+    @pytest.mark.asyncio
+    async def test_series_have_10_buckets(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        chart = data["time_pressure_chart"]
+        assert len(chart["user_series"]) == 10
+        assert len(chart["opp_series"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_total_endgame_games_matches_blitz_clock_games(
+        self, seeded_user: SeededUser
+    ) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        chart = data["time_pressure_chart"]
+        # Only blitz qualifies → the chart pools just those 11 games.
+        assert chart["total_endgame_games"] == (seeded_user.expected["clock_pressure_blitz_games"])
+
+    @pytest.mark.asyncio
+    async def test_chart_game_counts_sum_to_total(self, seeded_user: SeededUser) -> None:
+        """Sum of user_series bucket game_counts == total_endgame_games.
+
+        Each qualifying game contributes exactly one data point to user_series
+        (keyed by user's clock-remaining bucket) and one to opp_series (keyed
+        by opponent's bucket).
+        """
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        chart = data["time_pressure_chart"]
+        user_sum = sum(pt["game_count"] for pt in chart["user_series"])
+        opp_sum = sum(pt["game_count"] for pt in chart["opp_series"])
+        assert user_sum == chart["total_endgame_games"]
+        assert opp_sum == chart["total_endgame_games"]
+
 
 # -----------------------------------------------------------------------------
 # TestOpeningsNextMovesRouter

--- a/tests/test_integration_routers.py
+++ b/tests/test_integration_routers.py
@@ -1,0 +1,202 @@
+"""Router-level integration tests (Phase 61).
+
+Uses the shared seeded_user fixture to prove that the full stack
+HTTP → router → service → repository → DB produces the expected numbers
+for a known deterministic portfolio. Each test asserts exact integers
+against the EXPECTED aggregate dict committed alongside the seed spec.
+"""
+
+import httpx
+import pytest
+
+from app.main import app
+from tests.seed_fixtures import STARTING_POSITION_HASH, SeededUser
+# seeded_user fixture is provided by tests.seed_fixtures via conftest.py's
+# pytest_plugins registration — do NOT import the fixture name here or ruff
+# F811 will flag it as a redefinition against the test function parameter.
+
+_BASE = "http://test"
+
+
+def _find_by_label(items: list[dict], label: str) -> dict | None:
+    """WDLByCategory rows expose a `label` field (title-case: 'White', 'Blitz')."""
+    for c in items:
+        if c.get("label") == label:
+            return c
+    return None
+
+
+# -----------------------------------------------------------------------------
+# TestGlobalStatsRouter
+# -----------------------------------------------------------------------------
+
+
+class TestGlobalStatsRouter:
+    @pytest.mark.asyncio
+    async def test_totals_match_expected_games(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["total_games"]
+
+    @pytest.mark.asyncio
+    async def test_by_time_control_buckets_have_expected_counts(
+        self, seeded_user: SeededUser
+    ) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        for bucket, expected_total in seeded_user.expected["by_time_control"].items():
+            row = _find_by_label(data["by_time_control"], bucket.title())
+            assert row is not None, (
+                f"missing bucket {bucket.title()!r} in response; "
+                f"got labels={[c.get('label') for c in data['by_time_control']]}"
+            )
+            assert row["total"] == expected_total, (
+                f"{bucket}: got {row['total']} expected {expected_total}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_by_color_black_perspective(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        black = _find_by_label(data["by_color"], "Black")
+        assert black is not None
+        exp = seeded_user.expected["by_color"]["black"]
+        assert black["total"] == exp["total"]
+        assert black["wins"] == exp["wins"]
+        assert black["draws"] == exp["draws"]
+        assert black["losses"] == exp["losses"]
+
+    @pytest.mark.asyncio
+    async def test_by_color_white_perspective(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/stats/global", headers=seeded_user.auth_headers)
+        data = resp.json()
+        white = _find_by_label(data["by_color"], "White")
+        assert white is not None
+        exp = seeded_user.expected["by_color"]["white"]
+        assert white["total"] == exp["total"]
+        assert white["wins"] == exp["wins"]
+        assert white["draws"] == exp["draws"]
+        assert white["losses"] == exp["losses"]
+
+    @pytest.mark.asyncio
+    async def test_platform_filter_chess_com(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/stats/global?platform=chess.com",
+                headers=seeded_user.auth_headers,
+            )
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["by_platform"]["chess.com"]
+
+    @pytest.mark.asyncio
+    async def test_platform_filter_lichess(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get(
+                "/api/stats/global?platform=lichess",
+                headers=seeded_user.auth_headers,
+            )
+        data = resp.json()
+        total = sum(c["total"] for c in data["by_time_control"])
+        assert total == seeded_user.expected["by_platform"]["lichess"]
+
+
+# -----------------------------------------------------------------------------
+# TestEndgamesOverviewRouter
+# -----------------------------------------------------------------------------
+
+
+class TestEndgamesOverviewRouter:
+    @pytest.mark.asyncio
+    async def test_endgame_wdl_total(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert (
+            data["performance"]["endgame_wdl"]["total"]
+            == (seeded_user.expected["endgame_games_distinct"])
+        )
+
+    @pytest.mark.asyncio
+    async def test_per_type_rook_count(self, seeded_user: SeededUser) -> None:
+        """stats.categories contains a row per endgame_class with a total count."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        by_class = {c["endgame_class"]: c["total"] for c in data["stats"]["categories"]}
+        assert by_class.get("rook") == seeded_user.expected["endgame_rook_games"], (
+            f"stats.categories={by_class}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_per_type_pawn_count(self, seeded_user: SeededUser) -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        by_class = {c["endgame_class"]: c["total"] for c in data["stats"]["categories"]}
+        assert by_class.get("pawn") == seeded_user.expected["endgame_pawn_games"], (
+            f"stats.categories={by_class}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_material_rows_sum_equals_endgame_total(self, seeded_user: SeededUser) -> None:
+        """Phase 59 invariant verified at the router layer with real seeded data."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.get("/api/endgames/overview", headers=seeded_user.auth_headers)
+        data = resp.json()
+        rows_sum = sum(r["games"] for r in data["score_gap_material"]["material_rows"])
+        assert rows_sum == data["performance"]["endgame_wdl"]["total"]
+
+
+# -----------------------------------------------------------------------------
+# TestOpeningsNextMovesRouter
+# -----------------------------------------------------------------------------
+
+
+class TestOpeningsNextMovesRouter:
+    @pytest.mark.asyncio
+    async def test_starting_position_matches_all_seeded_games(
+        self, seeded_user: SeededUser
+    ) -> None:
+        """Every seeded game has a ply=0 GamePosition at STARTING_POSITION_HASH."""
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url=_BASE
+        ) as client:
+            resp = await client.post(
+                "/api/openings/next-moves",
+                headers=seeded_user.auth_headers,
+                json={"target_hash": str(STARTING_POSITION_HASH)},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert (
+            data["position_stats"]["total"]
+            == (seeded_user.expected["starting_position_game_count"])
+        )

--- a/tests/test_material_tally.py
+++ b/tests/test_material_tally.py
@@ -1,0 +1,83 @@
+"""Material tally sanity tests (Phase 61).
+
+Verifies that position_classifier's pure functions correctly compute material
+metrics from python-chess boards. These tests catch regressions in piece
+values, sign conventions, and signature ordering before they reach the DB.
+"""
+
+import chess
+
+from app.services.position_classifier import (
+    _compute_material_count,
+    _compute_material_imbalance,
+    _compute_material_signature,
+)
+
+
+class TestMaterialCount:
+    """_compute_material_count returns total centipawns for both sides combined."""
+
+    def test_starting_position_is_7800(self) -> None:
+        """Starting material = 2 × (Q + 2R + 2B + 2N + 8P) = 2 × 3900 = 7800 cp."""
+        assert _compute_material_count(chess.Board()) == 7800
+
+    def test_empty_board_is_zero(self) -> None:
+        board = chess.Board()
+        board.clear()
+        assert _compute_material_count(board) == 0
+
+    def test_after_white_captures_pawn(self) -> None:
+        """1. e4 d5 2. exd5 — white captures a black pawn; total drops 100 cp."""
+        board = chess.Board()
+        for move in ("e4", "d5", "exd5"):
+            board.push_san(move)
+        assert _compute_material_count(board) == 7700
+
+
+class TestMaterialImbalance:
+    """_compute_material_imbalance returns signed (white − black) centipawns."""
+
+    def test_starting_is_zero(self) -> None:
+        assert _compute_material_imbalance(chess.Board()) == 0
+
+    def test_white_up_a_pawn(self) -> None:
+        """After 1. e4 d5 2. exd5, white is up one pawn = +100 cp."""
+        board = chess.Board()
+        for move in ("e4", "d5", "exd5"):
+            board.push_san(move)
+        assert _compute_material_imbalance(board) == 100
+
+    def test_black_up_a_rook(self) -> None:
+        """FEN with white's a1 rook removed → black is up 500 cp = -500 imbalance."""
+        board = chess.Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/1NBQKBNR w Kkq - 0 1")
+        assert _compute_material_imbalance(board) == -500
+
+    def test_both_sides_missing_queen_is_zero_imbalance(self) -> None:
+        """FEN with no queens on either side → imbalance == 0 (equal material)."""
+        board = chess.Board(
+            "rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1"
+        )
+        assert _compute_material_imbalance(board) == 0
+
+
+class TestMaterialSignature:
+    """_compute_material_signature returns canonical 'white_black' piece strings."""
+
+    def test_starting_signature(self) -> None:
+        sig = _compute_material_signature(chess.Board())
+        assert sig == "KQRRBBNNPPPPPPPP_KQRRBBNNPPPPPPPP"
+
+    def test_white_before_black(self) -> None:
+        """Starting position is symmetric — both sides have identical piece strings."""
+        sig = _compute_material_signature(chess.Board())
+        assert "_" in sig
+        white, black = sig.split("_")
+        assert white == black
+        assert white.startswith("K")
+
+    def test_missing_white_queen(self) -> None:
+        """Remove white queen via FEN; signature's white half must not contain Q."""
+        board = chess.Board("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1")
+        sig = _compute_material_signature(board)
+        white, _black = sig.split("_")
+        assert "Q" not in white

--- a/tests/test_material_tally.py
+++ b/tests/test_material_tally.py
@@ -54,9 +54,7 @@ class TestMaterialImbalance:
 
     def test_both_sides_missing_queen_is_zero_imbalance(self) -> None:
         """FEN with no queens on either side → imbalance == 0 (equal material)."""
-        board = chess.Board(
-            "rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1"
-        )
+        board = chess.Board("rnb1kbnr/pppppppp/8/8/8/8/PPPPPPPP/RNB1KBNR w KQkq - 0 1")
         assert _compute_material_imbalance(board) == 0
 
 


### PR DESCRIPTION
## Summary
- Isolate the test database with a session-level truncate + shared `seeded_user` fixture (25-game portfolio)
- Add aggregation sanity, material-tally, and router integration tests to lock down the analytics surface
- Expand endgame/time-pressure router coverage and sync phase verification docs

## Test plan
- [ ] `uv run pytest` passes against a fresh `flawchess_test` DB
- [ ] `uv run pytest -k integration_routers` green
- [ ] `uv run ruff check .` and `uv run ty check app/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)