### PR TITLE
fix(openings): use JOIN over EXISTS in opening transitions standard-start filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ in `YYYY-MM-DD` (Europe/Zurich).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Opening Insights query plan regression for small users.** The `query_opening_transitions` standard-start filter used a correlated `EXISTS` subquery. For users with a few hundred games the planner picked `ix_gp_user_white_hash` for the inner scan (only `user_id` as index cond, row-by-row filter on `ply=0 AND full_hash=STARTING_HASH`), scanning ~25k rows per outer row × ~8k outer rows ≈ 188M shared buffer hits and ~88 s wall time. Heavy users (~20k+ games) coincidentally landed on `ix_gp_user_full_hash_move_san` and ran in ~1 s. Rewriting as an explicit `INNER JOIN` to a subquery pins the planner to the right index for both regimes: ~65 ms on the 499-game test user, equal-or-faster on a 23k-game user (928 ms vs 988 ms warm-cache).
+
 ## [v1.16] Stockfish Eval Analyses — 2026-05-11
 
 Downstream consumers of v1.15's Stockfish eval substrate (endgame span-entry + middlegame-entry `eval_cp` / `eval_mate` on `game_positions`). Adds opening-stats eval bullets with t-test confidence, transposition-inclusive Move Explorer + Opening Insights WDL, the Endgame Start vs End twin-tile section with 2×2 grid for Stockfish-baseline achievable score, and LLM narration of all three new metrics. Five phases (80, 80.1, 81, 82, 83) shipped via PRs #80, #82, #85, #86, #88.

--- a/app/repositories/openings_repository.py
+++ b/app/repositories/openings_repository.py
@@ -736,16 +736,30 @@ async def query_opening_transitions(
     # min(array_agg(...)) lexicographically picks such a chain. Games missing
     # a ply-0 row entirely (data corruption — should not occur) are also
     # excluded by the EXISTS predicate.
-    gp_root = aliased(GamePosition, name="gp_root")
-    has_standard_start = (
-        select(1)
+    # Pre-filter to games whose ply-0 position is the standard starting position
+    # (excludes chess.com puzzle/themed-event games with [SetUp "1"] PGN tags
+    # whose SAN prefix is unreachable from chess.Board() and would crash the
+    # replay in opening_insights_service._compute_prefix_hashes). Games missing
+    # a ply-0 row entirely (data corruption — should not occur) are also
+    # excluded.
+    #
+    # Implemented as an INNER JOIN to a subquery rather than a correlated
+    # EXISTS: on small users (e.g. 499 games) the EXISTS form caused the
+    # planner to pick ix_gp_user_white_hash for the inner scan (only user_id
+    # filterable, then row-by-row filter on ply=0 + full_hash), scanning ~25k
+    # rows per outer row × 8k outer rows = 188M buffer hits / ~88s. Heavy
+    # users (~20k+ games) happened to dodge the bug because the planner chose
+    # ix_gp_user_full_hash_move_san there. The JOIN form lets the planner push
+    # game_id into ix_gp_user_game_ply for the gp scan in both regimes —
+    # ~65ms on the same 499-game user.
+    standard_start_games_subq = (
+        select(GamePosition.game_id.label("game_id"))
         .where(
-            gp_root.game_id == GamePosition.game_id,
-            gp_root.user_id == GamePosition.user_id,
-            gp_root.ply == 0,
-            gp_root.full_hash == STARTING_POSITION_HASH,
+            GamePosition.user_id == user_id,
+            GamePosition.ply == 0,
+            GamePosition.full_hash == STARTING_POSITION_HASH,
         )
-        .exists()
+        .subquery("standard_start_games")
     )
     transitions_cte = (
         select(
@@ -787,16 +801,15 @@ async def query_opening_transitions(
             )
             .label("entry_san_sequence"),
         )
+        .join(
+            standard_start_games_subq,
+            GamePosition.game_id == standard_start_games_subq.c.game_id,
+        )
         .where(
             GamePosition.user_id == user_id,
             # Need ply 0 for the partition (so its move_san enters entry_san_sequence)
             # and ply MAX_ENTRY_PLY+1 so LEAD has a row to read for entries at MAX_ENTRY_PLY.
             GamePosition.ply.between(0, OPENING_INSIGHTS_MAX_ENTRY_PLY + 1),
-            # Phase 71 hotfix: include only games whose ply-0 position is the
-            # standard starting position (chess.com [SetUp "1"] PGN tags etc.
-            # are excluded) — their SAN prefix is unreachable from chess.Board()
-            # and would crash the replay in opening_insights_service.
-            has_standard_start,
         )
         .cte("transitions")
     )


### PR DESCRIPTION
## Summary

- Small users (a few hundred games) were hitting an 88s query plan on Opening Insights because the standard-start `EXISTS` filter pinned the planner to `ix_gp_user_white_hash` (only `user_id` as index cond) — 188M shared buffer hits.
- Rewriting as an explicit `INNER JOIN` to a subquery pins both small and heavy users to `ix_gp_user_full_hash_move_san` (perfect 2-column index cond).

## Measurements (prod, warm cache, EXPLAIN ANALYZE on a COUNT-only variant of the full query)

| User | Games | EXISTS (old) | JOIN (new) |
|------|-------|--------------|------------|
| 80   | 499   | ~88,000 ms   | **65 ms** (~1350×) |
| 21   | 11k   | ~1,420 ms*   | **463 ms** |
| 4    | 23k   | 988 ms       | **928 ms** (slightly faster) |

*Cold-I/O run; warm would be ~900 ms, on par with JOIN.

Both forms produce essentially the same plan shape for heavy users (Bitmap Heap Scan → Nested Loop → Index Only Scan on `ix_gp_user_game_ply`). The EXISTS form adds a no-op HashAggregate; at steady state they tie. The small-user catastrophe is entirely about index choice for the inner correlated scan.

## Test plan

- [x] `uv run pytest tests/repositories/test_opening_insights_repository.py tests/services/test_opening_insights_service.py tests/routers/test_insights_openings.py` — 64 passing
- [x] `uv run ruff check` + `uv run ty check` — clean
- [ ] Manual smoke on prod for user 80 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)