### PR TITLE
feat(import): add low-game-count info box and Alert refactor

### DIFF
--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Info, Lightbulb, AlertTriangle, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Info, AlertTriangle, AlertCircle, CheckCircle2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -10,7 +10,6 @@ const alertVariants = cva(
     variants: {
       variant: {
         info: 'border-border bg-muted/50 text-muted-foreground',
-        tip: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
         warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
         error: 'border-destructive/30 bg-destructive/10 text-destructive',
         success: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
@@ -24,7 +23,6 @@ const alertVariants = cva(
 
 const VARIANT_ICONS = {
   info: Info,
-  tip: Lightbulb,
   warning: AlertTriangle,
   error: AlertCircle,
   success: CheckCircle2,

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { Info, AlertTriangle, AlertCircle, CheckCircle2 } from 'lucide-react';
+import { Info, Lightbulb, AlertTriangle, AlertCircle, CheckCircle2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
@@ -10,6 +10,7 @@ const alertVariants = cva(
     variants: {
       variant: {
         info: 'border-border bg-muted/50 text-muted-foreground',
+        tip: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400',
         warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
         error: 'border-destructive/30 bg-destructive/10 text-destructive',
         success: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
@@ -23,6 +24,7 @@ const alertVariants = cva(
 
 const VARIANT_ICONS = {
   info: Info,
+  tip: Lightbulb,
   warning: AlertTriangle,
   error: AlertCircle,
   success: CheckCircle2,

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -333,10 +333,14 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
 
       {profile && (profile.chess_com_last_sync_at || profile.lichess_last_sync_at) &&
         (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
-          <Alert variant="info" data-testid="import-low-game-count-info">
+          <Alert
+            variant="info"
+            data-testid="import-low-game-count-info"
+            className="border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400"
+          >
             <p>
               Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
-              become more reliable, complete, and interesting the more games they are based on. A few gaps here and there are expected.
+              become more reliable, complete, and interesting the more games they are based on. With fewer games imported, expect a few gaps in the data.
             </p>
           </Alert>
       )}

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -333,11 +333,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
 
       {profile && (profile.chess_com_last_sync_at || profile.lichess_last_sync_at) &&
         (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
-          <Alert
-            variant="info"
-            data-testid="import-low-game-count-info"
-            className="border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-400"
-          >
+          <Alert variant="tip" data-testid="import-low-game-count-info">
             <p>
               Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
               become more reliable, complete, and interesting the more games they are based on. With fewer games imported, expect a few gaps in the data.

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as Sentry from '@sentry/react';
-import { X, DoorOpen } from 'lucide-react';
+import { X, DoorOpen, Info } from 'lucide-react';
 import { Alert } from '@/components/ui/alert';
 import { PlatformIcon } from '@/components/icons/PlatformIcon';
 import {
@@ -333,7 +333,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
 
       {profile && (profile.chess_com_last_sync_at || profile.lichess_last_sync_at) &&
         (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
-          <Alert variant="tip" data-testid="import-low-game-count-info">
+          <Alert variant="tip" icon={Info} data-testid="import-low-game-count-info">
             <p>
               Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
               become more reliable, complete, and interesting the more games they are based on. With fewer games imported, expect a few gaps in the data.
@@ -351,9 +351,6 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
         </p>
         <p>
           <strong className="text-foreground">Slow Import:</strong> due to partial stockfish game analysis, imports take a while. But it's worth the wait.
-        </p>
-        <p>
-          <strong className="text-foreground">Opponent Scouting:</strong> delete your games, import the opponent's games to analyze their openings, then delete and re-import your own games.
         </p>
       </div>
 

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -23,6 +23,7 @@ import { apiClient } from '@/api/client';
 
 
 const GAME_COUNT_REFRESH_INTERVAL_MS = 5000;
+const MIN_GAMES_FOR_RELIABLE_STATS = 1000;
 
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
@@ -328,6 +329,16 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
             ))}
           </div>
         </div>
+      )}
+
+      {profile && (profile.chess_com_last_sync_at || profile.lichess_last_sync_at) &&
+        (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
+          <Alert variant="info" data-testid="import-low-game-count-info">
+            <p>
+              Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
+              become more reliable, complete, and interesting the more games they are based on. A few gaps here and there are expected.
+            </p>
+          </Alert>
       )}
 
       {/* Info box: sync behavior and opponent scouting explanation */}

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -335,7 +335,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
         (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
           <Alert variant="info" data-testid="import-low-game-count-info">
             <p>
-              Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
+              <strong className="text-foreground">Low game count:</strong> Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
               become more reliable, complete, and interesting the more games they are based on. With fewer games imported, expect a few gaps in the data.
             </p>
           </Alert>

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as Sentry from '@sentry/react';
-import { X, DoorOpen, Info } from 'lucide-react';
+import { X, DoorOpen } from 'lucide-react';
 import { Alert } from '@/components/ui/alert';
 import { PlatformIcon } from '@/components/icons/PlatformIcon';
 import {
@@ -333,7 +333,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
 
       {profile && (profile.chess_com_last_sync_at || profile.lichess_last_sync_at) &&
         (profile.chess_com_game_count + profile.lichess_game_count) < MIN_GAMES_FOR_RELIABLE_STATS && (
-          <Alert variant="tip" icon={Info} data-testid="import-low-game-count-info">
+          <Alert variant="info" data-testid="import-low-game-count-info">
             <p>
               Many features and statistics are useful with fewer than {MIN_GAMES_FOR_RELIABLE_STATS.toLocaleString()} games, but they
               become more reliable, complete, and interesting the more games they are based on. With fewer games imported, expect a few gaps in the data.

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -341,18 +341,14 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
           </Alert>
       )}
 
-      {/* Info box: sync behavior and opponent scouting explanation */}
-      <div
-        data-testid="import-info"
-        className="charcoal-texture rounded-md px-4 py-3 text-sm text-muted-foreground space-y-2"
-      >
+      <Alert variant="info" data-testid="import-info">
         <p>
           <strong className="text-foreground">First Sync:</strong> imports all your games. Later syncs only fetch new games since the last import.
         </p>
         <p>
-          <strong className="text-foreground">Slow Import:</strong> due to partial stockfish game analysis, imports take a while. But it's worth the wait.
+          <strong className="text-foreground">Slow Import:</strong> due to partial stockfish game analysis, imports take a while.
         </p>
-      </div>
+      </Alert>
 
       {/* Delete All Games */}
       <div data-testid="import-data-management">


### PR DESCRIPTION
## Summary

- Add an Alert on the import page that explains stats become more reliable with more games. Shown once at least one platform has been synced and total games < 1000.
- Replace the existing charcoal-texture sync-behavior notice (First Sync / Slow Import) with the standard `<Alert variant="info">` component for consistency.

Visibility of the low-game-count alert is derived purely from `profile` (server state) — no local dismiss flag — so it naturally persists across logout/login and page reload.

## Test plan

- [ ] As a fresh user (zero games), the box does NOT appear (no sync has happened yet).
- [ ] After completing at least one platform sync with total games < 1000, the box appears.
- [ ] After total games ≥ 1000, the box disappears.
- [ ] Box re-appears on logout/login and page reload while the condition still holds.
- [ ] Sync-behavior notice still renders correctly using the info Alert variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)