### PR TITLE
Force grey arrow when confidence is low

### DIFF
--- a/frontend/src/components/move-explorer/MoveExplorer.tsx
+++ b/frontend/src/components/move-explorer/MoveExplorer.tsx
@@ -169,7 +169,7 @@ export function MoveExplorer({
                   <InfoPopover ariaLabel="Move arrows info" testId="move-arrows-info" side="top">
                     <div className="space-y-2">
                       <p>
-                        These are the moves that occurred next in the position shown on the board, over all the games that match the current filter settings. Moves with fewer than 10 games have unreliable statistics and are shown as muted.
+                        These are the moves that occurred next in the position shown on the board, over all the games that match the current filter settings. Moves with fewer than 10 games or low confidence are always grey. Rows with fewer than 10 games are also dimmed since their statistics are unreliable.
                       </p>
                       <p>
                         On desktop, click a move to play it. On mobile, tap to highlight (shows the arrow on the board), then tap again to play.
@@ -248,7 +248,7 @@ function MoveRow({ entry, selectedMove, onRowClick, onRowKeyDown, onMoveHover, h
   // chessboard arrow uses (green for strengths, red for weaknesses). Grey
   // (neutral or below the color threshold) means no tint. The deep-link
   // highlight reuses the same color and adds the pulse animation on top.
-  const arrowColor = getArrowColor(entry.score, entry.game_count, false);
+  const arrowColor = getArrowColor(entry.score, entry.game_count, entry.confidence, false);
   const severityColor = arrowColor === GREY ? null : arrowColor;
   const tintColor = highlightColor ?? severityColor;
 

--- a/frontend/src/lib/arrowColor.test.ts
+++ b/frontend/src/lib/arrowColor.test.ts
@@ -13,73 +13,92 @@ import {
 describe('getArrowColor (Phase 76 — score-based)', () => {
   describe('below-min-games guard', () => {
     it('returns GREY when gameCount < MIN_GAMES_FOR_COLOR (10) and not hovered', () => {
-      expect(getArrowColor(0.65, 9, false)).toBe(GREY);
-      expect(getArrowColor(0.30, 9, false)).toBe(GREY);
+      expect(getArrowColor(0.65, 9, 'high', false)).toBe(GREY);
+      expect(getArrowColor(0.30, 9, 'high', false)).toBe(GREY);
     });
 
     it('returns HOVER_BLUE when hovered, even below MIN_GAMES_FOR_COLOR', () => {
-      expect(getArrowColor(0.65, 9, true)).toBe(HOVER_BLUE);
-      expect(getArrowColor(0.30, 9, true)).toBe(HOVER_BLUE);
+      expect(getArrowColor(0.65, 9, 'high', true)).toBe(HOVER_BLUE);
+      expect(getArrowColor(0.30, 9, 'high', true)).toBe(HOVER_BLUE);
+    });
+  });
+
+  describe('low-confidence guard', () => {
+    it('returns GREY when confidence is low, regardless of score', () => {
+      expect(getArrowColor(0.65, 20, 'low', false)).toBe(GREY);
+      expect(getArrowColor(0.30, 20, 'low', false)).toBe(GREY);
+      expect(getArrowColor(0.80, 100, 'low', false)).toBe(GREY);
+    });
+
+    it('returns HOVER_BLUE when hovered, even with low confidence', () => {
+      expect(getArrowColor(0.65, 20, 'low', true)).toBe(HOVER_BLUE);
     });
   });
 
   describe('hover short-circuit', () => {
     it('returns HOVER_BLUE on hover regardless of score', () => {
-      expect(getArrowColor(0.50, 20, true)).toBe(HOVER_BLUE);
-      expect(getArrowColor(0.80, 20, true)).toBe(HOVER_BLUE);
-      expect(getArrowColor(0.20, 20, true)).toBe(HOVER_BLUE);
+      expect(getArrowColor(0.50, 20, 'high', true)).toBe(HOVER_BLUE);
+      expect(getArrowColor(0.80, 20, 'high', true)).toBe(HOVER_BLUE);
+      expect(getArrowColor(0.20, 20, 'high', true)).toBe(HOVER_BLUE);
     });
   });
 
   describe('neutral grey zone (strict boundaries)', () => {
     it('returns GREY at exact pivot 0.50', () => {
-      expect(getArrowColor(0.50, 20, false)).toBe(GREY);
+      expect(getArrowColor(0.50, 20, 'high', false)).toBe(GREY);
     });
 
     it('returns GREY just above pivot but below MINOR threshold (0.55)', () => {
-      expect(getArrowColor(0.501, 20, false)).toBe(GREY);
-      expect(getArrowColor(0.549, 20, false)).toBe(GREY);
+      expect(getArrowColor(0.501, 20, 'high', false)).toBe(GREY);
+      expect(getArrowColor(0.549, 20, 'high', false)).toBe(GREY);
     });
 
     it('returns GREY just above LIGHT_RED threshold (<=0.45) — i.e. 0.451', () => {
-      expect(getArrowColor(0.451, 20, false)).toBe(GREY);
-      expect(getArrowColor(0.499, 20, false)).toBe(GREY);
+      expect(getArrowColor(0.451, 20, 'high', false)).toBe(GREY);
+      expect(getArrowColor(0.499, 20, 'high', false)).toBe(GREY);
     });
   });
 
   describe('green buckets (positive score)', () => {
     it('returns LIGHT_GREEN at exact MINOR threshold 0.55', () => {
-      expect(getArrowColor(0.55, 20, false)).toBe(LIGHT_GREEN);
+      expect(getArrowColor(0.55, 20, 'high', false)).toBe(LIGHT_GREEN);
     });
 
     it('returns LIGHT_GREEN just below MAJOR threshold 0.60', () => {
-      expect(getArrowColor(0.599, 20, false)).toBe(LIGHT_GREEN);
+      expect(getArrowColor(0.599, 20, 'high', false)).toBe(LIGHT_GREEN);
     });
 
     it('returns DARK_GREEN at exact MAJOR threshold 0.60', () => {
-      expect(getArrowColor(0.60, 20, false)).toBe(DARK_GREEN);
+      expect(getArrowColor(0.60, 20, 'high', false)).toBe(DARK_GREEN);
     });
 
     it('returns DARK_GREEN at extreme score 0.80', () => {
-      expect(getArrowColor(0.80, 20, false)).toBe(DARK_GREEN);
+      expect(getArrowColor(0.80, 20, 'high', false)).toBe(DARK_GREEN);
     });
   });
 
   describe('red buckets (negative score)', () => {
     it('returns LIGHT_RED at exact MINOR threshold 0.45', () => {
-      expect(getArrowColor(0.45, 20, false)).toBe(LIGHT_RED);
+      expect(getArrowColor(0.45, 20, 'high', false)).toBe(LIGHT_RED);
     });
 
     it('returns LIGHT_RED just above MAJOR threshold 0.40 — i.e. 0.401', () => {
-      expect(getArrowColor(0.401, 20, false)).toBe(LIGHT_RED);
+      expect(getArrowColor(0.401, 20, 'high', false)).toBe(LIGHT_RED);
     });
 
     it('returns DARK_RED at exact MAJOR threshold 0.40', () => {
-      expect(getArrowColor(0.40, 20, false)).toBe(DARK_RED);
+      expect(getArrowColor(0.40, 20, 'high', false)).toBe(DARK_RED);
     });
 
     it('returns DARK_RED at extreme score 0.20', () => {
-      expect(getArrowColor(0.20, 20, false)).toBe(DARK_RED);
+      expect(getArrowColor(0.20, 20, 'high', false)).toBe(DARK_RED);
+    });
+  });
+
+  describe('medium confidence', () => {
+    it('returns colored arrow when confidence is medium and score is significant', () => {
+      expect(getArrowColor(0.60, 20, 'medium', false)).toBe(DARK_GREEN);
+      expect(getArrowColor(0.40, 20, 'medium', false)).toBe(DARK_RED);
     });
   });
 });
@@ -113,20 +132,20 @@ describe('arrowSortKey', () => {
     expect(arrowSortKey('#123456')).toBe(2);
   });
 
-  // Verify sort keys via getArrowColor round-trip (new score-based signature)
+  // Verify sort keys via getArrowColor round-trip
   it('hovered color from getArrowColor has sort key -1', () => {
-    expect(arrowSortKey(getArrowColor(0.65, 20, true))).toBe(-1);
+    expect(arrowSortKey(getArrowColor(0.65, 20, 'high', true))).toBe(-1);
   });
 
   it('green color from getArrowColor has sort key 0', () => {
-    expect(arrowSortKey(getArrowColor(0.65, 20, false))).toBe(0);
+    expect(arrowSortKey(getArrowColor(0.65, 20, 'high', false))).toBe(0);
   });
 
   it('red color from getArrowColor has sort key 1', () => {
-    expect(arrowSortKey(getArrowColor(0.20, 20, false))).toBe(1);
+    expect(arrowSortKey(getArrowColor(0.20, 20, 'high', false))).toBe(1);
   });
 
   it('grey color from getArrowColor has sort key 2', () => {
-    expect(arrowSortKey(getArrowColor(0.50, 20, false))).toBe(2);
+    expect(arrowSortKey(getArrowColor(0.50, 20, 'high', false))).toBe(2);
   });
 });

--- a/frontend/src/lib/arrowColor.ts
+++ b/frontend/src/lib/arrowColor.ts
@@ -25,19 +25,28 @@ export const HOVER_BLUE = '#3B82F6';
  * Returns a categorical hex color string for a board arrow / row tint based on
  * chess score (W + 0.5*D)/N.
  *
- * Encoding is effect-size-only (Phase 75 / 76 design lock — no confidence cue
- * on arrows). Strict >= / <= boundaries match the backend classification in
+ * Strict >= / <= boundaries match the backend classification in
  * app/services/opening_insights_service.py.
  *
- * @param score     Score in [0, 1]. The pivot is 0.50 (break-even).
- * @param gameCount Absolute game count for this move. Below MIN_GAMES_FOR_COLOR
- *                  (10), the function falls back to GREY (or HOVER_BLUE if
- *                  hovered) — small samples never carry color.
- * @param isHovered Whether this arrow is currently hovered by the user.
+ * @param score      Score in [0, 1]. The pivot is 0.50 (break-even).
+ * @param gameCount  Absolute game count for this move. Below MIN_GAMES_FOR_COLOR
+ *                   (10), the function falls back to GREY (or HOVER_BLUE if
+ *                   hovered) — small samples never carry color.
+ * @param confidence Statistical confidence ('low' | 'medium' | 'high'). 'low'
+ *                   collapses to GREY (or HOVER_BLUE if hovered) — the effect
+ *                   could plausibly be chance, so we don't encode it as a
+ *                   strength/weakness.
+ * @param isHovered  Whether this arrow is currently hovered by the user.
  */
-export function getArrowColor(score: number, gameCount: number, isHovered: boolean): string {
+export function getArrowColor(
+  score: number,
+  gameCount: number,
+  confidence: 'low' | 'medium' | 'high',
+  isHovered: boolean,
+): string {
   if (isHovered) return HOVER_BLUE;
   if (gameCount < MIN_GAMES_FOR_COLOR) return GREY;
+  if (confidence === 'low') return GREY;
 
   // Order matters: dark before light on each side. Strict >= / <= boundaries.
   if (score >= SCORE_PIVOT + MAJOR_EFFECT_SCORE) return DARK_GREEN;   // >= 0.60

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -404,7 +404,7 @@ export function OpeningsPage() {
         return {
           startSquare: squares.from,
           endSquare: squares.to,
-          color: getArrowColor(entry.score, entry.game_count, isHovered),
+          color: getArrowColor(entry.score, entry.game_count, entry.confidence, isHovered),
           width: entry.game_count / maxCount,
           isHovered,
           isHighlightPulse,


### PR DESCRIPTION
## Summary

- `getArrowColor` now also returns `GREY` when `confidence === 'low'`, in addition to the existing `gameCount < 10` guard. Moves whose effect could plausibly be chance no longer get the green/red strength/weakness treatment.
- Both call sites (`MoveExplorer.tsx` row tint and `Openings.tsx` board arrow) pass `entry.confidence` through.
- Updated the Move Explorer "Move arrows info" popover copy to explain the rule: *"Moves with fewer than 10 games or low confidence are always grey. Rows with fewer than 10 games are also dimmed since their statistics are unreliable."*

This is a small follow-up to Phase 76 (#70) — same color encoding, just one more reason to fall back to grey.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` clean
- [x] `arrowColor.test.ts` 28/28 (new low-confidence and medium-confidence cases added)
- [x] `move-explorer` tests 13/13
- [x] Manual: load a position with a low-confidence move that would otherwise be green/red; verify arrow + row are grey on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)