### PR TITLE
ci: switch CodeQL to advanced setup (PR + weekly cron)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+"on":
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly baseline refresh on main so PR alerts can diff against current state.
+    - cron: "27 6 * * 1"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` with PR + weekly schedule triggers, dropping the redundant push-to-main scan.
- Scans Python and JavaScript/TypeScript with the `security-and-quality` query suite.
- Weekly cron (Mon 06:27 UTC) keeps the default-branch baseline fresh so PR alerts can diff against current main.

## Why
The post-merge push-to-main run analyzes the same code the PR run already did. Dropping it saves CI minutes without losing coverage, as long as a periodic run keeps the baseline current.

## Action required before merge
GitHub does not allow CodeQL default setup and advanced setup to coexist. **Before merging**, disable default setup at:
Settings → Code security → CodeQL analysis → Configure → Switch to advanced (or disable default setup).

After merging, the next PR will be analyzed by this workflow, and the weekly cron will refresh the main baseline.

## Test plan
- [ ] Disable default-setup CodeQL in repo settings
- [ ] Merge PR
- [ ] Verify a follow-up PR triggers `CodeQL / Analyze (python)` and `CodeQL / Analyze (javascript-typescript)` checks
- [ ] Verify weekly cron run appears in Actions on next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)