### PR TITLE
Quick 260429-gmj: Insights finding card after-move arrow

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -113,9 +113,10 @@ Carried forward from v1.11 close (still relevant):
 | 260428-oxr | Replace Wald CI half-width confidence buckets with p-value thresholds and N>=10 gate | 2026-04-28 | f29617d | [260428-oxr-replace-wald-ci-half-width-confidence-bu](./quick/260428-oxr-replace-wald-ci-half-width-confidence-bu/) |
 | 260428-tgg | Sort opening insights findings by Wald CI bound (direction-aware tiebreak replacing effect-size) | 2026-04-28 | 45c5a20 | [260428-tgg-sort-opening-insights-findings-by-wald-c](./quick/260428-tgg-sort-opening-insights-findings-by-wald-c/) |
 | 260428-v9i | Switch opening insights ranking from Wald CI bound to Wilson score interval bound | 2026-04-28 | 0715fda | [260428-v9i-switch-opening-insights-ranking-from-wal](./quick/260428-v9i-switch-opening-insights-ranking-from-wal/) |
+| 260429-gmj | Insights finding cards: arrow for after-move on mini board | 2026-04-29 | de187ed | [260429-gmj-insights-finding-cards-arrow-for-after-m](./quick/260429-gmj-insights-finding-cards-arrow-for-after-m/) |
 
 ---
-Last activity: 2026-04-28 — Completed quick task 260428-v9i: Switch opening insights ranking from Wald CI bound to Wilson score interval bound.
+Last activity: 2026-04-29 — Completed quick task 260429-gmj: Insights finding cards: arrow for after-move on mini board.
 | 2026-04-27 | fast | Mobile: Moves/Games links beside mini board in OpeningFindingCard | ✅ |
 | 2026-04-27 | fast | widen game card WDL left border | ✅ |
 

--- a/.planning/quick/260429-gmj-insights-finding-cards-arrow-for-after-m/260429-gmj-PLAN.md
+++ b/.planning/quick/260429-gmj-insights-finding-cards-arrow-for-after-m/260429-gmj-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: quick-260429-gmj
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - frontend/src/components/board/MiniBoard.tsx
+  - frontend/src/components/board/LazyMiniBoard.tsx
+  - frontend/src/components/insights/OpeningFindingCard.tsx
+  - frontend/src/components/insights/OpeningFindingCard.test.tsx
+  - frontend/src/lib/sanToSquares.ts
+  - frontend/src/lib/sanToSquares.test.ts
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "Each Insights finding card mini-board renders a fine arrow from the candidate move's from-square to its to-square"
+    - "The arrow color matches the card's score-derived border color (DARK_RED / LIGHT_RED / DARK_GREEN / LIGHT_GREEN)"
+    - "The arrow is visually thinner than the main MoveExplorer board arrows (fine, not heavy)"
+    - "No color hex strings are introduced inline in components — colors come from arrowColor.ts/theme.ts only"
+    - "Mobile and desktop card layouts both render the arrow (no parity gap)"
+    - "Arrow rendering does not break for unreliable findings (n_games < 10 or confidence === 'low'); it inherits the same UNRELIABLE_OPACITY fade as the rest of the card"
+  artifacts:
+    - path: "frontend/src/lib/sanToSquares.ts"
+      provides: "Pure helper: (fen, san) -> { from, to } | null using chess.js"
+    - path: "frontend/src/components/board/MiniBoard.tsx"
+      provides: "Optional arrows prop with absolutely-positioned SVG overlay"
+  key_links:
+    - from: "OpeningFindingCard.tsx"
+      to: "sanToSquares.ts"
+      via: "sanToSquares(finding.entry_fen, finding.candidate_move_san)"
+      pattern: "sanToSquares\\("
+    - from: "OpeningFindingCard.tsx"
+      to: "MiniBoard arrows prop"
+      via: "LazyMiniBoard arrows={[{ from, to, color: borderLeftColor }]}"
+      pattern: "arrows=\\{"
+---
+
+<objective>
+Draw a fine, score-colored arrow on each Insights finding card's mini chessboard, from the "from" square to the "to" square of the candidate (after-) move.
+
+Purpose: Make findings instantly readable at a glance — the user sees both the position AND which move scored well/poorly, without having to read the SAN text or click through to the Move Explorer.
+
+Output: Updated MiniBoard with optional arrow overlay; OpeningFindingCard wires score-colored arrows for each finding; unit tests cover SAN→squares conversion and arrow rendering.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+</execution_context>
+
+<context>
+@./CLAUDE.md
+@frontend/src/components/insights/OpeningFindingCard.tsx
+@frontend/src/components/insights/OpeningFindingCard.test.tsx
+@frontend/src/components/board/MiniBoard.tsx
+@frontend/src/components/board/LazyMiniBoard.tsx
+@frontend/src/components/board/ChessBoard.tsx
+@frontend/src/lib/arrowColor.ts
+@frontend/src/lib/openingInsights.ts
+@frontend/src/types/insights.ts
+@frontend/src/lib/theme.ts
+
+<interfaces>
+<!-- Existing primitives the executor must reuse — do NOT reinvent these. -->
+
+From frontend/src/lib/arrowColor.ts:
+```typescript
+export const DARK_RED   = '#9B1C1C';
+export const LIGHT_RED  = '#E07070';
+export const DARK_GREEN = '#1E6B1E';
+export const LIGHT_GREEN = '#6BBF59';
+export const GREY       = '#B0B0B0';
+```
+
+From frontend/src/lib/openingInsights.ts:
+```typescript
+// Already used by OpeningFindingCard — returns the same hex the arrow should adopt.
+export function getSeverityBorderColor(
+  classification: OpeningInsightFinding['classification'],
+  severity:       OpeningInsightFinding['severity'],
+): string;
+```
+
+From frontend/src/types/insights.ts (OpeningInsightFinding fields used):
+```typescript
+entry_fen:           string;   // position BEFORE candidate move
+candidate_move_san:  string;   // SAN like "Be2", "Nxd4", "O-O"
+classification, severity, color, ...
+```
+
+From chess.js (already a dep, used in useChessGame.ts and zobrist.ts):
+```typescript
+import { Chess } from 'chess.js';
+const chess = new Chess(fen);
+const move  = chess.move(san);   // throws on illegal; returns { from, to, ... }
+// move.from / move.to are square strings like "e2" / "e4"
+```
+
+From frontend/src/components/board/ChessBoard.tsx (reference only — its ArrowOverlay
+draws an SVG of normalized width 0..1 mapped to MIN_SHAFT_WIDTH..MAX_SHAFT_WIDTH;
+the MiniBoard variant should use a fixed thin shaft width, not the normalized scale).
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: SAN→squares helper + MiniBoard arrow overlay</name>
+  <files>
+    frontend/src/lib/sanToSquares.ts,
+    frontend/src/lib/sanToSquares.test.ts,
+    frontend/src/components/board/MiniBoard.tsx,
+    frontend/src/components/board/LazyMiniBoard.tsx
+  </files>
+  <behavior>
+    sanToSquares (frontend/src/lib/sanToSquares.test.ts):
+    - Test 1: returns { from: 'e2', to: 'e4' } for ('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', 'e4')
+    - Test 2: returns { from: 'b1', to: 'c3' } for ('rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1', 'Nc3')
+    - Test 3: handles castling — 'O-O' on a kingside-castle-legal FEN returns { from: 'e1', to: 'g1' } for white (or e8/g8 for black FEN)
+    - Test 4: returns null on illegal/unparseable SAN (e.g. 'xx99' or a move illegal in the given FEN)
+    - Test 5: does NOT mutate or throw the caller — illegal SAN never produces an unhandled exception (chess.js v1.x throws on .move; helper must catch)
+
+    MiniBoard arrows (smoke-tested via OpeningFindingCard tests in Task 2 — no separate MiniBoard test file added unless the executor finds it valuable):
+    - When `arrows` prop is undefined or empty: renders identically to today (no overlay element).
+    - When `arrows={[{ from: 'e2', to: 'e4', color: '#9B1C1C' }]}`: renders an absolutely-positioned SVG overlay sibling to the Chessboard with one <path> whose `fill` equals the supplied color.
+    - Arrows respect the `flipped` prop (re-uses the same coord-flip math as ChessBoard.tsx).
+    - Shaft width is FIXED and visually fine (recommend: shaft = 0.07 * sqSize, head = 0.22 * sqSize, head length = head * 0.7) — distinct from ChessBoard's normalized 0..1 scale. Extract these as named constants at top of file (no magic numbers).
+  </behavior>
+  <action>
+    Create `frontend/src/lib/sanToSquares.ts`:
+    - Export `interface MoveSquares { from: string; to: string }`.
+    - Export `function sanToSquares(fen: string, san: string): MoveSquares | null` that constructs a `new Chess(fen)`, calls `.move(san)` inside try/catch, and returns `{ from: result.from, to: result.to }` on success or `null` on failure (illegal SAN, malformed FEN, etc.). chess.js v1.x throws on illegal moves — the helper must swallow and return null so the card can fall back to no arrow.
+    - Add JSDoc explaining: "FEN is the position BEFORE the move (= finding.entry_fen); san is the candidate move SAN."
+
+    Create `frontend/src/lib/sanToSquares.test.ts` (vitest, jsdom not required — pure logic) covering the 5 cases listed in <behavior>.
+
+    Modify `frontend/src/components/board/MiniBoard.tsx`:
+    - Add new optional prop `arrows?: ReadonlyArray<{ from: string; to: string; color: string }>` to MiniBoardProps.
+    - When `arrows` is non-empty, render an absolutely-positioned `<svg>` sibling layered over the Chessboard. The wrapper div must become `position: relative` and explicitly sized (it already is via `style={{ width: size, height: size }}`).
+    - Implement a small internal `MiniArrowOverlay` that mirrors ChessBoard.tsx's `squareToCoords` + `buildArrowPath` math but with FIXED FINE proportions:
+      `const MINI_SHAFT_WIDTH = 0.07; const MINI_HEAD_WIDTH = 0.22; const MINI_HEAD_LENGTH_RATIO = 0.7; const MINI_ARROW_OPACITY = 0.85; const MINI_TIP_OVERSHOOT = 0.10;`
+      (extract constants at module top — no magic numbers per CLAUDE.md "No magic numbers").
+    - SVG must include `pointerEvents: 'none'` (the parent already has `pointer-events-none`, but be explicit on the overlay too).
+    - Skip degenerate same-square arrows (defensive: `if (a.from === a.to) return null` inside the map, matching ChessBoard.tsx).
+    - Pass `arrows` straight through; do not sort/filter (mini cards always pass exactly one arrow).
+    - The `<svg>` element gets `data-testid="mini-board-arrow-overlay"` so OpeningFindingCard tests can assert presence/absence.
+    - Keep the existing `useMemo` on `options` for Chessboard untouched — only the new SVG should depend on `arrows`/`flipped`/`size`.
+
+    Modify `frontend/src/components/board/LazyMiniBoard.tsx`:
+    - Add same optional `arrows` prop and forward it into `<MiniBoard>`.
+    - No other changes.
+
+    Reuse, don't reimplement: copy/move the `squareToCoords` + `buildArrowPath` helpers from ChessBoard.tsx into a new shared module `frontend/src/components/board/arrowGeometry.ts` and import from BOTH files. This avoids duplicated SVG path math and is the cleanest factoring per CLAUDE.md "Shared Query Filters" precedent (single implementation rule).
+
+    Note on knip: the new `arrowGeometry.ts` exports must be imported by both MiniBoard.tsx AND ChessBoard.tsx, otherwise knip will flag dead exports and CI will fail.
+  </action>
+  <verify>
+    <automated>cd frontend &amp;&amp; npx vitest run src/lib/sanToSquares.test.ts</automated>
+  </verify>
+  <done>
+    - sanToSquares.test.ts passes all 5 cases.
+    - MiniBoard accepts arrows prop without breaking existing call sites (LazyMiniBoard call sites in GameCard, PositionBookmarkCard, etc. continue to work without passing arrows).
+    - arrowGeometry.ts exists and is imported by both MiniBoard.tsx and ChessBoard.tsx (verified via `grep -l "from.*arrowGeometry" frontend/src/components/board/`).
+    - No new color hex strings in MiniBoard.tsx — all colors come via the arrows prop.
+  </done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Wire score-colored arrow into OpeningFindingCard + tests + type/lint verification</name>
+  <files>
+    frontend/src/components/insights/OpeningFindingCard.tsx,
+    frontend/src/components/insights/OpeningFindingCard.test.tsx
+  </files>
+  <behavior>
+    OpeningFindingCard.test.tsx adds these cases (the existing react-chessboard mock + IntersectionObserver stub already cover MiniBoard rendering):
+    - Test A (mobile + desktop both): renders an `<svg data-testid="mini-board-arrow-overlay">` element inside the card when candidate_move_san is parseable from entry_fen. (Use `getAllByTestId` since both layouts mount.)
+    - Test B: the rendered <path> child of the overlay has `fill` equal to `getSeverityBorderColor(classification, severity)` — concretely:
+        * weakness/major → DARK_RED
+        * weakness/minor → LIGHT_RED
+        * strength/major → DARK_GREEN
+        * strength/minor → LIGHT_GREEN
+      Loop over all 4 (classification, severity) combos.
+    - Test C: when `candidate_move_san` is illegal in `entry_fen` (e.g. set candidate_move_san = 'Zz9' on a normal FEN), the card still renders without throwing and the arrow overlay is NOT present (`queryAllByTestId('mini-board-arrow-overlay').length === 0`).
+    - Test D: arrow renders for both color sides — when finding.color === 'black' the board is flipped; the overlay still mounts. (Don't assert exact path coordinates — too brittle. Just assert the overlay element exists.)
+  </behavior>
+  <action>
+    Modify `frontend/src/components/insights/OpeningFindingCard.tsx`:
+    - Import `sanToSquares` from `@/lib/sanToSquares`.
+    - At the top of the component (after `borderLeftColor` is computed, before `headerLine`):
+      ```ts
+      const moveSquares = sanToSquares(finding.entry_fen, finding.candidate_move_san);
+      const arrows = moveSquares
+        ? [{ from: moveSquares.from, to: moveSquares.to, color: borderLeftColor }] as const
+        : undefined;
+      ```
+    - Pass `arrows={arrows}` to BOTH `<LazyMiniBoard ... />` instances (mobile branch at the `sm:hidden` block AND desktop branch at the `hidden sm:flex` block) — per CLAUDE.md "Always apply changes to mobile too".
+    - No other markup changes — the troll watermark, layout, prose, links, opacity logic are untouched.
+
+    Modify `frontend/src/components/insights/OpeningFindingCard.test.tsx`:
+    - The existing `vi.mock('react-chessboard', ...)` stub returns null, which means MiniBoard's `<Chessboard>` does not render real DOM — but the MiniBoard's own SVG arrow overlay sibling DOES render (it's a plain React element, not part of Chessboard). Confirm this by inspection; no test plumbing change needed.
+    - Note re LazyMiniBoard: it gates rendering on IntersectionObserver firing. The existing MockIntersectionObserver stubs `observe`/`disconnect`/`unobserve` but never fires the callback, meaning `visible` stays `false` and MiniBoard never mounts. There are two viable fixes — pick whichever is cleaner:
+        Option (a) — preferred: replace the stub with one whose `observe` immediately invokes the callback with `[{ isIntersecting: true }]`, e.g.:
+          ```ts
+          class MockIntersectionObserver {
+            constructor(private cb: IntersectionObserverCallback) {}
+            observe = (el: Element) => {
+              this.cb([{ isIntersecting: true, target: el } as IntersectionObserverEntry], this as unknown as IntersectionObserver);
+            };
+            disconnect = vi.fn();
+            unobserve = vi.fn();
+          }
+          ```
+        Option (b): mock `@/components/board/LazyMiniBoard` to a passthrough that renders MiniBoard directly.
+      Option (a) is preferred because it exercises real component code paths.
+    - Add the four test cases A/B/C/D from <behavior>. Reuse `makeFinding()`. Keep tests in a new `describe('Quick task 260429-gmj — score-colored after-move arrow', () => { ... })` block at the bottom of the file.
+    - For Test B, use the same `hexToRgb` helper already defined at the bottom of the test file. Note: SVG `fill` attribute may or may not be normalized to rgb() in jsdom — check both forms (`fill === DARK_RED || fill === hexToRgb(DARK_RED)`) to be robust, OR query the rendered SVG path's `getAttribute('fill')` which preserves the literal hex.
+
+    Verification commands run as part of <verify> below:
+    - `cd frontend && npx tsc --noEmit` (zero errors required)
+    - `cd frontend && npm run lint` (zero errors required)
+    - `cd frontend && npx vitest run src/components/insights/OpeningFindingCard.test.tsx src/lib/sanToSquares.test.ts` (all green)
+    - `cd frontend && npm run knip` (no new dead exports — arrowGeometry.ts must be imported by both consumers)
+  </action>
+  <verify>
+    <automated>cd frontend &amp;&amp; npx tsc --noEmit &amp;&amp; npm run lint &amp;&amp; npx vitest run src/components/insights/OpeningFindingCard.test.tsx src/lib/sanToSquares.test.ts &amp;&amp; npm run knip</automated>
+  </verify>
+  <done>
+    - OpeningFindingCard renders the score-colored arrow on its mini board for both mobile and desktop branches.
+    - All 4 (classification, severity) combos produce the matching DARK_RED/LIGHT_RED/DARK_GREEN/LIGHT_GREEN arrow color.
+    - Illegal/unparseable SAN gracefully degrades to no arrow (no crash).
+    - tsc, lint, vitest (existing + new tests), and knip all pass with zero errors.
+    - No new color hex literals or magic-number coordinates introduced in OpeningFindingCard.tsx.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- Visual sanity check (manual, post-merge): on /openings, scroll the Insights findings; each card's mini board shows a fine arrow from the candidate move's source to target square, colored to match the card's left border.
+- Automated gates (CI parity): tsc, lint, vitest, knip all green from Task 2's verify step.
+- Mobile parity: Test A in OpeningFindingCard.test.tsx asserts the overlay renders in BOTH the `sm:hidden` and `hidden sm:flex` branches (use `getAllByTestId`).
+</verification>
+
+<success_criteria>
+- Each Insights finding card mini board renders a fine arrow from the candidate move's from-square to its to-square.
+- Arrow color exactly equals `getSeverityBorderColor(classification, severity)` — same source as the card's left-border tint.
+- Arrow is visibly thinner than MoveExplorer board arrows (fixed shaft = 0.07 of square size vs. MoveExplorer's normalized 0.06–0.26 scale, typically rendered in the upper half of that range).
+- chess.js illegal-move exceptions never propagate to the React render path.
+- No new color hex strings or magic numbers introduced — all colors via arrowColor.ts re-export, all geometry constants named at module top.
+- Mobile and desktop branches both updated.
+- `cd frontend && npx tsc --noEmit && npm run lint && npx vitest run && npm run knip` is green.
+</success_criteria>
+
+<output>
+After completion, no SUMMARY required (this is a /gsd:quick task). The user will commit and ship directly per CLAUDE.md "When working on the main branch (e.g. with /gsd:quick), don't commit the changes unless the user explicitly asks for it."
+</output>

--- a/.planning/quick/260429-gmj-insights-finding-cards-arrow-for-after-m/260429-gmj-SUMMARY.md
+++ b/.planning/quick/260429-gmj-insights-finding-cards-arrow-for-after-m/260429-gmj-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: quick-260429-gmj
+plan: 01
+subsystem: frontend/insights
+tags: [insights, arrows, mini-board, openings, ux]
+requires: []
+provides:
+  - "frontend/src/lib/sanToSquares.ts: SAN → {from,to} helper"
+  - "frontend/src/components/board/arrowGeometry.ts: shared squareToCoords + buildArrowPath"
+  - "frontend/src/components/board/MiniBoard.tsx: optional arrows prop with thin SVG overlay"
+affects:
+  - "frontend/src/components/insights/OpeningFindingCard.tsx (renders arrow on each finding card)"
+  - "frontend/src/components/board/ChessBoard.tsx (now imports geometry from arrowGeometry.ts)"
+key-files:
+  created:
+    - frontend/src/lib/sanToSquares.ts
+    - frontend/src/lib/sanToSquares.test.ts
+    - frontend/src/components/board/arrowGeometry.ts
+  modified:
+    - frontend/src/components/board/MiniBoard.tsx
+    - frontend/src/components/board/LazyMiniBoard.tsx
+    - frontend/src/components/board/ChessBoard.tsx
+    - frontend/src/components/insights/OpeningFindingCard.tsx
+    - frontend/src/components/insights/OpeningFindingCard.test.tsx
+decisions:
+  - "Extract squareToCoords + buildArrowPath into arrowGeometry.ts so MiniBoard and ChessBoard share one geometry implementation (CLAUDE.md single-implementation rule)"
+  - "MiniBoard arrows use FIXED proportions (shaft 0.07, head 0.22, head ratio 0.7) distinct from ChessBoard's normalized 0–1 scale — fine, decorative, no width modulation"
+  - "MockIntersectionObserver in OpeningFindingCard.test.tsx now fires its callback synchronously on observe() so LazyMiniBoard mounts during tests (option (a) from PLAN.md)"
+metrics:
+  duration: 6m
+  tasks_completed: 2
+  files_changed: 9
+  completed: 2026-04-29
+---
+
+# Quick Task 260429-gmj: Insights Finding Cards — score-colored after-move arrow Summary
+
+Each Insights finding card now renders a fine, score-colored arrow on its mini board pointing from the candidate move's source square to its target square — making the "what moved and how did it score" answerable at a glance without reading SAN text.
+
+## What was built
+
+- **`sanToSquares(fen, san)` helper** in `frontend/src/lib/sanToSquares.ts`. Wraps a `new Chess(fen).move(san)` call in try/catch; returns `{ from, to }` on success or `null` on illegal SAN, malformed FEN, or any other chess.js exception. Lets call sites consume the result with a simple ternary instead of try/catch.
+
+- **Shared `arrowGeometry.ts`** in `frontend/src/components/board/`. Hosts `squareToCoords` and `buildArrowPath`, the SVG-arrow math that previously lived only in `ChessBoard.tsx`. Both `ChessBoard.tsx` and the new `MiniBoard` overlay import from this single source — the CLAUDE.md "single implementation" rule that the shared `query_utils.py` follows on the backend.
+
+- **`MiniBoard` arrow overlay**. Accepts an optional `arrows?: ReadonlyArray<{ from, to, color }>` prop. When non-empty, renders an absolutely-positioned `<svg data-testid="mini-board-arrow-overlay">` sibling layered over the Chessboard with one `<path>` per arrow. Geometry constants live as named module-top constants (`MINI_SHAFT_WIDTH = 0.07`, `MINI_HEAD_WIDTH = 0.22`, `MINI_HEAD_LENGTH_RATIO = 0.7`, `MINI_ARROW_OPACITY = 0.85`, `MINI_TIP_OVERSHOOT = 0.10`). Skips degenerate same-square arrows defensively. SVG is `pointerEvents: 'none'` so card buttons stay clickable.
+
+- **`LazyMiniBoard` forwards arrows**. Same prop signature added and passed straight through to `<MiniBoard>`.
+
+- **`OpeningFindingCard` wiring**. Computes `moveSquares = sanToSquares(finding.entry_fen, finding.candidate_move_san)` once, builds an `arrows` array with `color: borderLeftColor` (the same hex from `getSeverityBorderColor` that tints the card's left border), and passes it to BOTH the `sm:hidden` mobile branch and the `hidden sm:flex` desktop branch (CLAUDE.md "Always apply changes to mobile too"). When `moveSquares` is null, `arrows` is `undefined` and the card simply renders without an overlay.
+
+## Tests
+
+- `sanToSquares.test.ts` — 7 cases: starting-position e4, Nc3, kingside castling for white and black, illegal SAN (xx99), illegal-in-FEN move (Nxd4 from start), malformed FEN. All ensure no exception escapes.
+
+- `OpeningFindingCard.test.tsx` — added `describe('Quick task 260429-gmj — score-colored after-move arrow')` block:
+  - **Test A**: arrow overlay renders in BOTH mobile and desktop branches (`getAllByTestId('mini-board-arrow-overlay').length === 2`).
+  - **Test B** (parameterized over 4 combos): arrow `<path>` `fill` attribute equals `getSeverityBorderColor(classification, severity)` — `weakness/major → DARK_RED`, `weakness/minor → LIGHT_RED`, `strength/major → DARK_GREEN`, `strength/minor → LIGHT_GREEN`. Robust to jsdom hex/rgb normalization.
+  - **Test C**: illegal SAN ("Zz9") → card renders, no overlay element present.
+  - **Test D**: `color === 'black'` (flipped board) still renders the overlay.
+
+- Replaced the `MockIntersectionObserver` in `OpeningFindingCard.test.tsx` with one whose `observe()` synchronously invokes the callback with `[{ isIntersecting: true }]`, so `LazyMiniBoard`'s gate flips to `visible=true` and `MiniBoard` actually mounts in tests. This was option (a) from the plan — preferred because it exercises the real component code path instead of mocking `LazyMiniBoard` away.
+
+## Verification
+
+`cd frontend && npx tsc --noEmit && npm run lint && npx vitest run src/components/insights/OpeningFindingCard.test.tsx src/lib/sanToSquares.test.ts && npm run knip`:
+
+- **tsc**: zero errors
+- **lint**: zero errors (3 pre-existing warnings under `coverage/` are unrelated artifacts)
+- **vitest** (targeted): 42 tests pass (35 existing + 7 sanToSquares)
+- **vitest** (full repo, sanity): 206/206 pass across 18 files
+- **knip**: zero issues — `arrowGeometry.ts` exports are imported by both `ChessBoard.tsx` and `MiniBoard.tsx`
+
+## Deviations from Plan
+
+None. The plan executed exactly as written. The two TDD cycles (RED → GREEN per task) both produced the expected red gate before implementation.
+
+One small judgment call worth noting: I added two extra `sanToSquares` test cases beyond the five in `<behavior>` (illegal-in-FEN as a separate case from purely unparseable SAN, and a malformed-FEN case) because they directly exercise the chess.js v1.x throw paths the helper has to swallow. Net 7 tests instead of 5; same intent.
+
+## Commits
+
+| Hash    | Type | Message                                                                |
+| ------- | ---- | ---------------------------------------------------------------------- |
+| 1342fdb | test | add failing tests for sanToSquares helper                              |
+| 36eb0af | feat | add sanToSquares helper + MiniBoard arrow overlay                      |
+| 74acf9e | test | add failing tests for score-colored after-move arrow                   |
+| de187ed | feat | wire score-colored after-move arrow into OpeningFindingCard            |
+
+## Self-Check: PASSED
+
+- `frontend/src/lib/sanToSquares.ts` exists
+- `frontend/src/lib/sanToSquares.test.ts` exists
+- `frontend/src/components/board/arrowGeometry.ts` exists
+- All 4 commits present in `git log`
+- All gates green: tsc, lint, vitest (targeted + full), knip

--- a/frontend/src/components/board/ChessBoard.tsx
+++ b/frontend/src/components/board/ChessBoard.tsx
@@ -3,6 +3,7 @@ import { Chessboard } from 'react-chessboard';
 import { arrowSortKey } from '../../lib/arrowColor';
 import { darkSquareStyle, lightSquareStyle, BOARD_DARK_SQUARE, BOARD_LIGHT_SQUARE } from '../../lib/theme';
 import { HIGHLIGHT_PULSE_DURATION_MS, HIGHLIGHT_PULSE_ITERATIONS } from '../../lib/highlightPulse';
+import { squareToCoords, buildArrowPath } from './arrowGeometry';
 
 interface BoardArrow {
   startSquare: string;
@@ -63,55 +64,6 @@ const ARROW_TIP_OVERSHOOT = 0.15;
 // Constants live in lib/highlightPulse.ts so the MoveExplorer row-pulse
 // stays driven by the same timing.
 const ARROW_PULSE_CLASS = 'animate-arrow-pulse';
-
-const FILES = 'abcdefgh';
-
-function squareToCoords(square: string, flipped: boolean): [number, number] {
-  // safe: square is always a 2-char chess square string like "e4"
-  const file = FILES.indexOf(square[0]!);
-  const rank = parseInt(square[1]!, 10) - 1;
-  const x = flipped ? 7 - file + 0.5 : file + 0.5;
-  const y = flipped ? rank + 0.5 : 7 - rank + 0.5;
-  return [x, y];
-}
-
-function buildArrowPath(
-  x1: number, y1: number, x2: number, y2: number,
-  shaftHalf: number, headHalf: number, headLen: number,
-): string {
-  const dx = x2 - x1;
-  const dy = y2 - y1;
-  const len = Math.sqrt(dx * dx + dy * dy);
-  // Unit vectors: along arrow and perpendicular
-  const ux = dx / len;
-  const uy = dy / len;
-  const px = -uy; // perpendicular
-  const py = ux;
-
-  // Arrowhead base point (where shaft meets head)
-  const bx = x2 - ux * headLen;
-  const by = y2 - uy * headLen;
-
-  // Key points
-  const startLeft = [x1 + px * shaftHalf, y1 + py * shaftHalf];
-  const junctionLeft = [bx + px * shaftHalf, by + py * shaftHalf];
-  const headLeft = [bx + px * headHalf, by + py * headHalf];
-  const tip = [x2, y2];
-  const headRight = [bx - px * headHalf, by - py * headHalf];
-  const junctionRight = [bx - px * shaftHalf, by - py * shaftHalf];
-  const startRight = [x1 - px * shaftHalf, y1 - py * shaftHalf];
-
-  return [
-    `M ${startLeft[0]},${startLeft[1]}`,
-    `L ${junctionLeft[0]},${junctionLeft[1]}`,
-    `L ${headLeft[0]},${headLeft[1]}`,
-    `L ${tip[0]},${tip[1]}`,
-    `L ${headRight[0]},${headRight[1]}`,
-    `L ${junctionRight[0]},${junctionRight[1]}`,
-    `L ${startRight[0]},${startRight[1]}`,
-    'Z',
-  ].join(' ');
-}
 
 // Render priority determined by arrowSortKey: grey = 2 (drawn first = bottom), red = 1 (middle), green = 0 (drawn last = on top).
 // Sort descending by key so grey (2) is rendered first (behind) and colored arrows (0, 1) render last (on top).

--- a/frontend/src/components/board/LazyMiniBoard.tsx
+++ b/frontend/src/components/board/LazyMiniBoard.tsx
@@ -6,10 +6,12 @@ export function LazyMiniBoard({
   fen,
   flipped,
   size,
+  arrows,
 }: {
   fen: string;
   flipped: boolean;
   size: number;
+  arrows?: ReadonlyArray<{ from: string; to: string; color: string }>;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [visible, setVisible] = useState(false);
@@ -37,7 +39,7 @@ export function LazyMiniBoard({
       className="shrink-0 rounded overflow-hidden bg-muted"
       style={{ width: size, height: size }}
     >
-      {visible && <MiniBoard fen={fen} size={size} flipped={flipped} />}
+      {visible && <MiniBoard fen={fen} size={size} flipped={flipped} arrows={arrows} />}
     </div>
   );
 }

--- a/frontend/src/components/board/MiniBoard.tsx
+++ b/frontend/src/components/board/MiniBoard.tsx
@@ -1,14 +1,87 @@
 import { useMemo } from 'react';
 import { Chessboard } from 'react-chessboard';
 import { darkSquareStyle, lightSquareStyle } from '../../lib/theme';
+import { squareToCoords, buildArrowPath } from './arrowGeometry';
+
+// Fine-arrow proportions, distinct from ChessBoard.tsx's normalized 0..1 width
+// scale. MiniBoard arrows are decorative pointers ("which move scored well/
+// poorly?"), so they stay visually thin even on small boards. All values are
+// fractions of a single square's pixel size.
+const MINI_SHAFT_WIDTH = 0.07;
+const MINI_HEAD_WIDTH = 0.22;
+const MINI_HEAD_LENGTH_RATIO = 0.7;
+const MINI_ARROW_OPACITY = 0.85;
+const MINI_TIP_OVERSHOOT = 0.10;
+
+interface MiniBoardArrow {
+  from: string;
+  to: string;
+  color: string;
+}
 
 interface MiniBoardProps {
   fen: string;
   size?: number;
   flipped?: boolean;
+  arrows?: ReadonlyArray<MiniBoardArrow>;
 }
 
-export function MiniBoard({ fen, size = 120, flipped = false }: MiniBoardProps) {
+function MiniArrowOverlay({
+  arrows,
+  size,
+  flipped,
+}: {
+  arrows: ReadonlyArray<MiniBoardArrow>;
+  size: number;
+  flipped: boolean;
+}) {
+  if (arrows.length === 0) return null;
+  const sqSize = size / 8;
+  return (
+    <svg
+      width={size}
+      height={size}
+      style={{ position: 'absolute', top: 0, left: 0, pointerEvents: 'none' }}
+      data-testid="mini-board-arrow-overlay"
+    >
+      {arrows.map((a) => {
+        // Skip degenerate arrows (same start/end square — would produce NaN path).
+        if (a.from === a.to) return null;
+
+        const [x1, y1] = squareToCoords(a.from, flipped);
+        const [cx2, cy2] = squareToCoords(a.to, flipped);
+
+        // Extend the tip past the target square center so the arrowhead point
+        // sits visibly inside the destination square instead of dead-center.
+        const adx = cx2 - x1;
+        const ady = cy2 - y1;
+        const alen = Math.sqrt(adx * adx + ady * ady);
+        const x2 = cx2 + (adx / alen) * MINI_TIP_OVERSHOOT;
+        const y2 = cy2 + (ady / alen) * MINI_TIP_OVERSHOOT;
+
+        const shaftHalf = (MINI_SHAFT_WIDTH * sqSize) / 2;
+        const headWidth = MINI_HEAD_WIDTH * sqSize;
+        const headLen = headWidth * MINI_HEAD_LENGTH_RATIO;
+
+        const d = buildArrowPath(
+          x1 * sqSize, y1 * sqSize, x2 * sqSize, y2 * sqSize,
+          shaftHalf, headWidth / 2, headLen,
+        );
+
+        return (
+          <path
+            key={`${a.from}-${a.to}`}
+            d={d}
+            fill={a.color}
+            opacity={MINI_ARROW_OPACITY}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export function MiniBoard({ fen, size = 120, flipped = false, arrows }: MiniBoardProps) {
   // Memoize the options object so re-renders of an ancestor (e.g. /openings/games
   // mounts up to 20 MiniBoards) don't hand react-chessboard 5.x a fresh `options`
   // identity and re-fire its internal piece-animation/dnd effects on every parent
@@ -29,8 +102,14 @@ export function MiniBoard({ fen, size = 120, flipped = false }: MiniBoardProps) 
   );
 
   return (
-    <div style={{ width: size, height: size }} className="pointer-events-none flex-shrink-0">
+    <div
+      style={{ width: size, height: size, position: 'relative' }}
+      className="pointer-events-none flex-shrink-0"
+    >
       <Chessboard options={options} />
+      {arrows && arrows.length > 0 && (
+        <MiniArrowOverlay arrows={arrows} size={size} flipped={flipped} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/board/MiniBoard.tsx
+++ b/frontend/src/components/board/MiniBoard.tsx
@@ -7,11 +7,11 @@ import { squareToCoords, buildArrowPath } from './arrowGeometry';
 // scale. MiniBoard arrows are decorative pointers ("which move scored well/
 // poorly?"), so they stay visually thin even on small boards. All values are
 // fractions of a single square's pixel size.
-const MINI_SHAFT_WIDTH = 0.07;
-const MINI_HEAD_WIDTH = 0.22;
+const MINI_SHAFT_WIDTH = 0.10;
+const MINI_HEAD_WIDTH = 0.30;
 const MINI_HEAD_LENGTH_RATIO = 0.7;
 const MINI_ARROW_OPACITY = 0.85;
-const MINI_TIP_OVERSHOOT = 0.10;
+const MINI_TIP_OVERSHOOT = 0.12;
 
 interface MiniBoardArrow {
   from: string;

--- a/frontend/src/components/board/MiniBoard.tsx
+++ b/frontend/src/components/board/MiniBoard.tsx
@@ -7,11 +7,11 @@ import { squareToCoords, buildArrowPath } from './arrowGeometry';
 // scale. MiniBoard arrows are decorative pointers ("which move scored well/
 // poorly?"), so they stay visually thin even on small boards. All values are
 // fractions of a single square's pixel size.
-const MINI_SHAFT_WIDTH = 0.10;
-const MINI_HEAD_WIDTH = 0.30;
+const MINI_SHAFT_WIDTH = 0.14;
+const MINI_HEAD_WIDTH = 0.40;
 const MINI_HEAD_LENGTH_RATIO = 0.7;
 const MINI_ARROW_OPACITY = 0.85;
-const MINI_TIP_OVERSHOOT = 0.12;
+const MINI_TIP_OVERSHOOT = 0.14;
 
 interface MiniBoardArrow {
   from: string;

--- a/frontend/src/components/board/MiniBoard.tsx
+++ b/frontend/src/components/board/MiniBoard.tsx
@@ -7,11 +7,11 @@ import { squareToCoords, buildArrowPath } from './arrowGeometry';
 // scale. MiniBoard arrows are decorative pointers ("which move scored well/
 // poorly?"), so they stay visually thin even on small boards. All values are
 // fractions of a single square's pixel size.
-const MINI_SHAFT_WIDTH = 0.14;
-const MINI_HEAD_WIDTH = 0.40;
+const MINI_SHAFT_WIDTH = 0.18;
+const MINI_HEAD_WIDTH = 0.50;
 const MINI_HEAD_LENGTH_RATIO = 0.7;
 const MINI_ARROW_OPACITY = 0.85;
-const MINI_TIP_OVERSHOOT = 0.14;
+const MINI_TIP_OVERSHOOT = 0.16;
 
 interface MiniBoardArrow {
   from: string;

--- a/frontend/src/components/board/arrowGeometry.ts
+++ b/frontend/src/components/board/arrowGeometry.ts
@@ -1,0 +1,66 @@
+// Shared SVG-arrow geometry for ChessBoard and MiniBoard.
+//
+// Both consumers map chess square strings ("e4") to grid coordinates and build
+// arrow-shaped <path> d-strings. ChessBoard uses normalized 0–1 widths from
+// arrow frequency; MiniBoard uses fixed thin proportions. The math is identical
+// — extracted here so we have a single source of truth (see CLAUDE.md
+// "Shared Query Filters" precedent: single implementation rule).
+
+const FILES = 'abcdefgh';
+
+/**
+ * Convert a chess square string ("e4") to grid coordinates centered on the
+ * square. Returns [x, y] in units of squares (0..8). The board orientation
+ * flips both axes when `flipped` is true.
+ */
+export function squareToCoords(square: string, flipped: boolean): [number, number] {
+  // safe: square is always a 2-char chess square string like "e4"
+  const file = FILES.indexOf(square[0]!);
+  const rank = parseInt(square[1]!, 10) - 1;
+  const x = flipped ? 7 - file + 0.5 : file + 0.5;
+  const y = flipped ? rank + 0.5 : 7 - rank + 0.5;
+  return [x, y];
+}
+
+/**
+ * Build the SVG `d` attribute for an arrow from (x1, y1) to (x2, y2). All
+ * coordinates and sizes are in pixel space. The arrow is a 7-point closed
+ * polygon: rectangular shaft expanding into a triangular head at the tip.
+ */
+export function buildArrowPath(
+  x1: number, y1: number, x2: number, y2: number,
+  shaftHalf: number, headHalf: number, headLen: number,
+): string {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  // Unit vectors: along arrow and perpendicular
+  const ux = dx / len;
+  const uy = dy / len;
+  const px = -uy; // perpendicular
+  const py = ux;
+
+  // Arrowhead base point (where shaft meets head)
+  const bx = x2 - ux * headLen;
+  const by = y2 - uy * headLen;
+
+  // Key points
+  const startLeft = [x1 + px * shaftHalf, y1 + py * shaftHalf];
+  const junctionLeft = [bx + px * shaftHalf, by + py * shaftHalf];
+  const headLeft = [bx + px * headHalf, by + py * headHalf];
+  const tip = [x2, y2];
+  const headRight = [bx - px * headHalf, by - py * headHalf];
+  const junctionRight = [bx - px * shaftHalf, by - py * shaftHalf];
+  const startRight = [x1 - px * shaftHalf, y1 - py * shaftHalf];
+
+  return [
+    `M ${startLeft[0]},${startLeft[1]}`,
+    `L ${junctionLeft[0]},${junctionLeft[1]}`,
+    `L ${headLeft[0]},${headLeft[1]}`,
+    `L ${tip[0]},${tip[1]}`,
+    `L ${headRight[0]},${headRight[1]}`,
+    `L ${junctionRight[0]},${junctionRight[1]}`,
+    `L ${startRight[0]},${startRight[1]}`,
+    'Z',
+  ].join(' ');
+}

--- a/frontend/src/components/insights/OpeningFindingCard.test.tsx
+++ b/frontend/src/components/insights/OpeningFindingCard.test.tsx
@@ -2,9 +2,23 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 
-// IntersectionObserver is not available in jsdom — stub it as a class constructor.
+// IntersectionObserver is not available in jsdom. Stub it as a class
+// constructor that fires the callback synchronously on observe() so
+// LazyMiniBoard mounts MiniBoard immediately and the arrow overlay renders
+// without us having to mock LazyMiniBoard itself. (Quick task 260429-gmj —
+// before this fix, `visible` stayed `false` and MiniBoard never mounted, so
+// arrow-overlay assertions could not work.)
 class MockIntersectionObserver {
-  observe = vi.fn();
+  private cb: IntersectionObserverCallback;
+  constructor(cb: IntersectionObserverCallback) {
+    this.cb = cb;
+  }
+  observe = (el: Element) => {
+    this.cb(
+      [{ isIntersecting: true, target: el } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  };
   disconnect = vi.fn();
   unobserve = vi.fn();
 }
@@ -401,6 +415,72 @@ describe('OpeningFindingCard', () => {
       const movesBtns = screen.getAllByTestId('opening-finding-card-7-moves');
       fireEvent.click(movesBtns[0]!);
       expect(onFindingClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('Quick task 260429-gmj — score-colored after-move arrow', () => {
+    // Test A: arrow overlay renders in BOTH layouts when the candidate move parses.
+    it('renders <svg data-testid="mini-board-arrow-overlay"> in both mobile and desktop layouts', () => {
+      const finding = makeFinding({
+        entry_fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        candidate_move_san: 'e4',
+      });
+      renderCard({ finding, idx: 0 });
+      const overlays = screen.getAllByTestId('mini-board-arrow-overlay');
+      expect(overlays.length).toBe(2); // one in sm:hidden, one in hidden sm:flex
+    });
+
+    // Test B: arrow color = getSeverityBorderColor for all 4 (classification, severity) combos.
+    it.each([
+      ['weakness', 'major', DARK_RED] as const,
+      ['weakness', 'minor', LIGHT_RED] as const,
+      ['strength', 'major', DARK_GREEN] as const,
+      ['strength', 'minor', LIGHT_GREEN] as const,
+    ])(
+      'arrow path fill matches getSeverityBorderColor for %s/%s',
+      (classification, severity, expectedHex) => {
+        const finding = makeFinding({
+          classification: classification as OpeningInsightFinding['classification'],
+          severity: severity as OpeningInsightFinding['severity'],
+          entry_fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+          candidate_move_san: 'e4',
+        });
+        renderCard({ finding, idx: 0 });
+        const overlays = screen.getAllByTestId('mini-board-arrow-overlay');
+        const path = overlays[0]!.querySelector('path');
+        expect(path).not.toBeNull();
+        const fillAttr = path!.getAttribute('fill') ?? '';
+        // jsdom may normalize hex → rgb() on inline style but preserves the
+        // raw value when set via the `fill` SVG attribute. Check both forms.
+        expect(
+          fillAttr === expectedHex || fillAttr === hexToRgb(expectedHex),
+        ).toBe(true);
+      },
+    );
+
+    // Test C: illegal/unparseable SAN gracefully degrades to no arrow.
+    it('does not render the arrow overlay when candidate_move_san is illegal in entry_fen', () => {
+      const finding = makeFinding({
+        entry_fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        candidate_move_san: 'Zz9',
+      });
+      renderCard({ finding, idx: 0 });
+      // Card should still render without throwing.
+      expect(screen.getByTestId('opening-finding-card-0')).toBeTruthy();
+      expect(screen.queryAllByTestId('mini-board-arrow-overlay').length).toBe(0);
+    });
+
+    // Test D: arrow renders for both color sides (board flipped for black).
+    it('renders the arrow overlay when finding.color === "black" (flipped board)', () => {
+      const finding = makeFinding({
+        color: 'black',
+        // Position after 1.e4 — black to move. e5 is legal here.
+        entry_fen: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1',
+        candidate_move_san: 'e5',
+      });
+      renderCard({ finding, idx: 0 });
+      const overlays = screen.getAllByTestId('mini-board-arrow-overlay');
+      expect(overlays.length).toBe(2);
     });
   });
 });

--- a/frontend/src/components/insights/OpeningFindingCard.tsx
+++ b/frontend/src/components/insights/OpeningFindingCard.tsx
@@ -6,6 +6,7 @@ import {
   formatConfidenceTooltip,
   getSeverityBorderColor,
 } from '@/lib/openingInsights';
+import { sanToSquares } from '@/lib/sanToSquares';
 import { MIN_GAMES_FOR_RELIABLE_STATS, TROLL_WATERMARK_OPACITY, UNRELIABLE_OPACITY } from '@/lib/theme';
 import { isTrollPosition } from '@/lib/trollOpenings';
 import trollFaceUrl from '@/assets/troll-face.svg';
@@ -37,6 +38,15 @@ export function OpeningFindingCard({
     finding.classification,
     finding.severity,
   );
+  // Quick-task 260429-gmj: render a fine score-colored arrow on the mini board
+  // pointing from the candidate move's source to its target square. The same
+  // hex used for the card border tint goes into the arrow so the visuals stay
+  // in lockstep. Illegal/unparseable SAN returns null and the card simply
+  // falls back to no arrow (no try/catch needed at the call site).
+  const moveSquares = sanToSquares(finding.entry_fen, finding.candidate_move_san);
+  const arrows = moveSquares
+    ? ([{ from: moveSquares.from, to: moveSquares.to, color: borderLeftColor }] as const)
+    : undefined;
   const isUnnamed = finding.opening_name === UNNAMED_SENTINEL;
 
   // D-02: Score-based prose (replaces broken loss_rate/win_rate reads removed in Phase 75).
@@ -148,6 +158,7 @@ export function OpeningFindingCard({
             fen={finding.entry_fen}
             flipped={finding.color === 'black'}
             size={MOBILE_BOARD_SIZE}
+            arrows={arrows}
           />
           <div className="flex-1 min-w-0 flex flex-col gap-2">
             {proseLine}
@@ -163,6 +174,7 @@ export function OpeningFindingCard({
           fen={finding.entry_fen}
           flipped={finding.color === 'black'}
           size={DESKTOP_BOARD_SIZE}
+          arrows={arrows}
         />
         <div className="min-w-0 flex-1 flex flex-col gap-2">
           {headerLine}

--- a/frontend/src/components/insights/OpeningFindingCard.tsx
+++ b/frontend/src/components/insights/OpeningFindingCard.tsx
@@ -19,8 +19,8 @@ interface OpeningFindingCardProps {
   onOpenGames: (finding: OpeningInsightFinding) => void;
 }
 
-const MOBILE_BOARD_SIZE = 105;
-const DESKTOP_BOARD_SIZE = 100;
+const MOBILE_BOARD_SIZE = 115;
+const DESKTOP_BOARD_SIZE = 110;
 const UNNAMED_SENTINEL = '<unnamed line>';
 
 export function OpeningFindingCard({

--- a/frontend/src/lib/sanToSquares.test.ts
+++ b/frontend/src/lib/sanToSquares.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { sanToSquares } from './sanToSquares';
+
+const STARTING_FEN_WHITE = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+// FEN with kingside castling legal for white (king + rook on home squares, no
+// pieces between, castling rights present). Same for black on a separate FEN.
+const KINGSIDE_CASTLE_WHITE_FEN =
+  'rnbqkbnr/pppppppp/8/8/4P3/5N2/PPPPBPPP/RNBQK2R w KQkq - 0 1';
+const KINGSIDE_CASTLE_BLACK_FEN =
+  'rnbqk2r/ppppbppp/5n2/4p3/4P3/5N2/PPPPBPPP/RNBQK2R b KQkq - 0 1';
+
+describe('sanToSquares', () => {
+  it('returns { from: e2, to: e4 } for the e4 opening move', () => {
+    const result = sanToSquares(STARTING_FEN_WHITE, 'e4');
+    expect(result).toEqual({ from: 'e2', to: 'e4' });
+  });
+
+  it('returns { from: b1, to: c3 } for Nc3 from the starting position', () => {
+    const result = sanToSquares(STARTING_FEN_WHITE, 'Nc3');
+    expect(result).toEqual({ from: 'b1', to: 'c3' });
+  });
+
+  it('handles kingside castling for white (O-O → e1/g1)', () => {
+    const result = sanToSquares(KINGSIDE_CASTLE_WHITE_FEN, 'O-O');
+    expect(result).toEqual({ from: 'e1', to: 'g1' });
+  });
+
+  it('handles kingside castling for black (O-O → e8/g8)', () => {
+    const result = sanToSquares(KINGSIDE_CASTLE_BLACK_FEN, 'O-O');
+    expect(result).toEqual({ from: 'e8', to: 'g8' });
+  });
+
+  it('returns null on illegal/unparseable SAN', () => {
+    const result = sanToSquares(STARTING_FEN_WHITE, 'xx99');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a SAN that is illegal in the given FEN (without throwing)', () => {
+    // Nxd4 is illegal from the starting position — no knight can capture on d4.
+    expect(() => sanToSquares(STARTING_FEN_WHITE, 'Nxd4')).not.toThrow();
+    expect(sanToSquares(STARTING_FEN_WHITE, 'Nxd4')).toBeNull();
+  });
+
+  it('returns null on a malformed FEN without throwing', () => {
+    expect(() => sanToSquares('this is not a fen', 'e4')).not.toThrow();
+    expect(sanToSquares('this is not a fen', 'e4')).toBeNull();
+  });
+});

--- a/frontend/src/lib/sanToSquares.ts
+++ b/frontend/src/lib/sanToSquares.ts
@@ -1,0 +1,26 @@
+import { Chess } from 'chess.js';
+
+export interface MoveSquares {
+  from: string;
+  to: string;
+}
+
+/**
+ * Convert a SAN move string into its from/to squares relative to a given FEN.
+ *
+ * `fen` is the position BEFORE the move (i.e. `finding.entry_fen` from the
+ * Insights API). `san` is the candidate move SAN ("Be2", "Nxd4", "O-O", etc.).
+ *
+ * chess.js v1.x throws on illegal moves and on malformed FENs. We swallow
+ * everything and return `null` so callers (e.g. OpeningFindingCard) can simply
+ * fall back to "no arrow" without try/catch boilerplate at every call site.
+ */
+export function sanToSquares(fen: string, san: string): MoveSquares | null {
+  try {
+    const chess = new Chess(fen);
+    const move = chess.move(san);
+    return { from: move.from, to: move.to };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Mini chessboards inside Openings → Insights finding cards now show a fine arrow from the candidate move's source to target square, colored to match the card's score-derived border (DARK_RED / LIGHT_RED / DARK_GREEN / LIGHT_GREEN).
- Mini board sizes bumped +10px (mobile 105 → 115, desktop 100 → 110); arrow proportions iterated to a chunkier final size (shaft 0.18, head 0.50 of square).
- New shared `arrowGeometry.ts` (extracted from `ChessBoard.tsx`) keeps SVG path math in one place; new `sanToSquares.ts` helper guards against illegal SAN with graceful no-arrow fallback.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npx vitest run` — 206/206 passing (35 OpeningFindingCard cases incl. 4 new)
- [x] `npm run knip` — 0 issues
- [ ] Manual: scroll Openings → Insights findings, confirm arrow color matches each card's left border tint on mobile + desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)