### PR TITLE
Mobile font-size bump + Global Stats → Overview rename

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,14 +51,14 @@ const NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/global-stats', label: 'Overview', Icon: BarChart3Icon },
+  { to: '/overview', label: 'Overview', Icon: BarChart3Icon },
 ] as const;
 
 const BOTTOM_NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/global-stats', label: 'Overview', Icon: BarChart3Icon },
+  { to: '/overview', label: 'Overview', Icon: BarChart3Icon },
 ] as const;
 
 // D-16: Admin nav item appended at render time when profile.is_superuser === true.
@@ -71,7 +71,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/import': 'Import',
   '/openings': 'Openings',
   '/endgames': 'Endgames',
-  '/global-stats': 'Overview',
+  '/overview': 'Overview',
   '/admin': 'Admin',
 };
 
@@ -444,8 +444,9 @@ function AppRoutes() {
           <Route path="/import" element={<ImportPage onImportStarted={handleImportStarted} activeJobIds={activeJobIds} onJobDismissed={handleJobDismissed} />} />
           <Route path="/openings/*" element={<OpeningsPage />} />
           <Route path="/endgames/*" element={<EndgamesPage />} />
-          <Route path="/rating" element={<Navigate to="/global-stats" replace />} />
-          <Route path="/global-stats" element={<GlobalStatsPage />} />
+          <Route path="/rating" element={<Navigate to="/overview" replace />} />
+          <Route path="/global-stats" element={<Navigate to="/overview" replace />} />
+          <Route path="/overview" element={<GlobalStatsPage />} />
           <Route path="/admin" element={<SuperuserRoute><AdminPage /></SuperuserRoute>} />
         </Route>
         {/* Catch-all redirects to homepage */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { DownloadIcon, BookOpenIcon, BarChart3Icon, MenuIcon, LogOutIcon, TrophyIcon, DoorOpen, Shield } from 'lucide-react';
+import { DownloadIcon, BookOpenIcon, LayoutDashboard, MenuIcon, LogOutIcon, TrophyIcon, DoorOpen, Shield } from 'lucide-react';
 import {
   Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerClose,
 } from '@/components/ui/drawer';
@@ -51,14 +51,14 @@ const NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/overview', label: 'Overview', Icon: BarChart3Icon },
+  { to: '/overview', label: 'Overview', Icon: LayoutDashboard },
 ] as const;
 
 const BOTTOM_NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/overview', label: 'Overview', Icon: BarChart3Icon },
+  { to: '/overview', label: 'Overview', Icon: LayoutDashboard },
 ] as const;
 
 // D-16: Admin nav item appended at render time when profile.is_superuser === true.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,14 +51,14 @@ const NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/global-stats', label: 'Global Stats', Icon: BarChart3Icon },
+  { to: '/global-stats', label: 'Overview', Icon: BarChart3Icon },
 ] as const;
 
 const BOTTOM_NAV_ITEMS = [
   { to: '/import', label: 'Import', Icon: DownloadIcon },
   { to: '/openings', label: 'Openings', Icon: BookOpenIcon },
   { to: '/endgames', label: 'Endgames', Icon: TrophyIcon },
-  { to: '/global-stats', label: 'Global Stats', Icon: BarChart3Icon },
+  { to: '/global-stats', label: 'Overview', Icon: BarChart3Icon },
 ] as const;
 
 // D-16: Admin nav item appended at render time when profile.is_superuser === true.
@@ -71,7 +71,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/import': 'Import',
   '/openings': 'Openings',
   '/endgames': 'Endgames',
-  '/global-stats': 'Global Stats',
+  '/global-stats': 'Overview',
   '/admin': 'Admin',
 };
 

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -347,7 +347,7 @@ export function FilterPanel({
         </Button>
         {showDeferredApplyHint && (
           <p
-            className="mt-2 text-[11px] leading-tight text-muted-foreground"
+            className="mt-2 text-xs leading-tight text-muted-foreground"
             data-testid="filter-deferred-apply-hint"
           >
             Filter changes apply on closing the filters panel.

--- a/frontend/src/components/stats/MiniWDLBar.tsx
+++ b/frontend/src/components/stats/MiniWDLBar.tsx
@@ -16,7 +16,7 @@ export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-5" }:
     <div className={`flex ${heightClass} w-full min-w-[80px] overflow-hidden rounded-sm`} data-testid="mini-wdl-bar">
       {win_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[11px] font-medium"
+          className="relative flex items-center justify-center text-xs font-medium"
           style={{ width: `${win_pct}%`, backgroundColor: WDL_WIN }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
@@ -27,7 +27,7 @@ export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-5" }:
       )}
       {draw_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[11px] font-medium"
+          className="relative flex items-center justify-center text-xs font-medium"
           style={{ width: `${draw_pct}%`, backgroundColor: WDL_DRAW }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />
@@ -38,7 +38,7 @@ export function MiniWDLBar({ win_pct, draw_pct, loss_pct, heightClass = "h-5" }:
       )}
       {loss_pct > 0 && (
         <div
-          className="relative flex items-center justify-center text-[11px] font-medium"
+          className="relative flex items-center justify-center text-xs font-medium"
           style={{ width: `${loss_pct}%`, backgroundColor: WDL_LOSS }}
         >
           <div className="absolute inset-0" style={{ background: GLASS_OVERLAY }} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -155,17 +155,6 @@
   .font-brand {
     font-family: 'Fredoka', sans-serif;
     }
-
-  /* Mobile typography bump.
-     Below the sm: breakpoint, lift Tailwind's default type scale by one tier so
-     small labels, filter chips, table captions, and body copy match typical
-     mobile-app sizing. Desktop (>=640px) is untouched. Spacing tokens are not
-     touched, so chess board, filter row, and grid layouts stay put. */
-  @media (max-width: 639.98px) {
-    .text-xs { font-size: 0.875rem; line-height: 1.25rem; }
-    .text-sm { font-size: 1rem; line-height: 1.5rem; }
-    .text-base { font-size: 1.125rem; line-height: 1.75rem; }
-  }
 }
 
 @layer components {
@@ -229,4 +218,17 @@
 .animate-progress-indeterminate {
   width: 40%;
   animation: progress-indeterminate 1.5s ease-in-out infinite;
+}
+
+/* Mobile typography bump.
+   Below the sm: breakpoint, lift Tailwind's default type scale by one tier so
+   labels, filter chips, table captions, and body copy match typical mobile-app
+   sizing. Desktop (>=640px) is untouched. Spacing tokens are not touched, so
+   chess board, filter row, and grid layouts stay put.
+   Kept unlayered (outside @layer) so it wins over Tailwind utility-layer
+   .text-xs / .text-sm / .text-base in the cascade. */
+@media (max-width: 639.98px) {
+  .text-xs { font-size: 0.875rem; line-height: 1.25rem; }
+  .text-sm { font-size: 1rem; line-height: 1.5rem; }
+  .text-base { font-size: 1.125rem; line-height: 1.75rem; }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -155,6 +155,17 @@
   .font-brand {
     font-family: 'Fredoka', sans-serif;
     }
+
+  /* Mobile typography bump.
+     Below the sm: breakpoint, lift Tailwind's default type scale by one tier so
+     small labels, filter chips, table captions, and body copy match typical
+     mobile-app sizing. Desktop (>=640px) is untouched. Spacing tokens are not
+     touched, so chess board, filter row, and grid layouts stay put. */
+  @media (max-width: 639.98px) {
+    .text-xs { font-size: 0.875rem; line-height: 1.25rem; }
+    .text-sm { font-size: 1rem; line-height: 1.5rem; }
+    .text-base { font-size: 1.125rem; line-height: 1.75rem; }
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

- Bump mobile font sizes one tier (12→14, 14→16, 16→18px) below the `sm:` breakpoint via an unlayered media-query override in `index.css`. Desktop unchanged. Spacing tokens untouched.
- Drop two `text-[11px]` holdouts (MiniWDLBar segments, FilterPanel deferred-apply hint) down to `text-xs` so nothing renders below 14px on mobile.
- Rename "Global Stats" tab → "Overview" (desktop nav, mobile bottom nav, mobile header). Route renamed `/global-stats` → `/overview` with a backward-compat redirect so old bookmarks keep working. Tab icon swapped from `BarChart3` to `LayoutDashboard`.

Internal symbols (`GlobalStatsPage`, `useGlobalStats`, `data-testid="global-stats-page"`, etc.) and the `/stats/global` API path are unchanged to keep test selectors and the backend stable.

## Test plan

- [ ] Mobile (<640px): labels, filter chips, table captions, body copy all read at the bumped tier
- [ ] Desktop (>=640px): unchanged
- [ ] Overview tab visible in desktop top nav and mobile bottom nav with LayoutDashboard icon
- [ ] Visiting /global-stats redirects to /overview
- [ ] Visiting /rating redirects to /overview
- [ ] Filter panel time-control toggle row doesn't overflow at 360px

🤖 Generated with [Claude Code](https://claude.com/claude-code)