### PR TITLE
feat: opponent strength range slider

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -126,6 +126,7 @@ Carried forward from v1.11 close (still relevant):
 | 260428-tgg | Sort opening insights findings by Wald CI bound (direction-aware tiebreak replacing effect-size) | 2026-04-28 | 45c5a20 | [260428-tgg-sort-opening-insights-findings-by-wald-c](./quick/260428-tgg-sort-opening-insights-findings-by-wald-c/) |
 | 260428-v9i | Switch opening insights ranking from Wald CI bound to Wilson score interval bound | 2026-04-28 | 0715fda | [260428-v9i-switch-opening-insights-ranking-from-wal](./quick/260428-v9i-switch-opening-insights-ranking-from-wal/) |
 | 260429-gmj | Insights finding cards: arrow for after-move on mini board | 2026-04-29 | de187ed | [260429-gmj-insights-finding-cards-arrow-for-after-m](./quick/260429-gmj-insights-finding-cards-arrow-for-after-m/) |
+| 260429-ty5 | Replace Opponent Strength ToggleGroup with dual-handle range slider + 4 preset chips (Spike 001) | 2026-04-29 | 124237b | [260429-ty5-opponent-strength-slider](./quick/260429-ty5-opponent-strength-slider/) |
 
 ---
-Last activity: 2026-04-29 — v1.14 milestone closed. Score-Based Opening Insights shipped (Phases 75, 76, 77; 16 plans; INSIGHT-UI-04 descoped). Next: open v1.15 via `/gsd-new-milestone`.
+Last activity: 2026-04-29 — Completed quick task 260429-ty5: dual-handle Opponent Strength range slider replacing the four-bucket ToggleGroup (Spike 001).

--- a/.planning/quick/260429-ty5-opponent-strength-slider/260429-ty5-PLAN.md
+++ b/.planning/quick/260429-ty5-opponent-strength-slider/260429-ty5-PLAN.md
@@ -1,0 +1,135 @@
+---
+quick_id: 260429-ty5
+slug: opponent-strength-slider
+description: Replace 4-option Opponent Strength ToggleGroup with a dual-handle range slider (-200..+200, step 50, unbounded endpoints) plus 4 preset chips (Any/Stronger/Similar/Weaker) that snap the slider.
+date: 2026-04-29
+status: planning
+must_haves:
+  truths:
+    - Backend accepts `opponent_gap_min` / `opponent_gap_max` (int | None) instead of (or in addition to) `opponent_strength` Literal across all game-filter endpoints.
+    - `apply_game_filters` filters games by `opp_rating - user_rating` against the gap bounds; missing ratings excluded when any bound set.
+    - Frontend `FilterState.opponentStrength` shape is `{ min: number | null, max: number | null }` where `null` means unbounded.
+    - FilterPanel renders 4 preset chips above a Radix dual-handle slider; chips snap the slider; manual handle drag deactivates active preset.
+    - Default = both handles parked at extremes (`min=null, max=null`) = no filter, equivalent to "Any".
+    - Mobile-first: thumb hit area ≥44px, `touch-action: none` on slider root, preset chips ≥44px tall.
+    - LLM endgame insights endpoint still accepts only the 4 preset ranges (or rejects custom ranges with 400) so the LLM cache key + scoping caveat stay simple.
+  artifacts:
+    - frontend/src/components/ui/slider.tsx (new shadcn-style Slider)
+    - frontend/src/components/filters/OpponentStrengthFilter.tsx (new — encapsulates presets + slider)
+    - frontend/src/lib/opponentStrength.ts (new — preset definitions + range↔preset helpers)
+    - app/repositories/query_utils.py (refactored signature)
+  key_links:
+    - .planning/spikes/MANIFEST.md
+    - .planning/spikes/001-opponent-strength-slider/README.md
+
+---
+
+# Quick Task 260429-ty5: Opponent Strength Range Slider
+
+## Goal
+
+Ship the dual-handle Opponent Strength filter validated by Spike 001. Frontend gets a range slider [-200..+200] step 50 with unbounded endpoints + 4 preset chips. Backend filter-by-gap replaces the four-bucket `Literal` everywhere except the LLM endgame insights cache layer (which keeps a derived preset string for cache-key stability).
+
+## Design Decisions (locked from spike)
+
+- Slider domain: `[-200, +200]`, step 50, both handles default to extremes.
+- Endpoints unbounded: when min handle is at `-200`, treat as `gap_min = null` (no lower bound). Same for max at `+200` → `gap_max = null`.
+- Presets:
+  - **Any** → `{min: null, max: null}` (slider [-200, +200])
+  - **Stronger** → `{min: 50, max: null}` (slider [+50, +200])
+  - **Similar** → `{min: -50, max: 50}` (slider [-50, +50])
+  - **Weaker** → `{min: null, max: -50}` (slider [-200, -50])
+- Inclusive bounds (gap ≥ min AND gap ≤ max). The original "stronger"/"weaker" SQL used `>=`/`<=` (inclusive at the threshold for stronger/weaker, strict for similar). Inclusive everywhere in the new world; +50 falls in both Stronger and Similar presets — fine, presets are user-facing shortcuts, not partitions.
+- `minStepsBetweenThumbs={1}` so handles can sit adjacent (e.g. [-50, 0]) but not on the same value.
+- Preset matching: a range matches a preset iff `min === preset.min && max === preset.max`.
+
+## Tasks
+
+### Task 1: Backend filter refactor (gap-based)
+
+**Files:**
+- `app/repositories/query_utils.py` — replace `opponent_strength` param with `opponent_gap_min: int | None` and `opponent_gap_max: int | None`; remove `elo_threshold`. Apply `opp_rating - user_rating BETWEEN min AND max` (only the bound that's non-null).
+- `app/schemas/openings.py` — replace `opponent_strength: Literal[...]` with `opponent_gap_min: int | None = None` and `opponent_gap_max: int | None = None` in 3 schemas.
+- `app/schemas/opening_insights.py` — same swap.
+- `app/schemas/insights.py` — `FilterContext`: same swap, plus a derived property `opponent_strength_preset: Literal["any","stronger","similar","weaker","custom"]` for LLM-side use.
+- `app/repositories/endgame_repository.py` — every function with `opponent_strength` param: replace with two int params.
+- `app/repositories/openings_repository.py` — same.
+- `app/repositories/stats_repository.py` — same.
+- `app/services/openings_service.py`, `app/services/endgame_service.py`, `app/services/opening_insights_service.py` — propagate.
+- `app/routers/openings.py`, `app/routers/endgames.py`, `app/routers/stats.py`, `app/routers/insights.py` — query params.
+- LLM-side (`app/schemas/llm_log.py`, `app/repositories/llm_log_repository.py`, `app/services/insights_llm.py`):
+  - Keep `LlmLogFilterContext.opponent_strength: Literal[...]` (derived preset name, "custom" possible).
+  - Insights endpoint: derive preset from `(gap_min, gap_max)`. If "custom", reject with HTTP 400 (defensive — UI gates this). Otherwise pass preset name down for cache key + scoping caveat.
+
+**Action:** Mechanical refactor. Use a helper `derive_preset(gap_min: int | None, gap_max: int | None) -> Literal[...]` to centralize the mapping.
+
+**Verify:** `uv run ruff check .`, `uv run ty check app/ tests/`, `uv run pytest`.
+
+**Done:** All backend filter paths accept `opponent_gap_min` / `opponent_gap_max`; `apply_game_filters` produces correct SQL; LLM cache key still uses preset string; tests pass.
+
+### Task 2: Frontend types, helpers, and Slider component
+
+**Files:**
+- `frontend/src/types/api.ts` — replace `OpponentStrength = 'any'|...` with:
+  ```ts
+  export type OpponentStrengthPreset = 'any' | 'stronger' | 'similar' | 'weaker';
+  export interface OpponentStrengthRange { min: number | null; max: number | null; }
+  ```
+  Keep `OpponentStrengthPreset` as a named type for places that need the preset (insights button gating, etc).
+- `frontend/src/types/position_bookmarks.ts` — `TimeSeriesRequest`: replace `opponent_strength?: 'any'|...` with `opponent_gap_min?: number | null; opponent_gap_max?: number | null;`.
+- `frontend/src/lib/opponentStrength.ts` (new): export
+  - `OPPONENT_STRENGTH_PRESETS` mapping name → range
+  - `derivePreset(range: OpponentStrengthRange): OpponentStrengthPreset | null`
+  - `presetToRange(p: OpponentStrengthPreset): OpponentStrengthRange`
+  - `formatRangeSummary(range): string` (e.g. "Any", "Stronger", "+50 … unbounded", "−100 … +50")
+  - Constants: `SLIDER_MIN = -200`, `SLIDER_MAX = 200`, `SLIDER_STEP = 50`
+- `frontend/src/components/ui/slider.tsx` (new): shadcn-style wrapper around `radix-ui/Slider` (the project already imports from `radix-ui` umbrella). Two-thumb support, `data-testid` plumbed via prop, `touch-action: none` on root.
+- Install dep: confirm `radix-ui` umbrella has `Slider` exported, otherwise add `@radix-ui/react-slider` to `frontend/package.json`.
+
+**Verify:** `npm run build`, `npm run lint`.
+
+**Done:** Slider component renders a dual-thumb slider; helpers correctly convert between range and preset.
+
+### Task 3: FilterPanel UI
+
+**Files:**
+- `frontend/src/components/filters/FilterPanel.tsx`:
+  - Replace ToggleGroup section with a new `<OpponentStrengthFilter />` (extract for reuse + testability).
+  - `DEFAULT_FILTERS.opponentStrength = { min: null, max: null }`.
+  - Update `FILTER_DOT_FIELDS` and `areFiltersEqual` to compare the range as an object (`min === min && max === max`).
+- `frontend/src/components/filters/OpponentStrengthFilter.tsx` (new):
+  - Header row: "Opponent Strength" label + range summary on the right (preset name in brand color, raw range otherwise).
+  - 4 preset chips (`Any` / `Stronger` / `Similar` / `Weaker`), 44px min-height, active-preset filled brand color.
+  - `<Slider />` with `value={[clamp(min ?? -200), clamp(max ?? 200)]}`, `min=-200`, `max=200`, `step=50`, `minStepsBetweenThumbs=1`.
+  - On commit: derive new range from slider values, mapping `-200 → null` and `+200 → null`.
+  - Endpoint tick labels `≤−200` / `≥+200` under the slider.
+  - InfoPopover: explain unbounded endpoints + preset shortcuts.
+  - data-testids: `filter-opponent-strength-preset-{any|stronger|similar|weaker}`, `filter-opponent-strength-slider`, `filter-opponent-strength-summary`.
+
+**Verify:** `npm run build`, `npm run lint`. Manually open in a browser: drag handles, tap presets, confirm summary updates.
+
+**Done:** FilterPanel shows the new UI on both desktop sidebar and mobile drawer (single shared component — already routed identically).
+
+### Task 4: Frontend hooks + API client wiring
+
+**Files:**
+- `frontend/src/api/client.ts` — every endpoint that takes `opponent_strength` now takes `opponent_gap_min`/`opponent_gap_max` (or omits them when null on both sides).
+- `frontend/src/hooks/useEndgameInsights.ts`, `useOpeningInsights.ts`, `useEndgames.ts`, `useStats.ts`, `useNextMoves.ts`, `useOpenings.ts` — replace `opponent_strength` param plumbing with the two new ints. Update `queryKey`s.
+- `frontend/src/components/insights/EndgameInsightsBlock.tsx`, `OpeningInsightsBlock.tsx` — wherever they read `opponent_strength` for gating/messaging, switch to deriving the preset name via `derivePreset(filters.opponentStrength)`.
+- `frontend/src/pages/GlobalStats.tsx` — same.
+- Tests: `frontend/src/hooks/__tests__/useEndgameInsights.test.tsx`, `useOpeningInsights.test.tsx` — update fixtures to new shape.
+
+**Verify:** `npm run build`, `npm test`, `npm run knip`.
+
+**Done:** All hooks send the new params, all tests pass, knip is clean.
+
+### Task 5: Final checks
+
+- `uv run ruff format . && uv run ruff check . && uv run ty check app/ tests/ && uv run pytest`
+- `npm run lint && npm run build && npm test && npm run knip`
+
+## Notes
+
+- The endgame insights LLM cache key intentionally collapses to preset name (`any|stronger|similar|weaker`). Custom ranges aren't allowed for that endpoint (router rejects with 400). The OpeningInsightsBlock + EndgameInsightsBlock buttons already gate on filter state — extend the gating to also disable when the range is "custom".
+- No DB migration needed: nothing is stored as `opponent_strength` in any table column. `LlmLog.filter_context` is JSONB and stores the preset string, which we keep.
+- We preserve the bookmark JSON shape backward-compat by accepting either old (`opponent_strength`) or new (`opponent_gap_min`/`max`) fields when reading; only emit the new fields when writing. Actually: bookmarks send filter state with the time-series request — they don't store strength. So no compat needed.

--- a/.planning/quick/260429-ty5-opponent-strength-slider/260429-ty5-SUMMARY.md
+++ b/.planning/quick/260429-ty5-opponent-strength-slider/260429-ty5-SUMMARY.md
@@ -1,0 +1,83 @@
+---
+quick_id: 260429-ty5
+slug: opponent-strength-slider
+description: Replace 4-option Opponent Strength ToggleGroup with a dual-handle range slider plus preset chips
+date: 2026-04-29
+status: complete
+commit: 124237b
+---
+
+# Quick Task 260429-ty5: Opponent Strength Range Slider — Summary
+
+## What changed
+
+Replaced the four-bucket `OpponentStrength` ToggleGroup (`any` / `stronger` / `similar` / `weaker`) with a dual-handle range slider over `[−200, +200]` ELO gap, snapping to multiples of 50, with four preset chips above (Any / Stronger / Similar / Weaker) that snap the slider. Slider endpoints map to unbounded (`null`) on the API, matching Spike 001.
+
+## Backend (commits f99d35a, 123d21f, 08363e6)
+
+- **New module** `app/core/opponent_strength.py` — preset/range mapping helpers (`derive_preset`, `preset_to_range`, `PRESET_THRESHOLD`). Lives in `core` so it can be imported from routers, services, and the LLM cache layer without violating the "no repository imports from services" layering rule.
+- **`app/repositories/query_utils.py`** — `apply_game_filters` now takes `opponent_gap_min: int | None` and `opponent_gap_max: int | None` (None = unbounded). Filters by `opp_rating - user_rating >= gap_min` / `<= gap_max`. Removed `DEFAULT_ELO_THRESHOLD` and the `opponent_strength` Literal param.
+- **Schemas** (`app/schemas/openings.py`, `opening_insights.py`) — replaced `opponent_strength` Literal field with `opponent_gap_min` / `opponent_gap_max` int fields.
+- **Repositories** (`endgame_repository.py`, `openings_repository.py`, `stats_repository.py`) — every function that took `opponent_strength` + `elo_threshold` now takes `opponent_gap_min` + `opponent_gap_max`. The two duplicated inline filter blocks in `openings_repository.py` were rewritten to use the new range form.
+- **Services** (`endgame_service.py`, `openings_service.py`, `opening_insights_service.py`, `stats_service.py`) — all signatures updated to forward the new gap params. `insights_service.compute_findings` translates `FilterContext.opponent_strength` (preset name) → range via `preset_to_range` before calling `get_endgame_overview`.
+- **Routers** (`endgames.py`, `stats.py`, `insights.py`) — accept `opponent_gap_min` / `opponent_gap_max` query params. The endgame insights endpoint additionally derives the preset name (`derive_preset`) and rejects custom (non-preset) ranges with HTTP 400 — keeping the LLM cache key (still keyed on preset name) stable.
+- **LLM cache** (`app/schemas/llm_log.py`, `llm_log_repository.py`, `services/insights_llm.py`) — unchanged; still uses preset-name string for cache key + scoping caveat. The router enforces "preset only" for this endpoint.
+- **Tests** updated: `test_stats_router.py`, `test_insights_router.py`, `tests/repositories/test_opening_insights_repository.py`. All 1165 backend tests pass.
+
+## Frontend (commit 124237b)
+
+- **New shadcn-style component** `frontend/src/components/ui/slider.tsx` — wraps `radix-ui/Slider` with two-thumb support, `touch-action: none`, 24px thumbs on a 44px-min hit area. Per-thumb aria-labels via the `thumbLabels` prop.
+- **New helper** `frontend/src/lib/opponentStrength.ts` — slider domain constants (`SLIDER_MIN=-200`, `SLIDER_MAX=200`, `SLIDER_STEP=50`), preset definitions, and helpers: `derivePreset`, `presetToRange`, `sliderToRange`, `rangeToSlider`, `formatRangeSummary`, `rangeToQueryParams`.
+- **New filter component** `frontend/src/components/filters/OpponentStrengthFilter.tsx`:
+  - Header row with label + summary text (preset name in brand color, raw range otherwise).
+  - 4 preset chips (44px tall on mobile, 28px on sm+).
+  - Radix dual-handle slider with `minStepsBetweenThumbs=1`.
+  - Endpoint tick labels `≤−200` / `0` / `≥+200`.
+  - InfoPopover explaining presets and unbounded endpoints.
+- **`FilterPanel.tsx`**:
+  - `FilterState.opponentStrength` shape changed from `OpponentStrength` literal to `OpponentStrengthRange = { min: number | null; max: number | null }`.
+  - `DEFAULT_FILTERS.opponentStrength = { min: null, max: null }` (= "Any" preset).
+  - `areFiltersEqual` extended with structural compare for the range object.
+  - Inline ToggleGroup replaced with `<OpponentStrengthFilter />`.
+- **API client** (`frontend/src/api/client.ts`) — `buildFilterParams` now accepts `opponent_strength: OpponentStrengthRange` and emits `opponent_gap_min` / `opponent_gap_max` query params (omitted when null).
+- **Hooks** (`useStats`, `useEndgames`, `useEndgameInsights`, `useOpeningInsights`, `useOpenings`, `useNextMoves`) — all wired to send the new range. Query keys include `range.min` and `range.max` so cache invalidation tracks the new shape.
+- **`EndgameInsightsBlock`** — Generate button now disabled when `derivePreset(filters.opponentStrength) === null` (custom range), with tooltip "Snap opponent strength to a preset". This mirrors the router-side 400 enforcement.
+- **Bookmarks** — `TimeSeriesRequest` accepts `opponent_gap_min` / `opponent_gap_max` instead of `opponent_strength`. `pages/Openings.tsx` uses `rangeToQueryParams` to spread the gap params into the request.
+- **Tests** — fixtures in `useEndgameInsights.test.tsx`, `useOpeningInsights.test.tsx`, `EndgameInsightsBlock.test.tsx`, `OpeningInsightsBlock.test.tsx` updated. All 211 frontend tests pass.
+
+## Design decisions (locked from spike)
+
+- Slider domain `[-200, +200]`, step 50; both handles default to extremes (= "Any" preset, no filter).
+- Endpoints unbounded: handle at `-200` → `null` (no lower bound); handle at `+200` → `null` (no upper bound).
+- Preset ranges:
+  - **Any** → `{min: null, max: null}`
+  - **Stronger** → `{min: 50, max: null}`
+  - **Similar** → `{min: -50, max: 50}`
+  - **Weaker** → `{min: null, max: -50}`
+- Inclusive bounds (gap ≥ min AND gap ≤ max). Differs slightly from the prior strict-similar SQL — a gap of exactly +50 now matches both Stronger and Similar presets, but presets are user-facing shortcuts, not partitions.
+- `minStepsBetweenThumbs={1}` — handles can sit adjacent (e.g. `[-50, 0]`) but not on the same value.
+- LLM endgame insights endpoint accepts only the four preset ranges; custom ranges return 400. The frontend disables the Generate button proactively.
+
+## Verification
+
+- `uv run ruff check app/ tests/` — clean
+- `uv run ty check app/ tests/` — clean
+- `uv run pytest tests/` — 1165 passed
+- `npm run lint` — 0 errors (3 unrelated coverage-file warnings)
+- `npm run build` — success
+- `npm test -- --run` — 211 passed
+- `npm run knip` — clean
+
+## No DB migration
+
+Nothing is stored as `opponent_strength` in any column. `LlmLog.filter_context` is JSONB and continues to store the preset name string — unchanged on the cache side.
+
+## Files
+
+- New: `app/core/opponent_strength.py`, `frontend/src/components/ui/slider.tsx`, `frontend/src/components/filters/OpponentStrengthFilter.tsx`, `frontend/src/lib/opponentStrength.ts`
+- Modified backend: `app/repositories/{query_utils,endgame_repository,openings_repository,stats_repository}.py`, `app/routers/{insights,endgames,stats}.py`, `app/schemas/{openings,opening_insights}.py`, `app/services/{endgame_service,openings_service,opening_insights_service,stats_service,insights_service}.py`, `tests/{test_stats_router,test_insights_router,repositories/test_opening_insights_repository}.py`
+- Modified frontend: `frontend/src/api/client.ts`, `frontend/src/components/filters/FilterPanel.tsx`, `frontend/src/components/insights/{EndgameInsightsBlock,OpeningInsightsBlock,OpeningInsightsBlock.test}.tsx`, `frontend/src/components/insights/__tests__/EndgameInsightsBlock.test.tsx`, `frontend/src/hooks/{useStats,useNextMoves,useOpeningInsights,useOpenings}.ts`, `frontend/src/hooks/__tests__/{useEndgameInsights,useOpeningInsights}.test.tsx`, `frontend/src/pages/Openings.tsx`, `frontend/src/types/{api,position_bookmarks}.ts`
+
+## Follow-ups (not in scope)
+
+- Real-phone mobile UX validation per spike checklist (`.planning/todos/pending/opponent-filter-mobile-ux-check.md`).

--- a/app/core/opponent_strength.py
+++ b/app/core/opponent_strength.py
@@ -1,0 +1,55 @@
+"""Opponent-strength preset helpers shared across routers, services, and repositories.
+
+The Opponent Strength filter is a (gap_min, gap_max) range over opponent_rating
+- user_rating, with four named preset shortcuts. This module centralises the
+mapping between range and preset so router/service/repository layers can all
+agree on the four canonical buckets without duplicating the thresholds.
+"""
+
+from typing import Literal
+
+# Preset thresholds (Elo gap, opponent − user) used to map between the four
+# preset shortcuts (any / stronger / similar / weaker) and the gap-based
+# range filter. Spike 001 locked these values.
+PRESET_THRESHOLD = 50
+
+OpponentStrengthPreset = Literal["any", "stronger", "similar", "weaker", "custom"]
+
+
+def preset_to_range(
+    preset: Literal["any", "stronger", "similar", "weaker"],
+) -> tuple[int | None, int | None]:
+    """Map a preset name to (gap_min, gap_max). Inverse of derive_preset."""
+    if preset == "any":
+        return (None, None)
+    if preset == "stronger":
+        return (PRESET_THRESHOLD, None)
+    if preset == "similar":
+        return (-PRESET_THRESHOLD, PRESET_THRESHOLD)
+    return (None, -PRESET_THRESHOLD)
+
+
+def derive_preset(
+    opponent_gap_min: int | None,
+    opponent_gap_max: int | None,
+) -> OpponentStrengthPreset:
+    """Map a (gap_min, gap_max) range to the closest preset name.
+
+    Returns "any" / "stronger" / "similar" / "weaker" when the range exactly
+    matches one of the four preset ranges, else "custom".
+
+    Preset ranges (None = unbounded):
+      any      → (None, None)
+      stronger → (50, None)
+      similar  → (-50, 50)
+      weaker   → (None, -50)
+    """
+    if opponent_gap_min is None and opponent_gap_max is None:
+        return "any"
+    if opponent_gap_min == PRESET_THRESHOLD and opponent_gap_max is None:
+        return "stronger"
+    if opponent_gap_min == -PRESET_THRESHOLD and opponent_gap_max == PRESET_THRESHOLD:
+        return "similar"
+    if opponent_gap_min is None and opponent_gap_max == -PRESET_THRESHOLD:
+        return "weaker"
+    return "custom"

--- a/app/repositories/endgame_repository.py
+++ b/app/repositories/endgame_repository.py
@@ -11,7 +11,7 @@ Functions:
 
 import datetime
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any
 
 from sqlalchemy import case, func, select, type_coerce
 from sqlalchemy.dialects.postgresql import ARRAY, aggregate_order_by
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
 from app.models.game_position import GamePosition
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD, apply_game_filters
+from app.repositories.query_utils import apply_game_filters
 from app.schemas.endgames import EndgameClass
 
 # Piece-count threshold for endgame classification (Lichess definition).
@@ -79,8 +79,8 @@ async def count_filtered_games(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> int:
     """Count ALL games for the user matching the given filters.
 
@@ -95,8 +95,8 @@ async def count_filtered_games(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     result = await session.execute(stmt)
     return result.scalar_one()
@@ -110,8 +110,8 @@ async def count_endgame_games(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> int:
     """Count games that reached an endgame phase per the uniform ENDGAME_PLY_THRESHOLD rule.
 
@@ -135,8 +135,8 @@ async def count_endgame_games(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     result = await session.execute(stmt)
     return result.scalar_one()
@@ -150,8 +150,8 @@ async def query_endgame_entry_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return one row per (game, endgame_class) span meeting the ply threshold.
 
@@ -250,8 +250,8 @@ async def query_endgame_entry_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -266,8 +266,8 @@ async def query_endgame_bucket_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return exactly one row per endgame game for conv/even/recov bucketing.
 
@@ -378,8 +378,8 @@ async def query_endgame_bucket_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -397,8 +397,8 @@ async def query_endgame_games(
     recency_cutoff: datetime.datetime | None,
     offset: int,
     limit: int,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> tuple[list[Game], int]:
     """Return paginated Game objects for games that spent >= ENDGAME_PLY_THRESHOLD plies
     in the given endgame class.
@@ -441,8 +441,8 @@ async def query_endgame_games(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Count total matching games (before pagination)
@@ -474,8 +474,8 @@ async def query_endgame_performance_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> tuple[list[Row[Any]], list[Row[Any]]]:
     """Return endgame and non-endgame game rows for performance comparison.
 
@@ -512,8 +512,8 @@ async def query_endgame_performance_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Non-endgame games: id NOT in the endgame subquery
@@ -527,8 +527,8 @@ async def query_endgame_performance_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Execute sequentially — AsyncSession is not safe for concurrent use from
@@ -548,8 +548,8 @@ async def query_endgame_timeline_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> tuple[list[Row[Any]], list[Row[Any]], dict[int, list[Row[Any]]]]:
     """Return rows for rolling-window time series (overall and per endgame class).
 
@@ -613,8 +613,8 @@ async def query_endgame_timeline_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Execute sequentially — AsyncSession is not safe for concurrent use from
@@ -669,8 +669,8 @@ async def query_endgame_timeline_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     non_endgame_result = await session.execute(non_endgame_stmt)
@@ -687,8 +687,8 @@ async def query_clock_stats_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return rows for Time Pressure at Endgame Entry and Time Pressure vs Performance.
 
@@ -789,8 +789,8 @@ async def query_clock_stats_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -805,8 +805,8 @@ async def query_endgame_elo_timeline_rows(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> tuple[list[Row[Any]], list[Row[Any]]]:
     """Return (bucket_rows, all_rows) for the Phase 57 Endgame ELO timeline.
 
@@ -828,7 +828,7 @@ async def query_endgame_elo_timeline_rows(
     Both queries:
     - Filter by Game.user_id == user_id at the TOP LEVEL (user scoping).
     - Use apply_game_filters for time_control/platform/rated/opponent_type/
-      recency_cutoff/opponent_strength. Never duplicate filter logic.
+      recency_cutoff/opponent_gap_{min,max}. Never duplicate filter logic.
     - Exclude rows with NULL played_at.
     - Exclude rows where white_rating IS NULL OR black_rating IS NULL (needed
       for per-side Elo math; a game without ratings can't contribute).
@@ -894,7 +894,9 @@ async def query_endgame_elo_timeline_rows(
             Game.white_rating,
             Game.black_rating,
             (entry_subq.c.entry_imbalance * color_sign).label("user_material_imbalance"),
-            (entry_subq.c.entry_imbalance_after * color_sign).label("user_material_imbalance_after"),
+            (entry_subq.c.entry_imbalance_after * color_sign).label(
+                "user_material_imbalance_after"
+            ),
             Game.result,
         )
         .join(entry_subq, Game.id == entry_subq.c.game_id)
@@ -913,8 +915,8 @@ async def query_endgame_elo_timeline_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # ── all_rows: one row per user game (endgame + non-endgame) ─────────────
@@ -942,8 +944,8 @@ async def query_endgame_elo_timeline_rows(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Execute sequentially — AsyncSession is not safe for concurrent use from

--- a/app/repositories/openings_repository.py
+++ b/app/repositories/openings_repository.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import aliased
 from app.models.game import Game
 from app.models.game_position import GamePosition
 from app.models.opening import Opening
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD, apply_game_filters
+from app.repositories.query_utils import apply_game_filters
 from app.services.opening_insights_constants import (
     OPENING_INSIGHTS_MAX_ENTRY_PLY,
     OPENING_INSIGHTS_MIN_ENTRY_PLY,
@@ -58,8 +58,8 @@ def _build_base_query(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
     color: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> Any:
     """Build a filtered SELECT that joins game_positions -> games.
 
@@ -104,7 +104,7 @@ def _build_base_query(
         base = base.where(Game.played_at >= recency_cutoff)
     if color is not None:
         base = base.where(Game.user_color == color)
-    if opponent_strength != "any":
+    if opponent_gap_min is not None or opponent_gap_max is not None:
         user_rating = case(
             (Game.user_color == "white", Game.white_rating),
             else_=Game.black_rating,
@@ -114,15 +114,11 @@ def _build_base_query(
             else_=Game.white_rating,
         )
         base = base.where(Game.white_rating.isnot(None), Game.black_rating.isnot(None))
-        if opponent_strength == "stronger":
-            base = base.where(opp_rating >= user_rating + elo_threshold)
-        elif opponent_strength == "similar":
-            base = base.where(
-                opp_rating > user_rating - elo_threshold,
-                opp_rating < user_rating + elo_threshold,
-            )
-        elif opponent_strength == "weaker":
-            base = base.where(opp_rating <= user_rating - elo_threshold)
+        gap = opp_rating - user_rating
+        if opponent_gap_min is not None:
+            base = base.where(gap >= opponent_gap_min)
+        if opponent_gap_max is not None:
+            base = base.where(gap <= opponent_gap_max)
 
     return base
 
@@ -138,8 +134,8 @@ async def query_time_series(
     rated: bool | None = None,
     opponent_type: str = "human",
     recency_cutoff: datetime.datetime | None = None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return (played_at, result, user_color) tuples for matching games, ordered chronologically.
 
@@ -174,7 +170,7 @@ async def query_time_series(
         stmt = stmt.where(Game.is_computer_game == True)  # noqa: E712
     if recency_cutoff is not None:
         stmt = stmt.where(Game.played_at >= recency_cutoff)
-    if opponent_strength != "any":
+    if opponent_gap_min is not None or opponent_gap_max is not None:
         user_rating = case(
             (Game.user_color == "white", Game.white_rating),
             else_=Game.black_rating,
@@ -184,15 +180,11 @@ async def query_time_series(
             else_=Game.white_rating,
         )
         stmt = stmt.where(Game.white_rating.isnot(None), Game.black_rating.isnot(None))
-        if opponent_strength == "stronger":
-            stmt = stmt.where(opp_rating >= user_rating + elo_threshold)
-        elif opponent_strength == "similar":
-            stmt = stmt.where(
-                opp_rating > user_rating - elo_threshold,
-                opp_rating < user_rating + elo_threshold,
-            )
-        elif opponent_strength == "weaker":
-            stmt = stmt.where(opp_rating <= user_rating - elo_threshold)
+        gap = opp_rating - user_rating
+        if opponent_gap_min is not None:
+            stmt = stmt.where(gap >= opponent_gap_min)
+        if opponent_gap_max is not None:
+            stmt = stmt.where(gap <= opponent_gap_max)
 
     # Wrap in subquery so outer query can order by played_at ASC after DISTINCT ON Game.id
     subq = stmt.subquery()
@@ -212,8 +204,8 @@ async def query_all_results(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
     color: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return (result, user_color) tuples for ALL matching games (for stats).
 
@@ -232,8 +224,8 @@ async def query_all_results(
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
         color=color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     rows = await session.execute(stmt)
     return list(rows.all())
@@ -250,8 +242,8 @@ async def query_wdl_counts(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
     color: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> Row[Any]:
     """Return a single row (total, wins, draws, losses) via SQL aggregation.
 
@@ -275,8 +267,8 @@ async def query_wdl_counts(
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
         color=color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     ).subquery("dedup")
 
     # W/D/L conditions on the subquery columns (same logic as stats_repository.py)
@@ -314,8 +306,8 @@ async def query_matching_games(
     color: str | None,
     offset: int,
     limit: int,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> tuple[list[Game], int]:
     """Return a paginated list of Game objects and the total matching count.
 
@@ -334,8 +326,8 @@ async def query_matching_games(
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
         color=color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     ).subquery()
     count_stmt = select(func.count()).select_from(count_subq)
     total: int = (await session.execute(count_stmt)).scalar_one()
@@ -355,8 +347,8 @@ async def query_matching_games(
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
         color=color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     if target_hash is not None:
         # DISTINCT ON needs id-first ordering for dedup; outer query re-sorts
@@ -387,8 +379,8 @@ async def query_next_moves(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
     color: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Any]:
     """Aggregate next moves for a given position with per-move W/D/L stats.
 
@@ -454,8 +446,8 @@ async def query_next_moves(
         opponent_type,
         recency_cutoff,
         color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     rows = await session.execute(stmt)
@@ -472,8 +464,8 @@ async def query_transposition_counts(
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
     color: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> dict[int, int]:
     """Return the total distinct games reaching each result_hash under the same filters.
 
@@ -508,8 +500,8 @@ async def query_transposition_counts(
         opponent_type,
         recency_cutoff,
         color,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     rows = await session.execute(stmt)
@@ -525,8 +517,8 @@ async def query_opening_transitions(
     rated: bool | None,
     opponent_type: str,
     recency_cutoff: datetime.datetime | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Aggregate (entry_hash, candidate_san) transitions for one user & color.
 
@@ -715,8 +707,8 @@ async def query_opening_transitions(
         opponent_type,
         recency_cutoff,
         color=None,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)

--- a/app/repositories/query_utils.py
+++ b/app/repositories/query_utils.py
@@ -2,13 +2,12 @@
 
 import datetime
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any
 
 from sqlalchemy import case
 
 from app.models.game import Game
 
-DEFAULT_ELO_THRESHOLD = 50
 
 def apply_game_filters(
     stmt: Any,
@@ -19,8 +18,8 @@ def apply_game_filters(
     recency_cutoff: datetime.datetime | None,
     color: str | None = None,
     *,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> Any:
     """Apply standard game filter WHERE clauses to a SELECT statement.
 
@@ -33,10 +32,14 @@ def apply_game_filters(
         recency_cutoff: Only include games played after this datetime. None = no filter.
         color: Filter by user's piece color ("white"/"black"). None = no color filter
                (used by endgame and stats repos where color is not applicable).
-        opponent_strength: Filter by relative opponent strength: "any", "stronger",
-                           "similar", or "weaker". Games with missing ratings are
-                           excluded when any non-"any" option is selected.
-        elo_threshold: Rating difference threshold for opponent_strength filter.
+        opponent_gap_min: Lower bound (inclusive) on opponent_rating - user_rating.
+                         None = unbounded below.
+        opponent_gap_max: Upper bound (inclusive) on opponent_rating - user_rating.
+                         None = unbounded above.
+
+    Notes:
+        When either gap bound is set, games with missing white/black ratings
+        are excluded.
 
     Returns:
         The statement with WHERE clauses appended.
@@ -55,7 +58,7 @@ def apply_game_filters(
         stmt = stmt.where(Game.played_at >= recency_cutoff)
     if color is not None:
         stmt = stmt.where(Game.user_color == color)
-    if opponent_strength != "any":
+    if opponent_gap_min is not None or opponent_gap_max is not None:
         user_rating = case(
             (Game.user_color == "white", Game.white_rating),
             else_=Game.black_rating,
@@ -64,15 +67,11 @@ def apply_game_filters(
             (Game.user_color == "white", Game.black_rating),
             else_=Game.white_rating,
         )
-        # Exclude games with missing ratings when filtering by opponent strength
+        # Exclude games with missing ratings when filtering by opponent gap.
         stmt = stmt.where(Game.white_rating.isnot(None), Game.black_rating.isnot(None))
-        if opponent_strength == "stronger":
-            stmt = stmt.where(opp_rating >= user_rating + elo_threshold)
-        elif opponent_strength == "similar":
-            stmt = stmt.where(
-                opp_rating > user_rating - elo_threshold,
-                opp_rating < user_rating + elo_threshold,
-            )
-        elif opponent_strength == "weaker":
-            stmt = stmt.where(opp_rating <= user_rating - elo_threshold)
+        gap = opp_rating - user_rating
+        if opponent_gap_min is not None:
+            stmt = stmt.where(gap >= opponent_gap_min)
+        if opponent_gap_max is not None:
+            stmt = stmt.where(gap <= opponent_gap_max)
     return stmt

--- a/app/repositories/stats_repository.py
+++ b/app/repositories/stats_repository.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
 from app.models.game_position import GamePosition
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD, apply_game_filters
+from app.repositories.query_utils import apply_game_filters
 
 # Standalone MetaData (not Base.metadata) keeps the view invisible to Alembic autogenerate.
 _openings_dedup = Table(
@@ -51,7 +51,8 @@ async def query_rating_history(
     recency_cutoff: datetime.datetime | None,
     *,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return one rating data point per (date, time_control_bucket) for a given platform.
 
@@ -91,7 +92,8 @@ async def query_rating_history(
         rated=None,
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -105,12 +107,13 @@ async def query_results_by_time_control(
     platform: str | None = None,
     *,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return (time_control_bucket, total, wins, draws, losses) via SQL aggregation.
 
     Excludes games where time_control_bucket is NULL.
-    Optionally filtered by platform, recency, opponent_type, and opponent_strength.
+    Optionally filtered by platform, recency, opponent_type, and opponent gap.
     """
     win_cond = or_(
         and_(Game.result == "1-0", Game.user_color == "white"),
@@ -145,7 +148,8 @@ async def query_results_by_time_control(
         rated=None,
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -159,12 +163,13 @@ async def query_results_by_color(
     platform: str | None = None,
     *,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return (user_color, total, wins, draws, losses) via SQL aggregation.
 
     Excludes games where user_color is NULL.
-    Optionally filtered by platform, recency, opponent_type, and opponent_strength.
+    Optionally filtered by platform, recency, opponent_type, and opponent gap.
     """
     win_cond = or_(
         and_(Game.result == "1-0", Game.user_color == "white"),
@@ -199,7 +204,8 @@ async def query_results_by_color(
         rated=None,
         opponent_type=opponent_type,
         recency_cutoff=recency_cutoff,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -218,8 +224,8 @@ async def query_top_openings_sql_wdl(
     platform: Sequence[str] | None = None,
     rated: bool | None = None,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> list[Row[Any]]:
     """Return top openings with SQL-side WDL aggregation, ranked by position count.
 
@@ -309,8 +315,8 @@ async def query_top_openings_sql_wdl(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     result = await session.execute(stmt)
@@ -339,8 +345,8 @@ async def query_position_wdl_batch(
     rated: bool | None = None,
     opponent_type: str = "human",
     recency_cutoff: datetime.datetime | None = None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> dict[int, PositionWDL]:
     """Return {full_hash: PositionWDL} for games passing through each position.
 
@@ -375,8 +381,8 @@ async def query_position_wdl_batch(
         rated,
         opponent_type,
         recency_cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     dedup = dedup.subquery()
 

--- a/app/routers/endgames.py
+++ b/app/routers/endgames.py
@@ -5,7 +5,7 @@ Endpoints (all mounted under /api/endgames):
 - GET /games: paginated game list filtered by endgame class
 """
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,7 +17,6 @@ from app.schemas.endgames import (
     EndgameGamesResponse,
     EndgameOverviewResponse,
 )
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
 from app.services import endgame_service
 from app.users import current_active_user
 
@@ -35,8 +34,8 @@ async def get_endgame_overview(
     rated: bool | None = Query(default=None),
     opponent_type: str = Query(default="human"),
     window: int = Query(default=50, ge=5, le=200),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
-    elo_threshold: int = Query(default=DEFAULT_ELO_THRESHOLD),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
 ) -> EndgameOverviewResponse:
     """Return all four endgame dashboard payloads in a single response.
 
@@ -56,8 +55,8 @@ async def get_endgame_overview(
         opponent_type=opponent_type,
         recency=recency,
         window=window,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
 
@@ -73,8 +72,8 @@ async def get_endgame_games(
     opponent_type: str = Query(default="human"),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, ge=1, le=100),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
-    elo_threshold: int = Query(default=DEFAULT_ELO_THRESHOLD),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
 ) -> EndgameGamesResponse:
     """Return paginated games filtered by endgame class (D-12, D-14).
 
@@ -96,6 +95,6 @@ async def get_endgame_games(
         recency=recency,
         offset=offset,
         limit=limit,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )

--- a/app/routers/insights.py
+++ b/app/routers/insights.py
@@ -37,6 +37,7 @@ from app.services.insights_llm import (
     InsightsRateLimitExceeded,
     InsightsValidationFailure,
 )
+from app.core.opponent_strength import derive_preset
 from app.services.opening_insights_service import compute_insights
 from app.users import current_active_user
 
@@ -90,7 +91,8 @@ async def get_endgame_insights(
         "all_time", "week", "month", "3months", "6months", "year", "3years", "5years"
     ] = Query(default="all_time"),
     rated: bool | None = Query(default=None),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
     color: Literal["all", "white", "black"] = Query(default="all"),
 ) -> EndgameInsightsResponse | JSONResponse:
     """Return the LLM-generated EndgameInsightsReport for the authenticated user.
@@ -101,15 +103,35 @@ async def get_endgame_insights(
     other than opponent_strength must be at defaults — see
     `_validate_full_history_filters`.
 
+    Opponent strength is accepted as a (gap_min, gap_max) pair to mirror the
+    range slider. Only the four preset ranges (any/stronger/similar/weaker) are
+    permitted here so the LLM cache key (keyed on preset name) stays stable —
+    custom ranges return 400.
+
     Returns:
         200: EndgameInsightsResponse with status in {fresh, cache_hit, stale_rate_limited}.
-        400: filters_not_supported (any non-default filter other than opponent_strength).
+        400: filters_not_supported (any non-default filter other than opponent_strength,
+             or custom (non-preset) opponent gap range).
         429: InsightsErrorResponse(error='rate_limit_exceeded', retry_after_seconds=N).
         502: InsightsErrorResponse(error='provider_error' | 'validation_failure').
     """
+    preset = derive_preset(opponent_gap_min, opponent_gap_max)
+    if preset == "custom":
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "filters_not_supported",
+                "message": (
+                    "Insights only support the preset opponent strength buckets "
+                    "(Any / Stronger / Similar / Weaker). Snap the slider to a "
+                    "preset to generate a report."
+                ),
+                "blocking": ["Snap opponent strength to a preset"],
+            },
+        )
     filter_context = FilterContext(
         recency=recency,
-        opponent_strength=opponent_strength,
+        opponent_strength=preset,
         color=color,
         time_controls=time_control or [],
         platforms=platform or [],

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -1,6 +1,6 @@
 """Stats router: GET /stats/rating-history and GET /stats/global endpoints."""
 
-from typing import Annotated, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_async_session
 from app.models.user import User
 from app.schemas.stats import GlobalStatsResponse, MostPlayedOpeningsResponse, RatingHistoryResponse
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
 from app.services import stats_service
 from app.users import current_active_user
 
@@ -22,11 +21,12 @@ async def get_rating_history(
     recency: str | None = Query(default=None),
     platform: str | None = Query(default=None),
     opponent_type: str = Query(default="human"),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
 ) -> RatingHistoryResponse:
     """Return per-platform per-game rating data points.
 
-    Optionally filtered by recency, platform, opponent_type, and opponent_strength.
+    Optionally filtered by recency, platform, opponent_type, and opponent gap.
     """
     return await stats_service.get_rating_history(
         session,
@@ -34,7 +34,8 @@ async def get_rating_history(
         recency,
         platform,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
 
@@ -45,11 +46,12 @@ async def get_global_stats(
     recency: str | None = Query(default=None),
     platform: str | None = Query(default=None),
     opponent_type: str = Query(default="human"),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
 ) -> GlobalStatsResponse:
     """Return global W/D/L breakdowns by time control and by color.
 
-    Optionally filtered by recency, platform, opponent_type, and opponent_strength.
+    Optionally filtered by recency, platform, opponent_type, and opponent gap.
     """
     return await stats_service.get_global_stats(
         session,
@@ -57,7 +59,8 @@ async def get_global_stats(
         recency,
         platform,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
 
@@ -70,8 +73,8 @@ async def get_most_played_openings(
     platform: list[str] | None = Query(default=None),
     rated: bool | None = Query(default=None),
     opponent_type: str = Query(default="human"),
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = Query(default="any"),
-    elo_threshold: int = Query(default=DEFAULT_ELO_THRESHOLD),
+    opponent_gap_min: int | None = Query(default=None),
+    opponent_gap_max: int | None = Query(default=None),
 ) -> MostPlayedOpeningsResponse:
     """Return top 10 most played openings per color with SQL-side WDL stats.
 
@@ -85,6 +88,6 @@ async def get_most_played_openings(
         platform=platform,
         rated=rated,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )

--- a/app/schemas/opening_insights.py
+++ b/app/schemas/opening_insights.py
@@ -4,7 +4,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
 from app.services.opening_insights_constants import (
     OPENING_INSIGHTS_MIN_GAMES_PER_CANDIDATE,
 )
@@ -31,8 +30,8 @@ class OpeningInsightsRequest(BaseModel):
     platform: list[Literal["chess.com", "lichess"]] | None = None
     rated: bool | None = None
     opponent_type: Literal["human", "bot", "both"] = "human"
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any"
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD
+    opponent_gap_min: int | None = None
+    opponent_gap_max: int | None = None
     color: Literal["all", "white", "black"] = "all"
 
 

--- a/app/schemas/openings.py
+++ b/app/schemas/openings.py
@@ -5,8 +5,6 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
-
 
 class OpeningsRequest(BaseModel):
     """Request body for POST /openings/positions."""
@@ -30,6 +28,7 @@ class OpeningsRequest(BaseModel):
         if isinstance(v, str):
             return int(v)
         return v
+
     match_side: Literal["white", "black", "full"] = "full"
 
     # Optional filters
@@ -37,11 +36,13 @@ class OpeningsRequest(BaseModel):
     platform: list[Literal["chess.com", "lichess"]] | None = None
     rated: bool | None = None
     opponent_type: Literal["human", "bot", "both"] = "human"
-    recency: Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None = None
+    recency: (
+        Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None
+    ) = None
     color: Literal["white", "black"] | None = None
 
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any"
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD
+    opponent_gap_min: int | None = None
+    opponent_gap_max: int | None = None
 
     # Pagination
     offset: Annotated[int, Field(ge=0)] = 0
@@ -119,18 +120,20 @@ class TimeSeriesRequest(BaseModel):
     platform: list[Literal["chess.com", "lichess"]] | None = None
     rated: bool | None = None
     opponent_type: Literal["human", "bot", "both"] = "human"
-    recency: Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None = None
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any"
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD
+    recency: (
+        Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None
+    ) = None
+    opponent_gap_min: int | None = None
+    opponent_gap_max: int | None = None
 
 
 class TimeSeriesPoint(BaseModel):
     """Win-rate data for a single rolling-window datapoint."""
 
-    date: str           # "2025-01-15" (ISO date of the game)
-    win_rate: float     # wins / total in trailing window
-    game_count: int     # total games in the window (1..window_size)
-    window_size: int    # the configured window size (always ROLLING_WINDOW_SIZE)
+    date: str  # "2025-01-15" (ISO date of the game)
+    win_rate: float  # wins / total in trailing window
+    game_count: int  # total games in the window (1..window_size)
+    window_size: int  # the configured window size (always ROLLING_WINDOW_SIZE)
 
 
 class BookmarkTimeSeries(BaseModel):
@@ -175,11 +178,13 @@ class NextMovesRequest(BaseModel):
     platform: list[Literal["chess.com", "lichess"]] | None = None
     rated: bool | None = None
     opponent_type: Literal["human", "bot", "both"] = "human"
-    recency: Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None = None
+    recency: (
+        Literal["week", "month", "3months", "6months", "year", "3years", "5years", "all"] | None
+    ) = None
     color: Literal["white", "black"] | None = None
     sort_by: Literal["frequency", "win_rate"] = "frequency"
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any"
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD
+    opponent_gap_min: int | None = None
+    opponent_gap_max: int | None = None
 
 
 class NextMoveEntry(BaseModel):
@@ -193,8 +198,8 @@ class NextMoveEntry(BaseModel):
     win_pct: float
     draw_pct: float
     loss_pct: float
-    result_hash: str   # BigInt as string for JS safety (full_hash of resulting position)
-    result_fen: str    # board FEN of resulting position (piece placement only)
+    result_hash: str  # BigInt as string for JS safety (full_hash of resulting position)
+    result_fen: str  # board FEN of resulting position (piece placement only)
     transposition_count: int
     score: float = Field(
         ge=0.0, le=1.0

--- a/app/services/endgame_service.py
+++ b/app/services/endgame_service.py
@@ -25,7 +25,6 @@ import sentry_sdk
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
 from app.repositories.endgame_repository import (
     count_endgame_games,
     count_filtered_games,
@@ -347,8 +346,8 @@ async def get_endgame_stats(
     rated: bool | None,
     opponent_type: str,
     recency: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgameStatsResponse:
     """Orchestrate endgame stats query and return EndgameStatsResponse.
 
@@ -367,8 +366,8 @@ async def get_endgame_stats(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     categories = _aggregate_endgame_stats(rows)
 
@@ -381,8 +380,8 @@ async def get_endgame_stats(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     # Count games that reached an endgame phase per the uniform ENDGAME_PLY_THRESHOLD rule
     # (quick-260414-ae4): a game qualifies if its total endgame plies meet the threshold.
@@ -394,8 +393,8 @@ async def get_endgame_stats(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     return EndgameStatsResponse(
@@ -416,8 +415,8 @@ async def get_endgame_games(
     recency: str | None,
     offset: int,
     limit: int,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgameGamesResponse:
     """Orchestrate endgame games query and return paginated EndgameGamesResponse.
 
@@ -439,8 +438,8 @@ async def get_endgame_games(
         recency_cutoff=cutoff,
         offset=offset,
         limit=limit,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     game_records = [
@@ -597,9 +596,7 @@ def _compute_score_gap_timeline(
             non_endgame_window = non_endgame_window[-window:]
 
         iso_year, iso_week, iso_weekday = played_at.isocalendar()
-        per_week_total[(iso_year, iso_week)] = (
-            per_week_total.get((iso_year, iso_week), 0) + 1
-        )
+        per_week_total[(iso_year, iso_week)] = per_week_total.get((iso_year, iso_week), 0) + 1
 
         eg_count = len(endgame_window)
         neg_count = len(non_endgame_window)
@@ -1358,9 +1355,7 @@ def _compute_clock_pressure_timeline(
         avg = statistics.mean(window_slice)
 
         iso_year, iso_week, iso_weekday = played_at.isocalendar()
-        per_week_count[(iso_year, iso_week)] = (
-            per_week_count.get((iso_year, iso_week), 0) + 1
-        )
+        per_week_count[(iso_year, iso_week)] = per_week_count.get((iso_year, iso_week), 0) + 1
         monday = (played_at - timedelta(days=iso_weekday - 1)).date()
         data_by_week[(iso_year, iso_week)] = {
             "date": monday.isoformat(),
@@ -1599,9 +1594,7 @@ def _compute_weekly_rolling_series(
         win_rate = window_slice.count("win") / window_total if window_total > 0 else 0.0
 
         iso_year, iso_week, iso_weekday = played_at.isocalendar()
-        per_week_count[(iso_year, iso_week)] = (
-            per_week_count.get((iso_year, iso_week), 0) + 1
-        )
+        per_week_count[(iso_year, iso_week)] = per_week_count.get((iso_year, iso_week), 0) + 1
         monday = (played_at - timedelta(days=iso_weekday - 1)).date()
         # Overwrite so each week keeps the window state after its last game.
         data_by_week[(iso_year, iso_week)] = {
@@ -1649,8 +1642,8 @@ async def get_endgame_performance(
     recency: str | None,
     rated: bool | None,
     opponent_type: str,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgamePerformanceResponse:
     """Orchestrate endgame performance query and return EndgamePerformanceResponse.
 
@@ -1672,8 +1665,8 @@ async def get_endgame_performance(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     entry_rows = await query_endgame_entry_rows(
         session,
@@ -1683,8 +1676,8 @@ async def get_endgame_performance(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     return _get_endgame_performance_from_rows(endgame_rows, non_endgame_rows, entry_rows)
@@ -1699,8 +1692,8 @@ async def get_endgame_timeline(
     rated: bool | None,
     opponent_type: str,
     window: int = 50,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgameTimelineResponse:
     """Orchestrate endgame timeline query and return EndgameTimelineResponse.
 
@@ -1726,8 +1719,8 @@ async def get_endgame_timeline(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=None,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Compute rolling series over full history, then filter to recency window
@@ -1808,8 +1801,8 @@ async def get_endgame_elo_timeline(
     rated: bool | None,
     opponent_type: str,
     recency: str | None,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgameEloTimelineResponse:
     """Orchestrate the Endgame ELO timeline query (Phase 57 ELO-05).
 
@@ -1830,8 +1823,8 @@ async def get_endgame_elo_timeline(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=None,  # pre-fill windows; filter output via cutoff_str
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Partition by (platform, time_control_bucket).
@@ -1908,8 +1901,8 @@ async def get_endgame_overview(
     opponent_type: str,
     recency: str | None,
     window: int = 50,
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> EndgameOverviewResponse:
     """Compose all five endgame dashboard payloads into a single response.
 
@@ -1934,8 +1927,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Stats: aggregate per-category W/D/L + conversion/recovery from entry_rows
@@ -1948,8 +1941,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     # Count games that reached an endgame phase per the uniform ENDGAME_PLY_THRESHOLD rule
     # (quick-260414-ae4): a game qualifies if its total endgame plies meet the threshold.
@@ -1961,8 +1954,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     stats = EndgameStatsResponse(
         categories=categories,
@@ -1983,8 +1976,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=None,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     if cutoff is not None:
         endgame_rows = [r for r in endgame_rows_all if r[0] is not None and r[0] >= cutoff]
@@ -2007,8 +2000,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     # Build score-gap timeline from unfiltered rows so the rolling 100-game
     # window per side is pre-filled with games before the cutoff; then drop
@@ -2036,8 +2029,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         window=window,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     # Clock pressure: fetch per-span arrays WITHOUT recency cutoff so the
     # clock-diff timeline can pre-fill from games before the cutoff. Filter in
@@ -2051,8 +2044,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=None,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     if cutoff is not None:
         clock_rows = [r for r in clock_rows_all if r[8] is not None and r[8] >= cutoff]
@@ -2083,8 +2076,8 @@ async def get_endgame_overview(
         rated=rated,
         opponent_type=opponent_type,
         recency=recency,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     return EndgameOverviewResponse(

--- a/app/services/insights_service.py
+++ b/app/services/insights_service.py
@@ -62,6 +62,7 @@ from app.schemas.insights import (
     SubsectionFinding,
     TimePoint,
 )
+from app.core.opponent_strength import preset_to_range
 from app.services.endgame_service import get_endgame_overview
 from app.services.endgame_zones import (
     TREND_MIN_SLOPE_VOL_RATIO,
@@ -138,6 +139,7 @@ async def compute_findings(
     is carried in the output but NOT forwarded to `get_endgame_overview` —
     that service has no color filter (per INS-03).
     """
+    gap_min, gap_max = preset_to_range(filter_context.opponent_strength)
     try:
         all_time_resp = await get_endgame_overview(
             session=session,
@@ -147,7 +149,8 @@ async def compute_findings(
             rated=True if filter_context.rated_only else None,
             opponent_type=_OPPONENT_TYPE,
             recency=None,
-            opponent_strength=filter_context.opponent_strength,
+            opponent_gap_min=gap_min,
+            opponent_gap_max=gap_max,
         )
         last_3mo_resp = await get_endgame_overview(
             session=session,
@@ -157,7 +160,8 @@ async def compute_findings(
             rated=True if filter_context.rated_only else None,
             opponent_type=_OPPONENT_TYPE,
             recency="3months",
-            opponent_strength=filter_context.opponent_strength,
+            opponent_gap_min=gap_min,
+            opponent_gap_max=gap_max,
         )
     except Exception as exc:
         # CLAUDE.md §Sentry: pass variable data via set_context; never embed
@@ -503,9 +507,7 @@ def _findings_score_timeline(
     gap_series = _weekly_points_to_time_points(gap_weekly, "last_3mo")
 
     # Trend per side: each finding carries its own trajectory.
-    endgame_trend, endgame_weekly_points = _compute_trend(
-        [p.endgame_score for p in timeline]
-    )
+    endgame_trend, endgame_weekly_points = _compute_trend([p.endgame_score for p in timeline])
     non_endgame_trend, non_endgame_weekly_points = _compute_trend(
         [p.non_endgame_score for p in timeline]
     )

--- a/app/services/opening_insights_service.py
+++ b/app/services/opening_insights_service.py
@@ -302,9 +302,9 @@ def _dedupe_continuations(
         full_path = tuple(finding.entry_san_sequence) + (finding.candidate_move_san,)
         same_line = False
         for kept_section_key, kp in kept_paths:
-            shares_line = (
-                len(full_path) >= len(kp) and full_path[: len(kp)] == kp
-            ) or (len(kp) >= len(full_path) and kp[: len(full_path)] == full_path)
+            shares_line = (len(full_path) >= len(kp) and full_path[: len(kp)] == kp) or (
+                len(kp) >= len(full_path) and kp[: len(full_path)] == full_path
+            )
             if not shares_line:
                 continue
             # D-21 exception: same exact transition reached from different
@@ -432,8 +432,8 @@ async def compute_insights(
                 rated=request.rated,
                 opponent_type=request.opponent_type,
                 recency_cutoff=cutoff,
-                opponent_strength=request.opponent_strength,
-                elo_threshold=request.elo_threshold,
+                opponent_gap_min=request.opponent_gap_min,
+                opponent_gap_max=request.opponent_gap_max,
             )
 
         # Pass 1: direct attribution for all entry hashes. Also include
@@ -446,9 +446,7 @@ async def compute_insights(
                 direct_entry_hashes_set.add(int(r.entry_hash))
                 if not (r.entry_san_sequence or []):
                     direct_entry_hashes_set.add(int(r.resulting_full_hash))
-        openings_by_hash = await query_openings_by_hashes(
-            session, list(direct_entry_hashes_set)
-        )
+        openings_by_hash = await query_openings_by_hashes(session, list(direct_entry_hashes_set))
 
         # Pass 2: parent-lineage attribution for unmatched (BLOCKER-1 / D-34).
         unmatched_parent_hashes: set[int] = set()

--- a/app/services/openings_service.py
+++ b/app/services/openings_service.py
@@ -55,9 +55,7 @@ RECENCY_DELTAS: dict[str, datetime.timedelta] = {
 }
 
 
-def derive_user_result(
-    result: str, user_color: str
-) -> Literal["win", "draw", "loss"]:
+def derive_user_result(result: str, user_color: str) -> Literal["win", "draw", "loss"]:
     """Derive win/draw/loss from the raw PGN result and the user's color.
 
     Args:
@@ -69,9 +67,7 @@ def derive_user_result(
     """
     if result == "1/2-1/2":
         return "draw"
-    if (result == "1-0" and user_color == "white") or (
-        result == "0-1" and user_color == "black"
-    ):
+    if (result == "1-0" and user_color == "white") or (result == "0-1" and user_color == "black"):
         return "win"
     return "loss"
 
@@ -118,8 +114,8 @@ async def analyze(
         opponent_type=request.opponent_type,
         recency_cutoff=cutoff,
         color=request.color,
-        opponent_strength=request.opponent_strength,
-        elo_threshold=request.elo_threshold,
+        opponent_gap_min=request.opponent_gap_min,
+        opponent_gap_max=request.opponent_gap_max,
     )
     wins, draws, losses, total = wdl_row.wins, wdl_row.draws, wdl_row.losses, wdl_row.total
 
@@ -154,8 +150,8 @@ async def analyze(
         color=request.color,
         offset=request.offset,
         limit=request.limit,
-        opponent_strength=request.opponent_strength,
-        elo_threshold=request.elo_threshold,
+        opponent_gap_min=request.opponent_gap_min,
+        opponent_gap_max=request.opponent_gap_max,
     )
 
     game_records = [
@@ -221,8 +217,8 @@ async def get_time_series(
             rated=request.rated,
             opponent_type=request.opponent_type,
             recency_cutoff=None,
-            opponent_strength=request.opponent_strength,
-            elo_threshold=request.elo_threshold,
+            opponent_gap_min=request.opponent_gap_min,
+            opponent_gap_max=request.opponent_gap_max,
         )
 
         # Build rolling-window datapoints from chronological per-game rows.
@@ -382,8 +378,8 @@ async def get_next_moves(
         opponent_type=request.opponent_type,
         recency_cutoff=cutoff,
         color=request.color,
-        opponent_strength=request.opponent_strength,
-        elo_threshold=request.elo_threshold,
+        opponent_gap_min=request.opponent_gap_min,
+        opponent_gap_max=request.opponent_gap_max,
     )
     wins, draws, losses, total = wdl_row.wins, wdl_row.draws, wdl_row.losses, wdl_row.total
     win_pct = round(wins / total * 100, 1) if total > 0 else 0.0
@@ -410,8 +406,8 @@ async def get_next_moves(
         opponent_type=request.opponent_type,
         recency_cutoff=cutoff,
         color=request.color,
-        opponent_strength=request.opponent_strength,
-        elo_threshold=request.elo_threshold,
+        opponent_gap_min=request.opponent_gap_min,
+        opponent_gap_max=request.opponent_gap_max,
     )
 
     if not move_rows:
@@ -429,8 +425,8 @@ async def get_next_moves(
         opponent_type=request.opponent_type,
         recency_cutoff=cutoff,
         color=request.color,
-        opponent_strength=request.opponent_strength,
-        elo_threshold=request.elo_threshold,
+        opponent_gap_min=request.opponent_gap_min,
+        opponent_gap_max=request.opponent_gap_max,
     )
 
     # --- Result FENs via PGN replay ---

--- a/app/services/stats_service.py
+++ b/app/services/stats_service.py
@@ -1,12 +1,11 @@
 """Stats service: aggregation logic for rating history and global stats."""
 
 import datetime
-from typing import Any, Literal, TypedDict
+from typing import Any, TypedDict
 
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.repositories.query_utils import DEFAULT_ELO_THRESHOLD
 from app.repositories.stats_repository import (
     query_position_wdl_batch,
     query_rating_history,
@@ -57,8 +56,8 @@ class FilterParams(TypedDict):
     rated: bool | None
     opponent_type: str
     recency_cutoff: datetime.datetime | None
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"]
-    elo_threshold: int
+    opponent_gap_min: int | None
+    opponent_gap_max: int | None
 
 
 async def get_rating_history(
@@ -68,7 +67,8 @@ async def get_rating_history(
     platform: str | None = None,
     *,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> RatingHistoryResponse:
     """Return per-platform per-game rating data points.
 
@@ -88,7 +88,8 @@ async def get_rating_history(
             platform="chess.com",
             recency_cutoff=cutoff,
             opponent_type=opponent_type,
-            opponent_strength=opponent_strength,
+            opponent_gap_min=opponent_gap_min,
+            opponent_gap_max=opponent_gap_max,
         )
         lichess_rows: list = []
     elif platform == "lichess":
@@ -99,7 +100,8 @@ async def get_rating_history(
             platform="lichess",
             recency_cutoff=cutoff,
             opponent_type=opponent_type,
-            opponent_strength=opponent_strength,
+            opponent_gap_min=opponent_gap_min,
+            opponent_gap_max=opponent_gap_max,
         )
     else:
         chesscom_rows = await query_rating_history(
@@ -108,7 +110,8 @@ async def get_rating_history(
             platform="chess.com",
             recency_cutoff=cutoff,
             opponent_type=opponent_type,
-            opponent_strength=opponent_strength,
+            opponent_gap_min=opponent_gap_min,
+            opponent_gap_max=opponent_gap_max,
         )
         lichess_rows = await query_rating_history(
             session,
@@ -116,7 +119,8 @@ async def get_rating_history(
             platform="lichess",
             recency_cutoff=cutoff,
             opponent_type=opponent_type,
-            opponent_strength=opponent_strength,
+            opponent_gap_min=opponent_gap_min,
+            opponent_gap_max=opponent_gap_max,
         )
 
     def rows_to_points(rows: list) -> list[RatingDataPoint]:
@@ -185,7 +189,8 @@ async def get_global_stats(
     platform: str | None = None,
     *,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> GlobalStatsResponse:
     """Return global W/D/L breakdowns by time control and by color.
 
@@ -199,7 +204,8 @@ async def get_global_stats(
         recency_cutoff=cutoff,
         platform=platform,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     color_rows = await query_results_by_color(
         session,
@@ -207,7 +213,8 @@ async def get_global_stats(
         recency_cutoff=cutoff,
         platform=platform,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     by_time_control = _rows_to_wdl_categories(
@@ -236,8 +243,8 @@ async def get_most_played_openings(
     platform: list[str] | None = None,
     rated: bool | None = None,
     opponent_type: str = "human",
-    opponent_strength: Literal["any", "stronger", "similar", "weaker"] = "any",
-    elo_threshold: int = DEFAULT_ELO_THRESHOLD,
+    opponent_gap_min: int | None = None,
+    opponent_gap_max: int | None = None,
 ) -> MostPlayedOpeningsResponse:
     """Return top 10 most played openings per color with position-based game counts.
 
@@ -259,8 +266,8 @@ async def get_most_played_openings(
         platform=platform,
         rated=rated,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     black_rows = await query_top_openings_sql_wdl(
         session,
@@ -274,8 +281,8 @@ async def get_most_played_openings(
         platform=platform,
         rated=rated,
         opponent_type=opponent_type,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
 
     # Batch-query position-based WDL — games passing through each position,
@@ -288,8 +295,8 @@ async def get_most_played_openings(
         rated=rated,
         opponent_type=opponent_type,
         recency_cutoff=cutoff,
-        opponent_strength=opponent_strength,
-        elo_threshold=elo_threshold,
+        opponent_gap_min=opponent_gap_min,
+        opponent_gap_max=opponent_gap_max,
     )
     # Row tuple shape: (eco, name, display_name, pgn, fen, full_hash, total, wins, draws, losses)
     # full_hash sits at index 5 after the display_name column was added (PRE-01).
@@ -303,8 +310,8 @@ async def get_most_played_openings(
         rated=filter_params["rated"],
         opponent_type=filter_params["opponent_type"],
         recency_cutoff=filter_params["recency_cutoff"],
-        opponent_strength=filter_params["opponent_strength"],
-        elo_threshold=filter_params["elo_threshold"],
+        opponent_gap_min=filter_params["opponent_gap_min"],
+        opponent_gap_max=filter_params["opponent_gap_max"],
     )
     black_position_wdl = await query_position_wdl_batch(
         session,
@@ -316,8 +323,8 @@ async def get_most_played_openings(
         rated=filter_params["rated"],
         opponent_type=filter_params["opponent_type"],
         recency_cutoff=filter_params["recency_cutoff"],
-        opponent_strength=filter_params["opponent_strength"],
-        elo_threshold=filter_params["elo_threshold"],
+        opponent_gap_min=filter_params["opponent_gap_min"],
+        opponent_gap_max=filter_params["opponent_gap_max"],
     )
 
     def rows_to_openings(

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -9,6 +9,23 @@ services:
       - "shared_preload_libraries=pg_stat_statements"
       - "-c"
       - "pg_stat_statements.track=all"
+      # Tuned for a 32 GB dev machine running analytic benchmark queries.
+      # Conservative on shared_buffers to leave headroom for IDE/other apps;
+      # generous on work_mem since this DB only has 1-2 concurrent connections.
+      - "-c"
+      - "shared_buffers=4GB"
+      - "-c"
+      - "work_mem=256MB"
+      - "-c"
+      - "maintenance_work_mem=1GB"
+      - "-c"
+      - "effective_cache_size=16GB"
+      - "-c"
+      - "random_page_cost=1.1"
+      - "-c"
+      - "effective_io_concurrency=200"
+      - "-c"
+      - "track_io_timing=on"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,8 @@ import type {
 } from '@/types/position_bookmarks';
 import type { RatingHistoryResponse, GlobalStatsResponse, MostPlayedOpeningsResponse } from '@/types/stats';
 import type { EndgameGamesResponse, EndgameOverviewResponse } from '@/types/endgames';
+import type { OpponentStrengthRange } from '@/types/api';
+import { rangeToQueryParams } from '@/lib/opponentStrength';
 
 /**
  * Central Axios instance.
@@ -70,7 +72,7 @@ export function buildFilterParams(params: {
   recency?: string | null;
   rated?: boolean | null;
   opponent_type?: string;
-  opponent_strength?: string;
+  opponent_strength?: OpponentStrengthRange;
   window?: number;
 }): Record<string, string | string[] | number | boolean> {
   const result: Record<string, string | string[] | number | boolean> = {};
@@ -79,7 +81,11 @@ export function buildFilterParams(params: {
   if (params.recency && params.recency !== 'all') result.recency = params.recency;
   if (params.rated !== null && params.rated !== undefined) result.rated = params.rated;
   if (params.opponent_type && params.opponent_type !== 'all') result.opponent_type = params.opponent_type;
-  if (params.opponent_strength && params.opponent_strength !== 'any') result.opponent_strength = params.opponent_strength;
+  if (params.opponent_strength) {
+    const gap = rangeToQueryParams(params.opponent_strength);
+    if (gap.opponent_gap_min !== undefined) result.opponent_gap_min = gap.opponent_gap_min;
+    if (gap.opponent_gap_max !== undefined) result.opponent_gap_max = gap.opponent_gap_max;
+  }
   if (params.window) result.window = params.window;
   return result;
 }
@@ -115,7 +121,7 @@ export const statsApi = {
     recency: string | null,
     platform: string | null,
     opponentType: string,
-    opponentStrength: string,
+    opponentStrength: OpponentStrengthRange,
   ) =>
     apiClient.get<RatingHistoryResponse>('/stats/rating-history', {
       params: buildFilterParams({
@@ -130,7 +136,7 @@ export const statsApi = {
     recency: string | null,
     platform: string | null,
     opponentType: string,
-    opponentStrength: string,
+    opponentStrength: OpponentStrengthRange,
   ) =>
     apiClient.get<GlobalStatsResponse>('/stats/global', {
       params: buildFilterParams({
@@ -147,7 +153,7 @@ export const statsApi = {
     platform?: string[] | null;
     rated?: boolean | null;
     opponent_type?: string;
-    opponent_strength?: string;
+    opponent_strength?: OpponentStrengthRange;
   }) =>
     apiClient.get<MostPlayedOpeningsResponse>('/stats/most-played-openings', {
       params: buildFilterParams(params ?? {}),
@@ -164,7 +170,7 @@ export const endgameApi = {
     recency?: string | null;
     rated?: boolean | null;
     opponent_type?: string;
-    opponent_strength?: string;
+    opponent_strength?: OpponentStrengthRange;
     window?: number;
   }) =>
     apiClient.get<EndgameOverviewResponse>('/endgames/overview', {
@@ -178,7 +184,7 @@ export const endgameApi = {
     recency?: string | null;
     rated?: boolean | null;
     opponent_type?: string;
-    opponent_strength?: string;
+    opponent_strength?: OpponentStrengthRange;
     offset?: number;
     limit?: number;
   }) =>

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -6,12 +6,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { MatchSide, TimeControl, Recency, Color, Platform, OpponentType, OpponentStrength } from '@/types/api';
+import type { MatchSide, TimeControl, Recency, Color, Platform, OpponentType, OpponentStrengthRange } from '@/types/api';
 import { cn } from '@/lib/utils';
-import { InfoPopover } from '@/components/ui/info-popover';
+import { ANY_RANGE } from '@/lib/opponentStrength';
 import { PlatformIcon } from '@/components/icons/PlatformIcon';
 import { TimeControlIcon } from '@/components/icons/TimeControlIcon';
 import { Button } from '@/components/ui/button';
+import { OpponentStrengthFilter } from './OpponentStrengthFilter';
 
 export interface FilterState {
   matchSide: MatchSide;
@@ -19,7 +20,11 @@ export interface FilterState {
   platforms: Platform[] | null; // null = all
   rated: boolean | null; // null = all
   opponentType: OpponentType; // default human = computer games excluded
-  opponentStrength: OpponentStrength; // default any = no strength filter
+  /**
+   * Opponent strength as a (gap_min, gap_max) range over opponent_rating - user_rating.
+   * Default `{ min: null, max: null }` = no filter (Any preset).
+   */
+  opponentStrength: OpponentStrengthRange;
   recency: Recency | null; // null = all time
   color: Color;
 }
@@ -31,7 +36,7 @@ export const DEFAULT_FILTERS: FilterState = {
   platforms: null,
   rated: null,
   opponentType: 'human',
-  opponentStrength: 'any',
+  opponentStrength: ANY_RANGE,
   recency: null,
   color: 'white',
 };
@@ -78,6 +83,13 @@ export function areFiltersEqual(
       const setB = new Set<string>(bv as readonly string[]);
       if (!(av as readonly string[]).every((v) => setB.has(v))) return false;
       continue;
+    }
+    // opponentStrength is the only object-shaped field; compare structurally.
+    if (key === 'opponentStrength') {
+      const ar = av as OpponentStrengthRange;
+      const br = bv as OpponentStrengthRange;
+      if (ar.min === br.min && ar.max === br.max) continue;
+      return false;
     }
     return false;
   }
@@ -242,42 +254,10 @@ export function FilterPanel({
 
       {/* Opponent Strength */}
       {show('opponentStrength') && (
-        <div>
-          <p className="mb-1 text-xs text-muted-foreground">
-            <span className="inline-flex items-center gap-1">
-              Opponent Strength
-              <InfoPopover ariaLabel="Opponent strength filter info" testId="filter-opponent-strength-info" side="bottom">
-                <div className="space-y-2">
-                  <div className="space-y-1">
-                    <p><strong>Stronger:</strong> Rated 50+ ELO above you</p>
-                    <p><strong>Similar:</strong> Within &plusmn;50 ELO</p>
-                    <p><strong>Weaker:</strong> Rated 50+ ELO below you</p>
-                  </div>
-                  <p>
-                    Useful when your games aren&apos;t always rating-matched (casual play, tournaments, arenas), or when you want to isolate how you perform against stronger, similar, or weaker opponents.
-                  </p>
-                </div>
-              </InfoPopover>
-            </span>
-          </p>
-          <ToggleGroup
-            type="single"
-            value={filters.opponentStrength}
-            onValueChange={(v) => {
-              if (!v) return;
-              update({ opponentStrength: v as OpponentStrength });
-            }}
-            variant="outline"
-            size="sm"
-            data-testid="filter-opponent-strength"
-            className="w-full"
-          >
-            <ToggleGroupItem value="any" data-testid="filter-opponent-strength-any" className="min-h-11 sm:min-h-0 flex-1">Any</ToggleGroupItem>
-            <ToggleGroupItem value="stronger" data-testid="filter-opponent-strength-stronger" className="min-h-11 sm:min-h-0 flex-1">Stronger</ToggleGroupItem>
-            <ToggleGroupItem value="similar" data-testid="filter-opponent-strength-similar" className="min-h-11 sm:min-h-0 flex-1">Similar</ToggleGroupItem>
-            <ToggleGroupItem value="weaker" data-testid="filter-opponent-strength-weaker" className="min-h-11 sm:min-h-0 flex-1">Weaker</ToggleGroupItem>
-          </ToggleGroup>
-        </div>
+        <OpponentStrengthFilter
+          value={filters.opponentStrength}
+          onChange={(opponentStrength) => update({ opponentStrength })}
+        />
       )}
 
       {/* Opponent Type */}

--- a/frontend/src/components/filters/FilterPanel.tsx
+++ b/frontend/src/components/filters/FilterPanel.tsx
@@ -262,7 +262,7 @@ export function FilterPanel({
 
       {/* Opponent Type */}
       {show('opponent') && (
-        <div>
+        <div className="pt-3 border-t border-border/40">
           <p className="mb-1 text-xs text-muted-foreground">Opponent Type</p>
           <ToggleGroup
             type="single"

--- a/frontend/src/components/filters/OpponentStrengthFilter.tsx
+++ b/frontend/src/components/filters/OpponentStrengthFilter.tsx
@@ -125,7 +125,7 @@ export function OpponentStrengthFilter({ value, onChange }: OpponentStrengthFilt
           thumbLabels={['Minimum opponent Elo gap', 'Maximum opponent Elo gap']}
           data-testid="filter-opponent-strength-slider"
         />
-        <div className="mt-1 flex justify-between text-[10px] tabular-nums text-muted-foreground">
+        <div className="mt-1 flex justify-between text-xs tabular-nums text-muted-foreground">
           <span>≤−{Math.abs(SLIDER_MIN)}</span>
           <span>0</span>
           <span>≥+{SLIDER_MAX}</span>

--- a/frontend/src/components/filters/OpponentStrengthFilter.tsx
+++ b/frontend/src/components/filters/OpponentStrengthFilter.tsx
@@ -1,0 +1,136 @@
+import { useCallback } from 'react';
+import { Slider } from '@/components/ui/slider';
+import { InfoPopover } from '@/components/ui/info-popover';
+import { cn } from '@/lib/utils';
+import type { OpponentStrengthPreset, OpponentStrengthRange } from '@/types/api';
+import {
+  PRESET_LABELS,
+  PRESET_ORDER,
+  SLIDER_MAX,
+  SLIDER_MIN,
+  SLIDER_STEP,
+  derivePreset,
+  formatRangeSummary,
+  presetToRange,
+  rangeToSlider,
+  sliderToRange,
+} from '@/lib/opponentStrength';
+
+interface OpponentStrengthFilterProps {
+  value: OpponentStrengthRange;
+  onChange: (next: OpponentStrengthRange) => void;
+}
+
+export function OpponentStrengthFilter({ value, onChange }: OpponentStrengthFilterProps) {
+  const activePreset = derivePreset(value);
+  const [sliderLo, sliderHi] = rangeToSlider(value);
+
+  const handleSliderChange = useCallback(
+    (values: number[]) => {
+      const lo = values[0] ?? SLIDER_MIN;
+      const hi = values[1] ?? SLIDER_MAX;
+      onChange(sliderToRange(lo, hi));
+    },
+    [onChange],
+  );
+
+  const handlePreset = useCallback(
+    (preset: OpponentStrengthPreset) => {
+      onChange(presetToRange(preset));
+    },
+    [onChange],
+  );
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1">
+            Opponent Strength
+            <InfoPopover
+              ariaLabel="Opponent strength filter info"
+              testId="filter-opponent-strength-info"
+              side="bottom"
+            >
+              <div className="space-y-2">
+                <div className="space-y-1">
+                  <p>
+                    <strong>Any</strong>: no filter, all opponents.
+                  </p>
+                  <p>
+                    <strong>Stronger</strong>: opponents rated 50+ Elo above you.
+                  </p>
+                  <p>
+                    <strong>Similar</strong>: opponents within ±50 Elo.
+                  </p>
+                  <p>
+                    <strong>Weaker</strong>: opponents rated 50+ Elo below you.
+                  </p>
+                </div>
+                <p>
+                  Drag the slider for a custom range in 50-Elo steps. The
+                  endpoints are unbounded: ≤−200 includes anyone weaker than
+                  that, ≥+200 includes anyone stronger.
+                </p>
+              </div>
+            </InfoPopover>
+          </span>
+        </p>
+        <span
+          className={cn(
+            'text-xs tabular-nums',
+            activePreset && activePreset !== 'any'
+              ? 'font-medium text-toggle-active'
+              : 'text-muted-foreground',
+          )}
+          data-testid="filter-opponent-strength-summary"
+        >
+          {formatRangeSummary(value)}
+        </span>
+      </div>
+
+      {/* Preset chips */}
+      <div className="mb-3 grid grid-cols-4 gap-1" data-testid="filter-opponent-strength-presets">
+        {PRESET_ORDER.map((preset) => {
+          const isActive = activePreset === preset;
+          return (
+            <button
+              key={preset}
+              type="button"
+              onClick={() => handlePreset(preset)}
+              data-testid={`filter-opponent-strength-preset-${preset}`}
+              aria-pressed={isActive}
+              className={cn(
+                'rounded border h-11 sm:h-7 text-xs transition-colors',
+                isActive
+                  ? 'border-toggle-active bg-toggle-active text-toggle-active-foreground'
+                  : 'border-border bg-inactive-bg text-muted-foreground hover:bg-inactive-bg-hover hover:text-foreground',
+              )}
+            >
+              {PRESET_LABELS[preset]}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Range slider */}
+      <div className="px-1.5">
+        <Slider
+          min={SLIDER_MIN}
+          max={SLIDER_MAX}
+          step={SLIDER_STEP}
+          minStepsBetweenThumbs={1}
+          value={[sliderLo, sliderHi]}
+          onValueChange={handleSliderChange}
+          thumbLabels={['Minimum opponent Elo gap', 'Maximum opponent Elo gap']}
+          data-testid="filter-opponent-strength-slider"
+        />
+        <div className="mt-1 flex justify-between text-[10px] tabular-nums text-muted-foreground">
+          <span>≤−{Math.abs(SLIDER_MIN)}</span>
+          <span>0</span>
+          <span>≥+{SLIDER_MAX}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/insights/EndgameInsightsBlock.tsx
+++ b/frontend/src/components/insights/EndgameInsightsBlock.tsx
@@ -3,6 +3,7 @@ import { BarChart3, Info, Lightbulb, ListChecks, Loader2, Sparkles, UserCircle2 
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { DEFAULT_FILTERS, type FilterState } from '@/components/filters/FilterPanel';
+import { derivePreset } from '@/lib/opponentStrength';
 import { useActiveJobs } from '@/hooks/useImport';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { useUserFlag, setUserFlag } from '@/hooks/useUserFlag';
@@ -56,6 +57,11 @@ function getBlockedReason(
     filters.matchSide !== DEFAULT_FILTERS.matchSide
   ) {
     return 'Reset the filters before generating insights';
+  }
+  // Insights only support the four opponent-strength presets. A custom slider
+  // range (not matching any preset) is rejected by the router.
+  if (derivePreset(filters.opponentStrength) === null) {
+    return 'Snap opponent strength to a preset (Any / Stronger / Similar / Weaker)';
   }
   return null;
 }

--- a/frontend/src/components/insights/OpeningFindingCard.test.tsx
+++ b/frontend/src/components/insights/OpeningFindingCard.test.tsx
@@ -407,6 +407,28 @@ describe('OpeningFindingCard', () => {
       expect(elements.length).toBe(1);
     });
 
+    it('renders the watermark when the candidate move LEADS to a troll position', () => {
+      // Starting position is not a troll position, but after 1.e4 the resulting
+      // FEN derives (white-side) to the seeded WHITE_TROLL_KEYS entry.
+      const finding = makeFinding({
+        entry_fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        candidate_move_san: 'e4',
+        color: 'white',
+      });
+      renderCard({ finding, idx: 7 });
+      expect(screen.getByTestId('opening-finding-card-7-troll-watermark')).toBeTruthy();
+    });
+
+    it('does not render the watermark when neither entry nor resulting position match', () => {
+      const finding = makeFinding({
+        entry_fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        candidate_move_san: 'd4', // resulting FEN is not the seeded troll key
+        color: 'white',
+      });
+      renderCard({ finding, idx: 7 });
+      expect(screen.queryByTestId('opening-finding-card-7-troll-watermark')).toBeNull();
+    });
+
     it('does not block clicks on the Moves button (D-04)', () => {
       const onFindingClick = vi.fn();
       const finding = makeFinding({ entry_fen: TROLL_FIXTURE_FEN, color: 'white' });

--- a/frontend/src/components/insights/OpeningFindingCard.tsx
+++ b/frontend/src/components/insights/OpeningFindingCard.tsx
@@ -6,7 +6,7 @@ import {
   formatConfidenceTooltip,
   getSeverityBorderColor,
 } from '@/lib/openingInsights';
-import { sanToSquares } from '@/lib/sanToSquares';
+import { fenAfterMove, sanToSquares } from '@/lib/sanToSquares';
 import { MIN_GAMES_FOR_RELIABLE_STATS, TROLL_WATERMARK_OPACITY, UNRELIABLE_OPACITY } from '@/lib/theme';
 import { isTrollPosition } from '@/lib/trollOpenings';
 import trollFaceUrl from '@/assets/troll-face.svg';
@@ -66,9 +66,15 @@ export function OpeningFindingCard({
     ...(isUnreliable ? { opacity: UNRELIABLE_OPACITY } : {}),
   };
 
-  // Phase 77 D-02/D-10: Show troll-face watermark when the position is in the curated set.
-  // Pure O(1) Set.has lookup after a tiny string transform — no useMemo needed.
-  const showTroll = isTrollPosition(finding.entry_fen, finding.color);
+  // Phase 77 D-02/D-10: Show troll-face watermark when the entry position OR the
+  // post-candidate-move position matches a curated troll line. Pure O(1) Set.has
+  // lookups after a tiny string transform — no useMemo needed. fenAfterMove()
+  // returns null on illegal SAN / malformed FEN, which isTrollPosition treats as
+  // a non-match, so the second branch degrades safely.
+  const resultingFen = fenAfterMove(finding.entry_fen, finding.candidate_move_san);
+  const showTroll =
+    isTrollPosition(finding.entry_fen, finding.color) ||
+    (resultingFen !== null && isTrollPosition(resultingFen, finding.color));
 
   const headerLine = (
     <div className="flex items-center gap-2 text-sm min-w-0">

--- a/frontend/src/components/insights/OpeningInsightsBlock.test.tsx
+++ b/frontend/src/components/insights/OpeningInsightsBlock.test.tsx
@@ -40,7 +40,7 @@ const DEFAULT_FILTERS: FilterState = {
   platforms: null,
   rated: null,
   opponentType: 'human',
-  opponentStrength: 'any',
+  opponentStrength: { min: null, max: null },
 };
 
 function makeFinding(overrides: Partial<OpeningInsightFinding> = {}): OpeningInsightFinding {

--- a/frontend/src/components/insights/OpeningInsightsBlock.tsx
+++ b/frontend/src/components/insights/OpeningInsightsBlock.tsx
@@ -40,6 +40,10 @@ const OPENING_INSIGHTS_POPOVER_COPY: ReactNode = (
       least 10 games, enough of a difference from 50% to be worth a closer look.
     </p>
     {OPENING_INSIGHTS_CONFIDENCE_COPY}
+    <p className="italic">
+      Tip: Use the filters to select recency, time control, or opponent strength
+      for a more targeted search.
+    </p>
   </div>
 );
 

--- a/frontend/src/components/insights/__tests__/EndgameInsightsBlock.test.tsx
+++ b/frontend/src/components/insights/__tests__/EndgameInsightsBlock.test.tsx
@@ -43,7 +43,7 @@ const BASE_FILTERS: FilterState = {
   platforms: null,
   rated: null,
   opponentType: 'human',
-  opponentStrength: 'any',
+  opponentStrength: { min: null, max: null },
   recency: null,
   color: 'white',
 };

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -37,6 +37,11 @@ function Slider({
   return (
     <SliderPrimitive.Root
       data-slot="slider"
+      // vaul (Drawer) escape hatch: a horizontal drag inside a `direction="right"`
+      // drawer would otherwise be interpreted as swipe-to-close, so the user
+      // can't move the slider thumbs on touch. `data-vaul-no-drag` opts the
+      // slider out of the drawer's drag handler.
+      data-vaul-no-drag=""
       defaultValue={defaultValue}
       value={value}
       min={min}

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -1,0 +1,77 @@
+import * as React from "react"
+import { Slider as SliderPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * shadcn-style wrapper around the Radix Slider primitive. Supports both
+ * single-thumb (`value={[v]}`) and dual-thumb (`value={[lo, hi]}`) modes.
+ *
+ * Mobile notes (Spike 001):
+ * - `touch-action: none` on the root prevents the page from scrolling while
+ *   the user drags a handle on touch devices.
+ * - Thumb is sized 24px with a 44px min hit-target (iOS HIG / Material).
+ */
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  thumbLabels,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root> & {
+  /** Per-thumb aria-labels. Length must match thumb count. */
+  thumbLabels?: readonly string[]
+}) {
+  const _values = React.useMemo<number[]>(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max],
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        // 44px min vertical hit area on the root so the thumbs are easy to grab on touch.
+        "min-h-11",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-toggle-active absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          aria-label={thumbLabels?.[index]}
+          key={index}
+          className="border-toggle-active bg-background ring-ring/50 block size-6 shrink-0 rounded-full border-2 shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/frontend/src/hooks/__tests__/useEndgameInsights.test.tsx
+++ b/frontend/src/hooks/__tests__/useEndgameInsights.test.tsx
@@ -33,7 +33,7 @@ const BASE_FILTERS: FilterState = {
   platforms: ['chess.com'],
   rated: true,
   opponentType: 'human',
-  opponentStrength: 'similar',
+  opponentStrength: { min: -50, max: 50 },
   recency: '90d',
   color: 'white',
 };
@@ -71,7 +71,8 @@ describe('useEndgameInsights', () => {
       platform: ['chess.com'],
       recency: '90d',
       rated: true,
-      opponent_strength: 'similar',
+      opponent_gap_min: -50,
+      opponent_gap_max: 50,
       color: 'white',
     });
   });

--- a/frontend/src/hooks/__tests__/useOpeningInsights.test.tsx
+++ b/frontend/src/hooks/__tests__/useOpeningInsights.test.tsx
@@ -43,7 +43,7 @@ describe('useOpeningInsights', () => {
           platforms: ['chess.com'],
           rated: true,
           opponentType: 'human',
-          opponentStrength: 'similar',
+          opponentStrength: { min: -50, max: 50 },
         }),
       { wrapper: createWrapper() },
     );
@@ -61,7 +61,8 @@ describe('useOpeningInsights', () => {
       platform: ['chess.com'],
       rated: true,
       opponent_type: 'human',
-      opponent_strength: 'similar',
+      opponent_gap_min: -50,
+      opponent_gap_max: 50,
     });
   });
 
@@ -74,7 +75,7 @@ describe('useOpeningInsights', () => {
           platforms: null,
           rated: null,
           opponentType: 'human',
-          opponentStrength: 'any',
+          opponentStrength: { min: null, max: null },
         }),
       { wrapper: createWrapper() },
     );
@@ -98,7 +99,7 @@ describe('useOpeningInsights', () => {
           platforms: null,
           rated: null,
           opponentType: 'human',
-          opponentStrength: 'any',
+          opponentStrength: { min: null, max: null },
         }),
       { wrapper, initialProps: { recency: 'year' as const } },
     );
@@ -150,7 +151,7 @@ describe('useOpeningInsights', () => {
           platforms: null,
           rated: null,
           opponentType: 'human',
-          opponentStrength: 'any',
+          opponentStrength: { min: null, max: null },
         }),
       { wrapper: createWrapper() },
     );

--- a/frontend/src/hooks/useNextMoves.ts
+++ b/frontend/src/hooks/useNextMoves.ts
@@ -3,8 +3,10 @@ import { apiClient } from '@/api/client';
 import type { NextMovesResponse } from '@/types/api';
 import type { FilterState } from '@/components/filters/FilterPanel';
 import { hashToString } from '@/lib/zobrist';
+import { rangeToQueryParams } from '@/lib/opponentStrength';
 
 export function useNextMoves(fullHash: bigint, filters: FilterState) {
+  const gapParams = rangeToQueryParams(filters.opponentStrength);
   return useQuery<NextMovesResponse>({
     queryKey: [
       'nextMoves',
@@ -14,7 +16,8 @@ export function useNextMoves(fullHash: bigint, filters: FilterState) {
         platform: filters.platforms,
         rated: filters.rated,
         opponent_type: filters.opponentType,
-        opponent_strength: filters.opponentStrength,
+        opponent_gap_min: gapParams.opponent_gap_min ?? null,
+        opponent_gap_max: gapParams.opponent_gap_max ?? null,
         recency: filters.recency,
         color: filters.color,
       },
@@ -26,7 +29,7 @@ export function useNextMoves(fullHash: bigint, filters: FilterState) {
         platform: filters.platforms,
         rated: filters.rated,
         opponent_type: filters.opponentType,
-        opponent_strength: filters.opponentStrength,
+        ...gapParams,
         recency: filters.recency,
         color: filters.color,
       });

--- a/frontend/src/hooks/useOpeningInsights.ts
+++ b/frontend/src/hooks/useOpeningInsights.ts
@@ -6,8 +6,9 @@ import type {
   TimeControl,
   Platform,
   OpponentType,
-  OpponentStrength,
+  OpponentStrengthRange,
 } from '@/types/api';
+import { ANY_RANGE, rangeToQueryParams } from '@/lib/opponentStrength';
 
 interface OpeningInsightsFilters {
   recency: Recency | null;
@@ -15,7 +16,7 @@ interface OpeningInsightsFilters {
   platforms: Platform[] | null;
   rated: boolean | null;
   opponentType: OpponentType;
-  opponentStrength: OpponentStrength;
+  opponentStrength: OpponentStrengthRange;
 }
 
 /**
@@ -32,7 +33,8 @@ export function useOpeningInsights(filters?: OpeningInsightsFilters) {
   const platform = filters?.platforms ?? null;
   const rated = filters?.rated ?? null;
   const opponentType = filters?.opponentType ?? 'human';
-  const opponentStrength = filters?.opponentStrength ?? 'any';
+  const opponentStrength = filters?.opponentStrength ?? ANY_RANGE;
+  const gapParams = rangeToQueryParams(opponentStrength);
 
   return useQuery<OpeningInsightsResponse>({
     queryKey: [
@@ -42,7 +44,8 @@ export function useOpeningInsights(filters?: OpeningInsightsFilters) {
       platform,
       rated,
       opponentType,
-      opponentStrength,
+      opponentStrength.min,
+      opponentStrength.max,
     ],
     queryFn: () =>
       apiClient
@@ -52,7 +55,7 @@ export function useOpeningInsights(filters?: OpeningInsightsFilters) {
           platform: platform ?? undefined,
           rated: rated ?? undefined,
           opponent_type: opponentType,
-          opponent_strength: opponentStrength,
+          ...gapParams,
           color: 'all', // D-02: always 'all' regardless of global filter
         })
         .then((r) => r.data),

--- a/frontend/src/hooks/useOpenings.ts
+++ b/frontend/src/hooks/useOpenings.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import type { OpeningsResponse } from '@/types/api';
 import { resolveMatchSide } from '@/types/api';
+import { rangeToQueryParams } from '@/lib/opponentStrength';
 import type { FilterState } from '@/components/filters/FilterPanel';
 
 export function useOpeningsPositionQuery(params: {
@@ -20,7 +21,7 @@ export function useOpeningsPositionQuery(params: {
         platform: params.filters.platforms,
         rated: params.filters.rated,
         opponent_type: params.filters.opponentType,
-        opponent_strength: params.filters.opponentStrength,
+        ...rangeToQueryParams(params.filters.opponentStrength),
         recency: params.filters.recency,
         color: params.filters.color,
         offset: params.offset,

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,18 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { statsApi } from '@/api/client';
-import type { Platform, Recency, TimeControl, OpponentType, OpponentStrength } from '@/types/api';
+import type { Platform, Recency, TimeControl, OpponentType, OpponentStrengthRange } from '@/types/api';
+import { ANY_RANGE } from '@/lib/opponentStrength';
 
 export function useRatingHistory(
   recency: Recency | null,
   platforms: Platform[] | null,
   opponentType: OpponentType,
-  opponentStrength: OpponentStrength,
+  opponentStrength: OpponentStrengthRange,
 ) {
   const normalizedRecency = recency === 'all' ? null : recency;
   // safe: length === 1 check guarantees index 0 exists
   const platform = platforms && platforms.length === 1 ? platforms[0]! : null;
   return useQuery({
-    queryKey: ['ratingHistory', normalizedRecency, platform, opponentType, opponentStrength],
+    queryKey: ['ratingHistory', normalizedRecency, platform, opponentType, opponentStrength.min, opponentStrength.max],
     queryFn: () => statsApi.getRatingHistory(normalizedRecency, platform, opponentType, opponentStrength),
   });
 }
@@ -21,13 +22,13 @@ export function useGlobalStats(
   recency: Recency | null,
   platforms: Platform[] | null,
   opponentType: OpponentType,
-  opponentStrength: OpponentStrength,
+  opponentStrength: OpponentStrengthRange,
 ) {
   const normalizedRecency = recency === 'all' ? null : recency;
   // safe: length === 1 check guarantees index 0 exists
   const platform = platforms && platforms.length === 1 ? platforms[0]! : null;
   return useQuery({
-    queryKey: ['globalStats', normalizedRecency, platform, opponentType, opponentStrength],
+    queryKey: ['globalStats', normalizedRecency, platform, opponentType, opponentStrength.min, opponentStrength.max],
     queryFn: () => statsApi.getGlobalStats(normalizedRecency, platform, opponentType, opponentStrength),
   });
 }
@@ -38,17 +39,17 @@ export function useMostPlayedOpenings(filters?: {
   platforms: Platform[] | null;
   rated: boolean | null;
   opponentType: OpponentType;
-  opponentStrength?: string;
+  opponentStrength?: OpponentStrengthRange;
 }) {
   const normalizedRecency = filters?.recency === 'all' ? null : (filters?.recency ?? null);
   const timeControl = filters?.timeControls ?? null;
   const platform = filters?.platforms ?? null;
   const rated = filters?.rated ?? null;
   const opponentType = filters?.opponentType ?? 'human';
-  const opponentStrength = filters?.opponentStrength ?? 'any';
+  const opponentStrength = filters?.opponentStrength ?? ANY_RANGE;
 
   return useQuery({
-    queryKey: ['mostPlayedOpenings', normalizedRecency, timeControl, platform, rated, opponentType, opponentStrength],
+    queryKey: ['mostPlayedOpenings', normalizedRecency, timeControl, platform, rated, opponentType, opponentStrength.min, opponentStrength.max],
     queryFn: () => statsApi.getMostPlayedOpenings({
       recency: normalizedRecency,
       time_control: timeControl,

--- a/frontend/src/lib/opponentStrength.ts
+++ b/frontend/src/lib/opponentStrength.ts
@@ -1,0 +1,109 @@
+import type { OpponentStrengthPreset, OpponentStrengthRange } from '@/types/api';
+
+// Slider domain (in Elo gap, opponent − user). Endpoints are unbounded:
+// reaching SLIDER_MIN/MAX on a handle is equivalent to `null` (no filter
+// on that side).
+export const SLIDER_MIN = -200;
+export const SLIDER_MAX = 200;
+export const SLIDER_STEP = 50;
+
+// Inclusive threshold defining "stronger" vs "similar" vs "weaker". Matches
+// app/core/opponent_strength.py PRESET_THRESHOLD.
+export const PRESET_THRESHOLD = 50;
+
+export const ANY_RANGE: OpponentStrengthRange = { min: null, max: null };
+
+export const PRESET_RANGES: Record<OpponentStrengthPreset, OpponentStrengthRange> = {
+  any: ANY_RANGE,
+  stronger: { min: PRESET_THRESHOLD, max: null },
+  similar: { min: -PRESET_THRESHOLD, max: PRESET_THRESHOLD },
+  weaker: { min: null, max: -PRESET_THRESHOLD },
+};
+
+export const PRESET_LABELS: Record<OpponentStrengthPreset, string> = {
+  any: 'Any',
+  stronger: 'Stronger',
+  similar: 'Similar',
+  weaker: 'Weaker',
+};
+
+export const PRESET_ORDER: OpponentStrengthPreset[] = ['any', 'stronger', 'similar', 'weaker'];
+
+/**
+ * Detect which preset the given range corresponds to, or null when the range
+ * is custom (matches no preset exactly).
+ */
+export function derivePreset(range: OpponentStrengthRange): OpponentStrengthPreset | null {
+  for (const preset of PRESET_ORDER) {
+    const r = PRESET_RANGES[preset];
+    if (r.min === range.min && r.max === range.max) return preset;
+  }
+  return null;
+}
+
+/** Inverse of derivePreset — preset name → range. */
+export function presetToRange(preset: OpponentStrengthPreset): OpponentStrengthRange {
+  return PRESET_RANGES[preset];
+}
+
+/**
+ * Convert a slider tuple [lo, hi] (in domain [SLIDER_MIN, SLIDER_MAX]) into
+ * an OpponentStrengthRange where extreme endpoints map to `null` (unbounded).
+ */
+export function sliderToRange(lo: number, hi: number): OpponentStrengthRange {
+  return {
+    min: lo <= SLIDER_MIN ? null : lo,
+    max: hi >= SLIDER_MAX ? null : hi,
+  };
+}
+
+/**
+ * Inverse: range → slider tuple, clamping null to the slider extremes.
+ */
+export function rangeToSlider(range: OpponentStrengthRange): [number, number] {
+  return [range.min ?? SLIDER_MIN, range.max ?? SLIDER_MAX];
+}
+
+/** True when the range filter is active (i.e. not "Any"). */
+export function isRangeActive(range: OpponentStrengthRange): boolean {
+  return range.min !== null || range.max !== null;
+}
+
+/**
+ * Format a single bound for the summary line. `null` becomes `≤−200` or
+ * `≥+200` to communicate the unbounded semantics; finite values are signed.
+ */
+function formatBound(value: number, signed: boolean): string {
+  // Use the proper minus sign (U+2212) for negatives so the signed format
+  // matches the slider tick labels.
+  if (value < 0) return `−${Math.abs(value)}`;
+  if (signed && value > 0) return `+${value}`;
+  return `${value}`;
+}
+
+/**
+ * Compact summary text for the active range. Returns the preset name when one
+ * matches, else a formatted range like `−50 … +200` or `≤−100 … +50`.
+ */
+export function formatRangeSummary(range: OpponentStrengthRange): string {
+  const preset = derivePreset(range);
+  if (preset) return PRESET_LABELS[preset];
+
+  const minLabel = range.min === null ? `≤${formatBound(SLIDER_MIN, false)}` : formatBound(range.min, true);
+  const maxLabel = range.max === null ? `≥+${SLIDER_MAX}` : formatBound(range.max, true);
+  return `${minLabel} … ${maxLabel}`;
+}
+
+/**
+ * Build the API query params for the opponent-gap filter. Returns an empty
+ * object when both bounds are null so unbounded filters don't appear in the
+ * query string at all.
+ */
+export function rangeToQueryParams(
+  range: OpponentStrengthRange,
+): { opponent_gap_min?: number; opponent_gap_max?: number } {
+  const params: { opponent_gap_min?: number; opponent_gap_max?: number } = {};
+  if (range.min !== null) params.opponent_gap_min = range.min;
+  if (range.max !== null) params.opponent_gap_max = range.max;
+  return params;
+}

--- a/frontend/src/lib/sanToSquares.test.ts
+++ b/frontend/src/lib/sanToSquares.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sanToSquares } from './sanToSquares';
+import { fenAfterMove, sanToSquares } from './sanToSquares';
 
 const STARTING_FEN_WHITE = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
 
@@ -45,5 +45,23 @@ describe('sanToSquares', () => {
   it('returns null on a malformed FEN without throwing', () => {
     expect(() => sanToSquares('this is not a fen', 'e4')).not.toThrow();
     expect(sanToSquares('this is not a fen', 'e4')).toBeNull();
+  });
+});
+
+describe('fenAfterMove', () => {
+  it('returns the resulting FEN after applying e4 from the starting position', () => {
+    const result = fenAfterMove(STARTING_FEN_WHITE, 'e4');
+    expect(result).not.toBeNull();
+    // Piece-placement portion should reflect the e2→e4 push.
+    expect(result!.startsWith('rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR')).toBe(true);
+  });
+
+  it('returns null on illegal SAN', () => {
+    expect(fenAfterMove(STARTING_FEN_WHITE, 'Nxd4')).toBeNull();
+  });
+
+  it('returns null on malformed FEN without throwing', () => {
+    expect(() => fenAfterMove('this is not a fen', 'e4')).not.toThrow();
+    expect(fenAfterMove('this is not a fen', 'e4')).toBeNull();
   });
 });

--- a/frontend/src/lib/sanToSquares.ts
+++ b/frontend/src/lib/sanToSquares.ts
@@ -24,3 +24,19 @@ export function sanToSquares(fen: string, san: string): MoveSquares | null {
     return null;
   }
 }
+
+/**
+ * Apply `san` to `fen` and return the resulting full FEN, or `null` if the move
+ * is illegal or the FEN is malformed. Render-time safe — never throws. Used by
+ * OpeningFindingCard to also show the troll-opening watermark when the
+ * candidate move's target position matches a troll line.
+ */
+export function fenAfterMove(fen: string, san: string): string | null {
+  try {
+    const chess = new Chess(fen);
+    chess.move(san);
+    return chess.fen();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -41,6 +41,7 @@ import {
   useTimeSeries,
 } from '@/hooks/usePositionBookmarks';
 import { useMostPlayedOpenings } from '@/hooks/useStats';
+import { rangeToQueryParams } from '@/lib/opponentStrength';
 import { ChessBoard } from '@/components/board/ChessBoard';
 import { MoveExplorer } from '@/components/move-explorer/MoveExplorer';
 import { MoveList } from '@/components/board/MoveList';
@@ -467,7 +468,7 @@ export function OpeningsPage() {
       platform: debouncedFilters.platforms,
       rated: debouncedFilters.rated,
       opponent_type: debouncedFilters.opponentType,
-      opponent_strength: debouncedFilters.opponentStrength,
+      ...rangeToQueryParams(debouncedFilters.opponentStrength),
       recency: debouncedFilters.recency === 'all' ? null : debouncedFilters.recency,
     };
   }, [chartBookmarks, debouncedFilters]);

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -38,7 +38,21 @@ type ApiMatchSide = 'white' | 'black' | 'full';
 export type Recency = 'week' | 'month' | '3months' | '6months' | 'year' | '3years' | '5years' | 'all';
 export type Color = 'white' | 'black';
 export type OpponentType = 'human' | 'bot' | 'both';
-export type OpponentStrength = 'any' | 'stronger' | 'similar' | 'weaker';
+
+/**
+ * Opponent-strength filter as a (gap_min, gap_max) range over
+ * opponent_rating - user_rating. `null` on either side means unbounded
+ * (no filter on that side). The default `{ min: null, max: null }` is
+ * the "Any" preset — equivalent to "no filter".
+ */
+export interface OpponentStrengthRange {
+  min: number | null;
+  max: number | null;
+}
+
+/** Named preset shortcuts for the four common opponent-strength buckets. */
+export type OpponentStrengthPreset = 'any' | 'stronger' | 'similar' | 'weaker';
+
 export type UserResult = 'win' | 'draw' | 'loss';
 
 /** Resolves mine/opponent/both + color to the API's white/black/full value */

--- a/frontend/src/types/position_bookmarks.ts
+++ b/frontend/src/types/position_bookmarks.ts
@@ -50,7 +50,8 @@ export interface TimeSeriesRequest {
   rated?: boolean | null;
   opponent_type?: 'human' | 'bot' | 'both';
   recency?: 'week' | 'month' | '3months' | '6months' | 'year' | '3years' | '5years' | 'all' | null;
-  opponent_strength?: 'any' | 'stronger' | 'similar' | 'weaker';
+  opponent_gap_min?: number;
+  opponent_gap_max?: number;
 }
 
 export interface TimeSeriesPoint {

--- a/tests/repositories/test_opening_insights_repository.py
+++ b/tests/repositories/test_opening_insights_repository.py
@@ -169,7 +169,8 @@ def _default_call_args(
         "rated": None,
         "opponent_type": "both",
         "recency_cutoff": None,
-        "opponent_strength": "any",
+        "opponent_gap_min": None,
+        "opponent_gap_max": None,
     }
 
 

--- a/tests/test_insights_router.py
+++ b/tests/test_insights_router.py
@@ -524,7 +524,7 @@ class TestFilterPassing:
         monkeypatch: pytest.MonkeyPatch,
         test_engine: AsyncEngine,
     ) -> None:
-        """opponent_strength is forwarded as FilterContext (v8: the only
+        """opponent_gap_min/max → derived preset on FilterContext (v8: the only
         non-default filter the router accepts)."""
         headers, user = authed_user_with_session
         fake_insights_agent(_sample_report())
@@ -549,7 +549,7 @@ class TestFilterPassing:
         ) as client:
             response = await client.post(
                 INSIGHTS_ENDPOINT,
-                params={"opponent_strength": "stronger"},
+                params={"opponent_gap_min": 50},
                 headers=headers,
             )
 

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -352,13 +352,12 @@ class TestGetMostPlayedOpenings:
 
 
 # ---------------------------------------------------------------------------
-# Additional tests for opponent_type/opponent_strength on /stats/global
-# (added to TestGetGlobalStats class below as stand-alone tests outside the class)
+# Additional tests for opponent_type/opponent_gap_min/max on /stats/global
 # ---------------------------------------------------------------------------
 
 
 class TestGetGlobalStatsOpponentFilters:
-    """Tests for opponent_type + opponent_strength params on GET /stats/global."""
+    """Tests for opponent_type + opponent_gap_min/max params on GET /stats/global."""
 
     @pytest.mark.asyncio
     async def test_accepts_opponent_type(self, auth_headers: dict[str, str]) -> None:
@@ -377,34 +376,34 @@ class TestGetGlobalStatsOpponentFilters:
         assert "by_color" in body
 
     @pytest.mark.asyncio
-    async def test_accepts_opponent_strength(self, auth_headers: dict[str, str]) -> None:
-        """Endpoint should accept opponent_strength param without error (D-18)."""
+    async def test_accepts_opponent_gap_range(self, auth_headers: dict[str, str]) -> None:
+        """Endpoint should accept opponent_gap_min/max params without error."""
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
         ) as client:
             resp = await client.get(
                 "/api/stats/global",
-                params={"opponent_strength": "stronger"},
+                params={"opponent_gap_min": 50},
                 headers=auth_headers,
             )
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_rejects_invalid_opponent_strength(self, auth_headers: dict[str, str]) -> None:
-        """Invalid opponent_strength returns 422 via Literal validation."""
+    async def test_rejects_non_integer_opponent_gap(self, auth_headers: dict[str, str]) -> None:
+        """Non-integer opponent_gap_min returns 422 via int validation."""
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
         ) as client:
             resp = await client.get(
                 "/api/stats/global",
-                params={"opponent_strength": "bogus"},
+                params={"opponent_gap_min": "bogus"},
                 headers=auth_headers,
             )
         assert resp.status_code == 422
 
 
 class TestGetRatingHistoryOpponentFilters:
-    """Tests for opponent_type + opponent_strength params on GET /stats/rating-history."""
+    """Tests for opponent_type + opponent_gap_min/max params on GET /stats/rating-history."""
 
     @pytest.mark.asyncio
     async def test_rating_history_accepts_opponent_type(self, auth_headers: dict[str, str]) -> None:
@@ -414,7 +413,7 @@ class TestGetRatingHistoryOpponentFilters:
         ) as client:
             resp = await client.get(
                 "/api/stats/rating-history",
-                params={"opponent_type": "bot", "opponent_strength": "similar"},
+                params={"opponent_type": "bot", "opponent_gap_min": -50, "opponent_gap_max": 50},
                 headers=auth_headers,
             )
         assert resp.status_code == 200
@@ -423,31 +422,31 @@ class TestGetRatingHistoryOpponentFilters:
         assert "lichess" in body
 
     @pytest.mark.asyncio
-    async def test_rating_history_accepts_opponent_strength(
+    async def test_rating_history_accepts_opponent_gap_range(
         self, auth_headers: dict[str, str]
     ) -> None:
-        """Endpoint should accept opponent_strength param without error (D-18)."""
+        """Endpoint should accept opponent_gap_min/max params without error."""
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
         ) as client:
             resp = await client.get(
                 "/api/stats/rating-history",
-                params={"opponent_strength": "similar"},
+                params={"opponent_gap_min": -50, "opponent_gap_max": 50},
                 headers=auth_headers,
             )
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_rating_history_rejects_invalid_opponent_strength(
+    async def test_rating_history_rejects_non_integer_opponent_gap(
         self, auth_headers: dict[str, str]
     ) -> None:
-        """Invalid opponent_strength returns 422 via Literal validation."""
+        """Non-integer opponent_gap_min returns 422 via int validation."""
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://test"
         ) as client:
             resp = await client.get(
                 "/api/stats/rating-history",
-                params={"opponent_strength": "bogus"},
+                params={"opponent_gap_min": "bogus"},
                 headers=auth_headers,
             )
         assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Replaces the 4-option Opponent Strength ToggleGroup (Any / Stronger / Similar / Weaker) with a dual-handle range slider over [−200, +200] ELO gap (step 50), plus four preset chips that snap the slider. Slider endpoints map to unbounded (`null`) on the API.

- Backend: new `app/core/opponent_strength.py` (preset/range mapping); `apply_game_filters` now takes `opponent_gap_min` / `opponent_gap_max` (None = unbounded); routers, services, schemas, and repositories all rewired. The endgame LLM insights endpoint still accepts only preset ranges (rejects custom ranges with 400) so the LLM cache key stays stable.
- Frontend: new shadcn-style dual-handle `Slider` (radix-ui), new `OpponentStrengthFilter` with preset chips + InfoPopover + tick labels, new `lib/opponentStrength.ts` helpers. `FilterState.opponentStrength` is now a `{min, max}` range; all hooks and `buildFilterParams` send `opponent_gap_min` / `opponent_gap_max`. Generate button is disabled (with tooltip) when a custom range is active.
- No DB migration. `LlmLog.filter_context` continues to store the preset name string.

## Verification

- `uv run ruff check app/ tests/` — clean
- `uv run ty check app/ tests/` — clean
- `uv run pytest tests/` — 1165 passed
- `npm run lint` — 0 errors
- `npm run build` — success
- `npm test -- --run` — 211 passed
- `npm run knip` — clean

## Test plan

- [ ] Verify slider drag works on desktop (mouse) and mobile (touch); 24px thumbs, 44px hit area
- [ ] Verify each preset chip snaps the slider correctly (Any / Stronger / Similar / Weaker)
- [ ] Verify summary text shows preset name in brand color, raw range otherwise
- [ ] Verify endgame Generate button is disabled with tooltip when on a custom range
- [ ] Verify endgame Generate button works when snapped to a preset (LLM cache hits)
- [ ] Verify openings, stats, and bookmarks queries refetch when range changes
- [ ] Mobile real-phone UX check (tracked separately as a pending todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)