### PR TITLE
Phase 84: Data plumbing — per-type cohort p50 + mirror-rate audit

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -363,7 +363,9 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state
 
 ---
-*Last updated: 2026-05-12 — v1.17 (Endgame Stats Card Redesign) opened. Frontend-only refactor replacing 3 table-driven sections on the Endgames page with the WDL+ScoreBullet card pattern; two-bullet doctrine (cohort + peer) preserves the self-calibrating opponent signal as a second bullet on Conv/Parity/Recov + Section 3 per-type cards. No backend or benchmark changes.*
+*Last updated: 2026-05-13 — Phase 84 (Data plumbing — mirror-rate audit) complete. DATA-02 shipped via plan 84-01: `ConversionRecoveryStats` extended with 4 `opponent_*` fields populated by same-game mirror identity in `_aggregate_endgame_stats`, gated on `_MIN_OPPONENT_SAMPLE`. Section 2 wiring audited and confirmed already present. Pivot during v1.17 exploration replaced the two-bullet doctrine (cohort + peer) with a single peer bullet on Conv/Parity/Recov + Section 3 — rating-tier confound made the cohort/p50 frame near-redundant with ELO. v1.17 remaining: 4 phases (85, 86, 87, 88).*
+
+*Previous: 2026-05-12 — v1.17 (Endgame Stats Card Redesign) opened. Frontend-only refactor (with Phase 84 as the lone backend touch) replacing 3 table-driven sections on the Endgames page with the WDL+ScoreBullet card pattern.*
 
 *Previous: 2026-05-11 after v1.16 milestone — Stockfish Eval Analyses shipped (PRs #80, #82, #85, #86, #88). 5 phases (80, 80.1, 81, 82, 83), 24 plans, 118 commits in 7 days. SEED-014 closed by Phase 83; SEED-015 (predicted-vs-achieved gap as first-class metric) remains dormant.*
 

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -50,7 +50,7 @@ Replaces the section's `EndgameWDLChart` (grouped horizontal-bar overview) and e
 
 Frontend-only milestone, with one payload audit.
 
-- [ ] **DATA-02**: Mirror-bucket peer rates (`opponentRate` for Conv / Parity / Recov / Skill components in Section 2 and per-type Conv / Recov in Section 3) are exposed on the `/api/endgames/overview` response payload (audit existing schema; extend only if not already present). Skill card's derived `Opp Skill` is computed frontend-side from `opp_conv` + `opp_recov`, so no new payload field is required for it.
+- [x] **DATA-02**: Mirror-bucket peer rates (`opponentRate` for Conv / Parity / Recov / Skill components in Section 2 and per-type Conv / Recov in Section 3) are exposed on the `/api/endgames/overview` response payload (audit existing schema; extend only if not already present). Skill card's derived `Opp Skill` is computed frontend-side from `opp_conv` + `opp_recov`, so no new payload field is required for it.
 
 ### Polish & Calibration (POLISH)
 
@@ -107,7 +107,7 @@ Populated by gsd-roadmapper 2026-05-12.
 | SEC3-05 | Phase 87 | Pending |
 | SEC3-06 | Phase 87 | Pending |
 | SEC3-07 | Phase 87 | Pending |
-| DATA-02 | Phase 84 | Pending |
+| DATA-02 | Phase 84 | Complete |
 | POLISH-01 | Phase 88 | Pending |
 | POLISH-02 | Phase 88 | Pending |
 | POLISH-03 | Phase 88 | Pending |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.17
 milestone_name: Endgame Stats Card Redesign
 status: executing
-last_updated: "2026-05-13T05:20:02.617Z"
-last_activity: 2026-05-13 -- Phase 84 execution started
+last_updated: "2026-05-13T05:40:00.000Z"
+last_activity: 2026-05-13 -- Phase 84 verified passed (1/1 plans complete)
 progress:
   total_phases: 0
   completed_phases: 0
@@ -16,10 +16,10 @@ progress:
 
 ## Current Position
 
-Phase: 84 (data-plumbing-per-type-cohort-p50-and-mirror-rate-audit) — EXECUTING
-Plan: 1 of 1
-Status: Executing Phase 84
-Last activity: 2026-05-13 -- Phase 84 execution started
+Phase: 85 (Section 1 — Games with vs without Endgame cards) — NEXT
+Plan: not started
+Status: Phase 84 complete (verified passed) — ready for Phase 85 discuss/plan
+Last activity: 2026-05-13 -- Phase 84 verified passed (1/1 plans complete)
 
 ## Project Reference
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,9 +2,9 @@
 gsd_state_version: 1.0
 milestone: v1.17
 milestone_name: Endgame Stats Card Redesign
-status: executing
-last_updated: "2026-05-13T05:40:00.000Z"
-last_activity: 2026-05-13 -- Phase 84 verified passed (1/1 plans complete)
+status: "Phase 84 shipped — PR #95"
+last_updated: "2026-05-13T05:45:37.958Z"
+last_activity: 2026-05-13
 progress:
   total_phases: 0
   completed_phases: 0
@@ -18,8 +18,8 @@ progress:
 
 Phase: 85 (Section 1 — Games with vs without Endgame cards) — NEXT
 Plan: not started
-Status: Phase 84 complete (verified passed) — ready for Phase 85 discuss/plan
-Last activity: 2026-05-13 -- Phase 84 verified passed (1/1 plans complete)
+Status: Phase 84 shipped — PR #95
+Last activity: 2026-05-13
 
 ## Project Reference
 

--- a/.planning/milestones/v1.17-ROADMAP.md
+++ b/.planning/milestones/v1.17-ROADMAP.md
@@ -123,7 +123,7 @@ Replace three table-driven sections on the Endgames page with the established WD
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 84. Data plumbing — mirror-rate audit | 0/TBD | Not started (prior plans deleted 2026-05-12) | — |
+| 84. Data plumbing — mirror-rate audit | 1/1 | Complete | 2026-05-13 |
 | 85. Section 1 — Games with vs without Endgame cards | 0/TBD | Not started | — |
 | 86. Section 2 — Endgame Metrics 4-card layout | 0/TBD | Not started | — |
 | 87. Section 3 — Per-type Endgame Type Breakdown cards | 0/TBD | Not started | — |

--- a/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-01-SUMMARY.md
+++ b/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-01-SUMMARY.md
@@ -1,0 +1,187 @@
+---
+phase: 84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit
+plan: 01
+subsystem: api
+tags: [endgames, pydantic, mirror-identity, opponent-baseline, fastapi, phase-60-pattern]
+
+# Dependency graph
+requires:
+  - phase: 60
+    provides: same-game mirror-identity pattern (Section 2) for opponent baselines on MaterialRow
+provides:
+  - ConversionRecoveryStats.opponent_conversion_pct / opponent_conversion_games (per-class, gated on recovery_games >= 10)
+  - ConversionRecoveryStats.opponent_recovery_pct / opponent_recovery_games (per-class, gated on conversion_games >= 10)
+  - Audit confirmation that Section 2 peer rates are already exposed on MaterialRow (Phase 60 baseline)
+affects: [86-skill-card, 87-per-type-bullets]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Per-class same-game mirror identity (Phase 84 extension of Phase 60 Section 2 pattern)"
+    - "Mirror-bucket gating: opponent_*_pct is None when the MIRROR bucket sample (not the own bucket) falls below _MIN_OPPONENT_SAMPLE"
+
+key-files:
+  created:
+    - .planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-01-SUMMARY.md
+  modified:
+    - app/schemas/endgames.py
+    - app/services/endgame_service.py
+    - tests/test_endgame_service.py
+    - tests/services/test_insights_llm.py
+    - tests/services/test_insights_service_series.py
+
+key-decisions:
+  - "Reuse _MIN_OPPONENT_SAMPLE (line 233) rather than introduce a parallel PER_CLASS_OPPONENT_SAMPLE_MIN (D-05)."
+  - "Inline ~20 lines of arithmetic in _aggregate_endgame_stats over extracting a _compute_per_type_opponent_baseline helper — nesting depth stays at 2 inside the existing per-class loop (D-07)."
+  - "Audit prose lives inline in 84-01-SUMMARY.md (single-plan default per D-11), not as a separate .planning/notes/ entry."
+
+patterns-established:
+  - "Asymmetric mirror formulas: Conv uses (recovery_games - recovery_wins - recovery_draws) / recovery_games; Recov uses (conversion_losses + conversion_draws) / conversion_games. Conv is a win-rate, Recov is a save-rate, so the formulas are NOT copy-paste of each other."
+  - "Gate the opponent baseline on the MIRROR bucket size, not the own bucket. The mirror bucket is what supplies the opponent's sample."
+
+requirements-completed: [DATA-02]
+
+# Metrics
+duration: ~25min
+completed: 2026-05-13
+---
+
+# Phase 84 Plan 01: Per-class Opponent Baselines via Mirror Identity Summary
+
+**ConversionRecoveryStats carries four new per-class opponent-baseline fields (opponent_conversion_pct/games + opponent_recovery_pct/games) populated by the same-game mirror identity in `_aggregate_endgame_stats`, gated on `_MIN_OPPONENT_SAMPLE` against the MIRROR bucket size — Phase 87 can now render per-type Conv/Recov peer bullets directly from the response payload without re-deriving WDL math client-side.**
+
+## Performance
+
+- **Duration:** ~25 min
+- **Started:** 2026-05-13T05:02:00Z (approx, pre-Task-1)
+- **Completed:** 2026-05-13T05:27:49Z
+- **Tasks:** 3
+- **Files modified:** 5 (1 schema, 1 service, 3 tests)
+
+## Accomplishments
+
+- `ConversionRecoveryStats` extended with four REQUIRED fields after `recovery_draws`: `opponent_conversion_pct: float | None`, `opponent_conversion_games: int`, `opponent_recovery_pct: float | None`, `opponent_recovery_games: int`.
+- `_aggregate_endgame_stats` populates all four via the same-game mirror identity (one new ~20-line block between `recovery_pct = ...` and the existing `ConversionRecoveryStats(...)` constructor call); no new accumulator, no new constant, no new DB query, no new helper.
+- Five new tests inside `TestAggregateEndgameStats` cover symmetric mirror (60/40), below-threshold (9 games → None), at-threshold (10 games → non-None), zero-sample (no `ZeroDivisionError`), and schema shape (four new fields are REQUIRED).
+- Section 2 audit prose with file:line citations confirms Phase 87's per-type bullets and Phase 86's Skill `Opp Skill` baseline reuse Phase 60's existing `MaterialRow.opponent_score` plumbing — no new payload field needed for Section 2.
+
+## Task Commits
+
+1. **Task 1: Extend ConversionRecoveryStats schema with 4 opponent fields** — `76521311` (feat)
+2. **Task 2: Wire mirror-identity computation into _aggregate_endgame_stats** — `e1f9acff` (feat — combined RED/GREEN; fixture-update for existing tests included)
+3. **Task 3: Add per-type opponent-baseline tests + audit SUMMARY** — pending this commit (test + docs)
+
+## Files Created/Modified
+
+- `app/schemas/endgames.py` — Added 4 required fields to `ConversionRecoveryStats` after `recovery_draws`; extended docstring with Phase 84 paragraph.
+- `app/services/endgame_service.py` — Inserted Phase 84 mirror-identity block in `_aggregate_endgame_stats` (between lines ~355 and the existing constructor call). Reuses `_MIN_OPPONENT_SAMPLE = 10` (line 233). `_compute_score_gap_material` (Section 2) is byte-identical to pre-task.
+- `tests/test_endgame_service.py` — Added 5 new test methods inside `TestAggregateEndgameStats` (per RESEARCH.md Open Question 1: co-locate with the function under test).
+- `tests/services/test_insights_llm.py` — Updated 2 existing `ConversionRecoveryStats(...)` fixture call-sites to supply the new required fields (Rule 3 — blocking issue: ty rejected the missing kwargs).
+- `tests/services/test_insights_service_series.py` — Updated 1 existing `_make_conv_stats` fixture for the same reason.
+- `.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-01-SUMMARY.md` — This file (audit deliverable per D-02).
+
+## DATA-02 Section 2 audit (already wired)
+
+Section 2's Conv / Parity / Recov peer bullets and the Skill card's derived Opp Skill
+baseline are already exposed on `/api/endgames/overview` — no new payload field for
+Section 2.
+
+Evidence:
+- `MaterialRow.opponent_score: float | None` + `MaterialRow.opponent_games: int`
+  defined in `app/schemas/endgames.py:252-254`.
+- Populated by `_compute_score_gap_material` in `app/services/endgame_service.py:851-870`
+  via Phase 60's swap-bucket mirror identity (`opponent_score = 1.0 - bucket_score[swap_bucket]`,
+  gated on `_MIN_OPPONENT_SAMPLE = 10` at line 233).
+- Wired into `/api/endgames/overview` via `ScoreGapMaterialResponse.material_rows`
+  (`app/schemas/endgames.py:296-320`) and `EndgameOverviewResponse.score_gap_material`
+  (`app/schemas/endgames.py:492-505`).
+- Frontend consumes the fields in `frontend/src/components/charts/EndgameScoreGapSection.tsx:114-145`
+  via `MIRROR_BUCKET` and `opponentRate()`.
+
+Skill peer baseline (Opp Skill) — Phase 86 will derive it client-side from
+`MaterialRow[conversion].opponent_score` + `MaterialRow[recovery].opponent_score`
+(mirroring the Section 2 frontend helper). No new payload field is required for
+Skill; the existing two opponent scores suffice. Originating phase: Phase 60.
+
+## DATA-02 Section 3 extension (this phase)
+
+`ConversionRecoveryStats` now carries four new required fields after `recovery_draws`,
+populated by `_aggregate_endgame_stats` via the same-game mirror identity scoped per
+`EndgameClass`:
+
+- `opponent_conversion_pct: float | None` — opponent's win-rate when opponent entered
+  with eval advantage. Mirror identity: `(recovery_games - recovery_wins - recovery_draws)
+  / recovery_games`. Gated on `recovery_games >= _MIN_OPPONENT_SAMPLE`.
+- `opponent_conversion_games: int` — `== recovery_games` (mirror sample size).
+- `opponent_recovery_pct: float | None` — opponent's save-rate when opponent entered
+  with eval deficit. Mirror identity: `(conversion_losses + conversion_draws) /
+  conversion_games`. Gated on `conversion_games >= _MIN_OPPONENT_SAMPLE`.
+- `opponent_recovery_games: int` — `== conversion_games` (mirror sample size).
+
+The mirror formulas are asymmetric (Conv = win-rate, Recov = save-rate). The
+threshold gate (`>= 10`) is strictly tighter than `> 0`, so no separate
+DivByZero guard is needed. Phase 87 will consume these fields directly for the
+per-type Conv / Recov peer bullets.
+
+## Decisions Made
+
+- **Reuse `_MIN_OPPONENT_SAMPLE` (line 233)** — per D-05, the per-class baseline shares the same sample-size threshold as Section 2. No parallel `PER_CLASS_OPPONENT_SAMPLE_MIN` constant.
+- **Inline ~20 lines over a helper extraction** — per D-07 and CLAUDE.md's "keep functions small and shallow" rule. Nesting depth stays at 2 inside the existing `for endgame_class in wdl:` loop, and the arithmetic is structurally similar to the Section 2 mirror block. A `_compute_per_type_opponent_baseline(...)` helper would require either threading two dicts as args or constructing a per-class context dataclass, both of which violate the "don't invent context dataclasses to make signatures fit" rule.
+- **Inline audit in SUMMARY (not `.planning/notes/`)** — per D-02 / D-11 single-plan default. ~30 lines of audit prose with file:line citations is within the SUMMARY's natural scope.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Updated 3 existing test fixtures that construct `ConversionRecoveryStats`**
+- **Found during:** Task 2 (after schema extension in Task 1, `ty check` flagged 3 call-sites missing the four new required kwargs)
+- **Issue:** `tests/services/test_insights_llm.py:1064` (`_conv` factory inside the test class), `tests/services/test_insights_llm.py:1188` (`rook_conv` literal), and `tests/services/test_insights_service_series.py:393` (`_make_conv_stats` module-level helper) all construct `ConversionRecoveryStats` directly with the legacy 10-field shape; ty's `missing-argument` rule rejected them after the schema gained 4 required fields.
+- **Fix:** Threaded the four new fields through each fixture using mirror-identity values that match the fixture's existing W/D/L counts (not `None`/`0` placeholders), so the fixtures stay arithmetically consistent for any future consumer.
+- **Files modified:** `tests/services/test_insights_llm.py`, `tests/services/test_insights_service_series.py`
+- **Verification:** `uv run ty check app/ tests/` is green; `uv run pytest tests/test_endgame_service.py` and `uv run pytest tests/services/test_insights_llm.py tests/services/test_insights_service_series.py -k 'conv or wdl' -x` both pass.
+- **Committed in:** `e1f9acff` (Task 2 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (Rule 3 — blocking, missing required kwargs in pre-existing fixtures).
+**Impact on plan:** Plan output is unchanged. The fixture updates are required to keep ty green after the schema extension; values were chosen to preserve the original test intent.
+
+## Issues Encountered
+
+- **Repo-wide `ruff format --check .` is not green** (95 files would be reformatted, including most Alembic migrations and several services). This is pre-existing and out of scope per CLAUDE.md's scope-boundary rule. Confirmed all files I modified (`app/schemas/endgames.py`, `app/services/endgame_service.py`, `tests/test_endgame_service.py`, `tests/services/test_insights_llm.py`, `tests/services/test_insights_service_series.py`) pass `ruff format --check`. No action taken on the unrelated files. Logged here for visibility; the orchestrator may want to schedule a separate `/gsd:quick` for a repo-wide `ruff format .` sweep.
+- The plan's `<verification>` step `uv run ruff format --check .` will report 95 reformat candidates; that is the pre-existing condition and not a regression from this plan.
+
+## TDD Gate Compliance
+
+Plan tasks were marked `tdd="true"`. The actual execution combined RED/GREEN into single commits per task because the iteration cycle on three tasks was tight and reverting between RED and GREEN would have added churn without surfacing additional information:
+
+- Task 1 (schema-only) had no behavior change, so RED/GREEN distinction degenerates; the verification was the introspection one-liner from the plan's `<verify>` block.
+- Task 2 (service wiring) was committed as a single feat commit (`e1f9acff`) covering both the implementation and the fixture updates the implementation required.
+- Task 3 (tests + SUMMARY) is committed in this final commit. The 5 new tests pass against the Task 2 implementation, which validates the mirror identities behave as documented.
+
+Note for the verifier: the `feat(84-01)` commits cover what would otherwise have been separate `test(84-01)` + `feat(84-01)` pairs.
+
+## Next Phase Readiness
+
+- Phase 86 (Skill card "Opp Skill") can now consume `MaterialRow[conversion].opponent_score` and `MaterialRow[recovery].opponent_score` directly client-side; no new backend work needed for the Skill peer baseline.
+- Phase 87 (per-type Conv/Recov peer bullets) can now consume `EndgameCategoryStats.conversion.opponent_conversion_pct` / `opponent_recovery_pct` directly from `/api/endgames/overview` and `/api/endgames/stats` payloads; FE renders the bullet width from `conversion_pct` vs `opponent_conversion_pct` without re-deriving WDL math.
+- No DB migration, no new payload route, no new threshold constant introduced — the existing endpoints' shapes are additive only (4 new required fields on `ConversionRecoveryStats`).
+
+## Self-Check: PASSED
+
+- `app/schemas/endgames.py` — modified, present (4 new fields on `ConversionRecoveryStats`).
+- `app/services/endgame_service.py` — modified, present (mirror-identity block at ~line 357, `_compute_score_gap_material` unchanged at line 723+).
+- `tests/test_endgame_service.py` — modified, present (5 new methods inside `TestAggregateEndgameStats`).
+- `tests/services/test_insights_llm.py` — modified, present (2 fixture updates).
+- `tests/services/test_insights_service_series.py` — modified, present (1 fixture update).
+- `84-01-SUMMARY.md` — created, present.
+- Commit `76521311` (Task 1 schema) — present in git log.
+- Commit `e1f9acff` (Task 2 service + fixture updates) — present in git log.
+- Test run: `uv run pytest tests/test_endgame_service.py` reports 237 passed (was 232 before Task 3; +5 new opponent tests).
+- ty: `uv run ty check app/ tests/` reports "All checks passed!"
+
+---
+*Phase: 84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit*
+*Plan: 01*
+*Completed: 2026-05-13*

--- a/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-REVIEW.md
+++ b/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-REVIEW.md
@@ -1,0 +1,125 @@
+---
+phase: 84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit
+reviewed: 2026-05-13T00:00:00Z
+depth: standard
+files_reviewed: 5
+files_reviewed_list:
+  - app/schemas/endgames.py
+  - app/services/endgame_service.py
+  - tests/test_endgame_service.py
+  - tests/services/test_insights_llm.py
+  - tests/services/test_insights_service_series.py
+findings:
+  critical: 0
+  warning: 2
+  info: 3
+  total: 5
+status: issues_found
+---
+
+# Phase 84: Code Review Report
+
+**Reviewed:** 2026-05-13
+**Depth:** standard
+**Files Reviewed:** 5
+**Status:** issues_found
+
+## Summary
+
+Phase 84 extends `ConversionRecoveryStats` with four opponent-baseline fields (`opponent_conversion_pct`, `opponent_conversion_games`, `opponent_recovery_pct`, `opponent_recovery_games`) computed via same-game mirror identity. Tests cover the symmetric / below-threshold / at-threshold / zero-sample cases and a schema-shape guard. Other tests in `test_insights_llm.py` and `test_insights_service_series.py` were updated to supply the new required fields.
+
+The core mirror-identity math is correct:
+- `opponent_conversion_pct = recovery_losses / recovery_games * 100` — when the user is in the recovery bucket the opponent simultaneously entered the conversion bucket; the opponent wins iff the user loses.
+- `opponent_recovery_pct = (conversion_losses + conversion_draws) / conversion_games * 100` — when the user is in the conversion bucket the opponent simultaneously entered the recovery bucket; the opponent "saves" iff the user does not win.
+
+Both percentages are gated on the MIRROR bucket size against `_MIN_OPPONENT_SAMPLE` (10), which correctly reflects that the opponent's sample size IS the mirror bucket. No divide-by-zero risk — the gate guards the only division.
+
+No critical bugs found. Two warning-level findings relate to test-helper inconsistencies and a schema drift with the frontend type mirror. Three info items cover comment/docstring inaccuracies introduced in the new block.
+
+## Warnings
+
+### WR-01: Test helper `_conv()` produces inconsistent `recovery_saves` vs `recovery_wins + recovery_draws`
+
+**File:** `tests/services/test_insights_llm.py:1057-1085`
+**Issue:** The Phase 84 edit reshaped the local `_conv()` helper to derive `conv_losses`, `recov_wins`, `recov_draws`, `recov_losses` from `int(...)` truncations, then computes mirror identities on those values. But it keeps the pre-existing `recovery_saves=int(n_recov * recov_pct / 100)`, which is *not* recomputed as `recov_wins + recov_draws`. With `n_recov=20, recov_pct=30`:
+- `recov_wins = int(20 * 0.3 * 0.6) = int(3.6) = 3`
+- `recov_draws = int(20 * 0.3 * 0.4) = int(2.4) = 2`
+- `recovery_saves = int(20 * 0.3) = 6`, but `recov_wins + recov_draws = 5`
+
+That breaks the documented invariant on `ConversionRecoveryStats` (`recovery_saves = recovery_wins + recovery_draws`, kept "for backward compat" per schema comment line 47). Any consumer that double-checks this invariant in a future test will fail spuriously. Phase 84 didn't introduce the underlying off-by-one, but it touched these same lines and is the natural place to fix it.
+**Fix:**
+```python
+recov_wins = int(n_recov * recov_pct / 100 * 0.6)
+recov_draws = int(n_recov * recov_pct / 100 * 0.4)
+recov_losses = n_recov - recov_wins - recov_draws
+# ...
+recovery_saves=recov_wins + recov_draws,  # honor the documented invariant
+```
+
+### WR-02: Frontend `ConversionRecoveryStats` TS interface diverges from the new backend schema
+
+**File:** `frontend/src/types/endgames.ts:9-20` (consumer of the modified `app/schemas/endgames.py`)
+**Issue:** The backend `ConversionRecoveryStats` Pydantic model now ships four additional fields (`opponent_conversion_pct`, `opponent_conversion_games`, `opponent_recovery_pct`, `opponent_recovery_games`) on `/api/endgames/overview` and `/api/endgames/stats`. The TS mirror in `frontend/src/types/endgames.ts` does NOT declare them. Phase 84's plan explicitly disclaims frontend changes (DATA-02 is backend-only data plumbing for Phase 86), but the project's general convention is to keep the TS mirror in lockstep with the Pydantic schema — see the file's own docstring: "TypeScript mirrors of the Pydantic v2 endgame schemas from the backend." TypeScript will tolerate the extra runtime fields, but the schema drift will silently rot and complicate the future Phase 86 wire-up. Either update the interface now (zero risk, additive) or add a comment in the TS file pointing to Phase 86.
+**Fix:**
+```ts
+export interface ConversionRecoveryStats {
+  // ... existing fields ...
+  recovery_draws: number;
+  // Phase 84: per-class opponent baseline via same-game mirror identity.
+  // Null when the MIRROR bucket sample < 10.
+  opponent_conversion_pct: number | null;
+  opponent_conversion_games: number;
+  opponent_recovery_pct: number | null;
+  opponent_recovery_games: number;
+}
+```
+
+## Info
+
+### IN-01: Stale line-number references in new comment block
+
+**File:** `app/services/endgame_service.py:358-362`
+**Issue:** The Phase 84 block's comment claims to reference `_MIN_OPPONENT_SAMPLE` at "line 233" — the constant is actually defined on line 234. The same comment cites `_compute_score_gap_material (~line 824)` for the precedent pattern, but the relevant `swap_games >= _MIN_OPPONENT_SAMPLE` check sits at line 866 (and the function itself starts at line 723). Line-number annotations rot quickly; either drop them or reference the symbol name only.
+**Fix:**
+```python
+# Phase 84: per-class opponent baseline via same-game mirror identity.
+# Conv is a win-rate, Recov is a save-rate, so the two mirror formulas
+# are asymmetric. Reuses _MIN_OPPONENT_SAMPLE, gated on the MIRROR bucket
+# size (not the own bucket). Phase 60 introduced the pattern for Section 2
+# in _compute_score_gap_material.
+```
+
+### IN-02: Asymmetric local-variable scoping for `recovery_losses` vs `conversion_losses`
+
+**File:** `app/services/endgame_service.py:345 vs 365`
+**Issue:** `conversion_losses` is computed unconditionally at line 345 (then reused both for `ConversionRecoveryStats.conversion_losses=` and inside the mirror identity at line 374). `recovery_losses` is only computed *inside* the `if recovery_games >= _MIN_OPPONENT_SAMPLE:` branch at line 365, even though it's a one-liner. The asymmetry isn't a bug — both branches compute correct values — but it makes the new block harder to read at a glance and makes the two mirror formulas look more different than they are. Hoist `recovery_losses` to live next to `recovery_pct` for symmetry.
+**Fix:**
+```python
+recovery_saves = recovery_wins + recovery_draws
+recovery_losses = recovery_games - recovery_wins - recovery_draws  # mirrors conversion_losses
+recovery_pct = (
+    round(recovery_saves / recovery_games * 100, 1) if recovery_games > 0 else 0.0
+)
+# ... then in the gated block ...
+if recovery_games >= _MIN_OPPONENT_SAMPLE:
+    opponent_conversion_pct = round(recovery_losses / recovery_games * 100, 1)
+```
+
+### IN-03: Test docstring "symmetric_60_40" is misleading
+
+**File:** `tests/test_endgame_service.py:393-399`
+**Issue:** The test is named `test_per_type_opponent_baseline_symmetric_60_40` and the docstring describes the case as "Mirror identities: opp_conv == 60.0, opp_recov == 40.0". Those mirror values aren't structurally symmetric — they happen to equal 60/40 because conv_pct = 60% (so conv_loss_rate = 40%) and recov_save_rate = 40% (so recov_loss_rate = 60%) coincidentally match. The name implies the two mirror percentages must be equal in this scenario, which would mislead a reader updating the test later. Rename to something like `test_per_type_opponent_baseline_mirror_values` or `test_per_type_opponent_baseline_at_60_pct_conv_40_pct_recov`.
+**Fix:** Rename the test method and clarify the docstring:
+```python
+def test_per_type_opponent_baseline_mirror_values(self):
+    """Rook conv 6W/0D/4L → opp_recov == 40%; recov 2W/2D/6L → opp_conv == 60%.
+
+    The two opponent rates need not be equal; they happen to invert here
+    because conv_loss_rate(40%) == recov_save_rate(40%)."""
+```
+
+---
+
+_Reviewed: 2026-05-13_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-VERIFICATION.md
+++ b/.planning/milestones/v1.17-phases/84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit/84-VERIFICATION.md
@@ -1,0 +1,111 @@
+---
+phase: 84-data-plumbing-per-type-cohort-p50-and-mirror-rate-audit
+verified: 2026-05-13T10:00:00Z
+status: passed
+score: 7/7 must-haves verified
+overrides_applied: 0
+---
+
+# Phase 84: Data plumbing — mirror-rate audit — Verification Report
+
+**Phase Goal:** Audit that mirror-bucket peer rates (`opponent_score` / `opponent_games`) are already exposed on `/api/endgames/overview` for Section 2 (Conv/Parity/Recov rows, plus `opp_conv` + `opp_recov` consumed by the derived Skill peer baseline) and Section 3 (per-type Conv/Recov). Prerequisite for the peer bullets in Section 2 + 3.
+
+**Verified:** 2026-05-13T10:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+The phase pivoted during planning: Section 2 (MaterialRow) peer rates were already wired by Phase 60, but Section 3 (per-type ConversionRecoveryStats) was NOT — so plan 84-01 shipped the minimal backend extension via the same mirror-identity pattern. The success criterion explicitly permits this ("OR a minimal backend extension is shipped"). Both halves are verified in the codebase: the Section 2 audit is documented with file:line evidence that matches the actual code, and the Section 3 extension is shipped and tested.
+
+### Observable Truths
+
+| #   | Truth | Status     | Evidence       |
+| --- | ----- | ---------- | -------------- |
+| 1 | ConversionRecoveryStats carries four opponent-baseline fields per endgame class | VERIFIED | `app/schemas/endgames.py:52-59` — `opponent_conversion_pct: float \| None`, `opponent_conversion_games: int`, `opponent_recovery_pct: float \| None`, `opponent_recovery_games: int`, all REQUIRED |
+| 2 | opponent_conversion_pct computed via mirror identity `(recovery_games - recovery_wins - recovery_draws) / recovery_games` rounded 1 dp, 0-100 | VERIFIED | `app/services/endgame_service.py:363-368` — `recovery_losses = recovery_games - recovery_wins - recovery_draws; opponent_conversion_pct = round(recovery_losses / recovery_games * 100, 1)`. Test `test_per_type_opponent_baseline_symmetric_60_40` asserts == 60.0 |
+| 3 | opponent_recovery_pct computed via mirror identity `(conversion_losses + conversion_draws) / conversion_games` rounded 1 dp, 0-100 | VERIFIED | `app/services/endgame_service.py:371-377` — `opponent_recovery_pct = round((conversion_losses + conversion_draws) / conversion_games * 100, 1)`. Test asserts == 40.0 |
+| 4 | opponent_conversion_pct is None when recovery_games < 10; opponent_recovery_pct is None when conversion_games < 10 | VERIFIED | `endgame_service.py:364, 367-368, 372, 376-377` — both gates use `>= _MIN_OPPONENT_SAMPLE` (= 10 at line 234). Test `test_per_type_opponent_baseline_below_threshold` verifies both sides at games=9 → None |
+| 5 | opponent_conversion_games == recovery_games (int, possibly 0); opponent_recovery_games == conversion_games | VERIFIED | `endgame_service.py:369, 378` — direct assignments outside gate, always int. Test `test_per_type_opponent_baseline_zero_sample` asserts both equal 0 without ZeroDivisionError |
+| 6 | Audit paragraph in SUMMARY.md cites file:line evidence for Section 2 wiring + Opp Skill derivation note | VERIFIED | `84-01-SUMMARY.md:84-105` — cites `MaterialRow.opponent_score` at `endgames.py:252-254`, `_compute_score_gap_material` at `endgame_service.py:851-870`, frontend `EndgameScoreGapSection.tsx:114-145`. Skill derivation note for Phase 86 present at lines 102-105 |
+| 7 | All existing endgame_service tests pass; new mirror-identity tests pass; ty and ruff green | VERIFIED | `pytest tests/test_endgame_service.py` 237 passed; full touched-files run 327 passed; `ty check app/ tests/` reports "All checks passed!"; `ruff check` and `ruff format --check` on modified files clean |
+
+**Score:** 7/7 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| -------- | -------- | ------ | ------- |
+| `app/schemas/endgames.py` | ConversionRecoveryStats with 4 new opponent_* fields appended after recovery_draws | VERIFIED | Fields present at lines 52-59 in exact specified order with `float \| None` / `int` types and per-field docstrings. Class docstring updated with Phase 84 paragraph at lines 31-36 |
+| `app/services/endgame_service.py` | _aggregate_endgame_stats wiring populates 4 fields via mirror identities + _MIN_OPPONENT_SAMPLE gating | VERIFIED | Mirror-identity block at lines 358-378; constructor kwargs at lines 391-394; `_MIN_OPPONENT_SAMPLE = 10` at line 234 reused (no parallel constant introduced); `_compute_score_gap_material` (Section 2 path) intact at lines 723+/851-870 |
+| `tests/test_endgame_service.py` | Unit tests for symmetric mirror, below-threshold None, at-threshold computed, zero-sample safety, schema shape | VERIFIED | Five new tests at lines 393-499 inside `TestAggregateEndgameStats`: `test_per_type_opponent_baseline_symmetric_60_40`, `_below_threshold`, `_at_threshold_10`, `_zero_sample`, `_schema_shape`. All 5 pass; class total 17 tests green |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| ---- | -- | --- | ------ | ------- |
+| `endgame_service.py:_aggregate_endgame_stats` | `endgames.py:ConversionRecoveryStats` | constructor kwargs | WIRED | `endgame_service.py:380-395` constructs `ConversionRecoveryStats(...)` passing all 4 new kwargs |
+| Phase 84 mirror block | `_MIN_OPPONENT_SAMPLE` (line 234) | threshold gate on mirror bucket size | WIRED | Both gates (lines 364, 372) reference `_MIN_OPPONENT_SAMPLE`; no parallel constant grep-confirmed (grep `PER_CLASS_OPPONENT_SAMPLE_MIN` returns 0 matches) |
+| Backend payload | `/api/endgames/overview` | `EndgameCategoryStats.conversion: ConversionRecoveryStats` → `EndgameStatsResponse` / `EndgameOverviewResponse` | WIRED | `endgames.py:78` embeds `ConversionRecoveryStats` in `EndgameCategoryStats.conversion`; reaches `/api/endgames/overview` via `EndgameOverviewResponse` (used by `_aggregate_endgame_stats` call at `endgame_service.py:2121`) |
+
+### Data-Flow Trace (Level 4)
+
+| Artifact | Data Variable | Source | Produces Real Data | Status |
+| -------- | ------------- | ------ | ------------------ | ------ |
+| `ConversionRecoveryStats.opponent_*` | `opponent_conversion_pct`, `opponent_recovery_pct` | Computed inline from `conv_data` / `recov_data` accumulators at `endgame_service.py:340-378`; populated by `wdl`/`conv`/`recov` Counters fed from `_aggregate_endgame_stats(rows)` input which originates from the existing endgame DB rows | FLOWING | Tests use real `_aggregate_endgame_stats(rows)` calls with synthetic rows and observe correct percentages (60.0 / 40.0) — confirms data flows through the accumulator → arithmetic → schema chain |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| -------- | ------- | ------ | ------ |
+| Schema introspection: 4 new fields present and required | `python -c "from app.schemas.endgames import ConversionRecoveryStats; f = ConversionRecoveryStats.model_fields; print(all(n in f and f[n].is_required() for n in ('opponent_conversion_pct','opponent_conversion_games','opponent_recovery_pct','opponent_recovery_games')))"` (via test_per_type_opponent_baseline_schema_shape) | passed | PASS |
+| Mirror identity 60/40 produces documented values | `pytest tests/test_endgame_service.py::TestAggregateEndgameStats::test_per_type_opponent_baseline_symmetric_60_40` | passed | PASS |
+| Below-threshold gating returns None | `pytest tests/test_endgame_service.py -k "below_threshold"` | passed | PASS |
+| At-threshold (=10) computes non-None | `pytest tests/test_endgame_service.py -k "at_threshold"` | passed | PASS |
+| Zero-sample safety (no ZeroDivisionError) | `pytest tests/test_endgame_service.py -k "zero_sample"` | passed | PASS |
+| Full TestAggregateEndgameStats green | `pytest tests/test_endgame_service.py::TestAggregateEndgameStats -x` | 17 passed | PASS |
+| Touched-files regression | `pytest tests/test_endgame_service.py tests/services/test_insights_llm.py tests/services/test_insights_service_series.py` | 327 passed | PASS |
+| ty check zero errors | `uv run ty check app/ tests/` | All checks passed! | PASS |
+| ruff lint clean (modified files) | `uv run ruff check app/schemas/endgames.py app/services/endgame_service.py tests/test_endgame_service.py ...` | All checks passed! | PASS |
+| ruff format check (modified files) | `uv run ruff format --check ...` | 5 files already formatted | PASS |
+
+### Probe Execution
+
+No project-conventional `scripts/*/tests/probe-*.sh` declared in PLAN or SUMMARY. The phase's verification contract is the `pytest` + `ty` + `ruff` block in PLAN `<verification>`, which is fully covered above as behavioral spot-checks.
+
+SKIPPED (no probes declared).
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+| ----------- | ----------- | ----------- | ------ | -------- |
+| DATA-02 | 84-01 | Mirror-bucket peer rates exposed on `/api/endgames/overview` for Section 2 (Conv/Parity/Recov + Skill components) and per-type Conv/Recov in Section 3 | SATISFIED | Section 2: audited as already wired via Phase 60 (`MaterialRow.opponent_score/games` at `endgames.py:252-254` + `_compute_score_gap_material` at `endgame_service.py:851-870` + frontend consumer at `EndgameScoreGapSection.tsx:114-145`). Section 3: shipped via 4 new fields on `ConversionRecoveryStats` populated by mirror identity (`endgame_service.py:358-394`). Skill derivation note documents Phase 86 client-side computation from existing `MaterialRow[conversion].opponent_score` + `MaterialRow[recovery].opponent_score` — no new payload field needed |
+
+No orphaned requirements: REQUIREMENTS.md line 110 maps `DATA-02 → Phase 84 → Pending`, and 84-01-PLAN.md's `requirements: [DATA-02]` claims it. SEC2-05, SEC3-03, DATA-01 were intentionally dropped on 2026-05-12 per the single-bullet doctrine pivot (`.planning/REQUIREMENTS.md:117`) — not orphaned.
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+| ---- | ---- | ------- | -------- | ------ |
+| `app/services/endgame_service.py` | 968 | `TODO (Phase 56): deduplicate with the backend endgame_skill() port` | Info | Pre-existing, unrelated to Phase 84 changes (modifications are at lines 358-394 and 380-395 only). Not introduced by this phase. References Phase 56 follow-up. Not a blocker for this phase. |
+
+No new debt markers added by Phase 84. `git diff` over the phase commits shows no `+` lines containing `TODO`, `FIXME`, `XXX`, `HACK`, or `PLACEHOLDER`.
+
+### Out-of-Scope Files Check
+
+Per PLAN `<verification>` block: `app/services/endgame_zones.py`, `scripts/gen_endgame_zones_ts.py`, `frontend/src/generated/endgameZones.ts`, `tests/services/test_endgame_zones.py` must be UNCHANGED. `git diff --name-only HEAD~5 HEAD | grep -E "(endgame_zones\.py|gen_endgame_zones_ts\.py|endgameZones\.ts|test_endgame_zones\.py)"` returns empty — confirmed clean.
+
+### Human Verification Required
+
+None. The phase deliverable is a backend schema extension + an audit prose paragraph. Both are fully verifiable through code introspection and the test suite (which exercises the mirror identities with deterministic inputs against documented expected outputs). No UI/UX, no real-time behavior, no external service — Phase 86 and Phase 87 are the consumers and will surface UI bugs in their own verifications.
+
+### Gaps Summary
+
+None. All seven must-have truths verified; all three artifacts present and substantive; all three key links wired; data flows correctly through the accumulator → arithmetic → schema chain; behavioral spot-checks all pass; DATA-02 satisfied through the documented audit + minimal backend extension; no out-of-scope files touched; no debt markers introduced.
+
+The phase pivoted scope mid-flight (per the planning notes the audit revealed Section 3 was NOT already wired and a minimal extension was required) — the success criterion explicitly permits this via its "OR a minimal backend extension is shipped" clause. The shipped extension follows the established Phase 60 mirror-identity pattern, with the documented asymmetry (Conv = win-rate, Recov = save-rate) correctly preserved in both code and tests.
+
+---
+
+_Verified: 2026-05-13T10:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/app/schemas/endgames.py
+++ b/app/schemas/endgames.py
@@ -27,6 +27,13 @@ class ConversionRecoveryStats(BaseModel):
     Conversion: win rate when user entered this endgame type with eval advantage.
     Recovery: draw+win rate when user entered this endgame type with eval deficit.
     Both are computed per endgame type (D-11), not per game phase.
+
+    Phase 84: opponent baselines via same-game mirror identity, scoped per
+    endgame class. opponent_conversion = opponent's win rate when opponent
+    entered with eval advantage (derived from user_recovery_*);
+    opponent_recovery = opponent's save rate when opponent entered with eval
+    deficit (derived from user_conversion_*). Gated on _MIN_OPPONENT_SAMPLE
+    against the mirror bucket size.
     """
 
     conversion_pct: float  # win rate when user entered with eval >= +1.0 (0-100), per D-08
@@ -40,6 +47,16 @@ class ConversionRecoveryStats(BaseModel):
     recovery_saves: int  # draws+wins among those games (kept for backward compat)
     recovery_wins: int  # wins among those games
     recovery_draws: int  # draws among those games
+
+    # Phase 84: per-class opponent baselines via same-game mirror identity.
+    opponent_conversion_pct: float | None
+    """None when recovery_games < _MIN_OPPONENT_SAMPLE; else opponent's win-rate when opponent entered with eval advantage (Phase 84, mirror identity)."""
+    opponent_conversion_games: int
+    """== recovery_games (mirror sample size, always int, possibly 0)."""
+    opponent_recovery_pct: float | None
+    """None when conversion_games < _MIN_OPPONENT_SAMPLE; else opponent's save-rate when opponent entered with eval deficit."""
+    opponent_recovery_games: int
+    """== conversion_games (mirror sample size, always int, possibly 0)."""
 
 
 class EndgameCategoryStats(BaseModel):

--- a/app/services/endgame_service.py
+++ b/app/services/endgame_service.py
@@ -227,6 +227,7 @@ def _classify_endgame_bucket(
         return "recovery"
     return "parity"
 
+
 # Phase 60: minimum opponent sample size required to display the opponent
 # baseline in the Conversion/Even/Recovery bullet chart. Matches the WDL-bar
 # mute threshold used elsewhere (e.g. Opening Explorer moves list).
@@ -354,6 +355,28 @@ def _aggregate_endgame_stats(
             round(recovery_saves / recovery_games * 100, 1) if recovery_games > 0 else 0.0
         )
 
+        # Phase 84: per-class opponent baseline via same-game mirror identity.
+        # Conv is a win-rate, Recov is a save-rate, so the two mirror formulas
+        # are asymmetric. Reuses _MIN_OPPONENT_SAMPLE (line 233), gated on the
+        # MIRROR bucket size (not the own bucket). Phase 60 introduced the
+        # pattern for Section 2 at _compute_score_gap_material (~line 824).
+        opponent_conversion_pct: float | None
+        if recovery_games >= _MIN_OPPONENT_SAMPLE:
+            recovery_losses = recovery_games - recovery_wins - recovery_draws
+            opponent_conversion_pct = round(recovery_losses / recovery_games * 100, 1)
+        else:
+            opponent_conversion_pct = None
+        opponent_conversion_games = recovery_games
+
+        opponent_recovery_pct: float | None
+        if conversion_games >= _MIN_OPPONENT_SAMPLE:
+            opponent_recovery_pct = round(
+                (conversion_losses + conversion_draws) / conversion_games * 100, 1
+            )
+        else:
+            opponent_recovery_pct = None
+        opponent_recovery_games = conversion_games
+
         conversion_stats = ConversionRecoveryStats(
             conversion_pct=conversion_pct,
             conversion_games=conversion_games,
@@ -365,6 +388,10 @@ def _aggregate_endgame_stats(
             recovery_saves=recovery_saves,
             recovery_wins=recovery_wins,
             recovery_draws=recovery_draws,
+            opponent_conversion_pct=opponent_conversion_pct,
+            opponent_conversion_games=opponent_conversion_games,
+            opponent_recovery_pct=opponent_recovery_pct,
+            opponent_recovery_games=opponent_recovery_games,
         )
 
         # _ENDGAME_CATEGORY_LABELS is exhaustive for all EndgameClass values — direct lookup.
@@ -1730,9 +1757,7 @@ def _get_endgame_performance_from_rows(
     _conf_s, p_score_raw, _se = compute_confidence_bucket(
         endgame_wdl.wins, endgame_wdl.draws, endgame_wdl.losses, endgame_wdl.total
     )
-    endgame_score_p_value: float | None = (
-        p_score_raw if endgame_wdl.total >= 10 else None
-    )
+    endgame_score_p_value: float | None = p_score_raw if endgame_wdl.total >= 10 else None
 
     # Phase 83 Plan 2 (D-04..D-07, D-21): Stockfish-baseline expected score
     # sibling aggregator over the same bucket_rows cursor. Per-game expected
@@ -1762,13 +1787,9 @@ def _get_endgame_performance_from_rows(
     entry_expected_score = ex_sum / ex_n if ex_n > 0 else 0.0
     # Wilson sig test vs 50% via the (score, n) sibling helper. Single Wilson
     # code path with compute_confidence_bucket (memory feedback_wilson_chess_score.md).
-    _conf_x, p_ex_raw, _se_ex = compute_score_confidence_from_mean(
-        entry_expected_score, ex_n
-    )
+    _conf_x, p_ex_raw, _se_ex = compute_score_confidence_from_mean(entry_expected_score, ex_n)
     # Same n >= 10 wire-format gate as entry_eval_p_value / endgame_score_p_value.
-    entry_expected_score_p_value: float | None = (
-        p_ex_raw if ex_n >= 10 else None
-    )
+    entry_expected_score_p_value: float | None = p_ex_raw if ex_n >= 10 else None
     entry_expected_score_ci_low: float | None
     entry_expected_score_ci_high: float | None
     if ex_n >= 2:

--- a/frontend/src/components/insights/EvalConfidenceTooltip.tsx
+++ b/frontend/src/components/insights/EvalConfidenceTooltip.tsx
@@ -68,7 +68,8 @@ export function EvalConfidenceTooltip({
   return (
     <div className="text-left space-y-1">
       <p>
-        <strong>{fmtSigned(evalMeanPawns)} pawns</strong> over {gameCount} games (average Stockfish eval at the end of this opening).
+        <strong>{fmtSigned(evalMeanPawns)} pawns</strong> over {gameCount} games (average Stockfish eval at the
+        end of your openings which include this position).
       </p>
       <p>
         <strong>{headline(level, evalMeanPawns)}</strong> {CONFIDENCE_LABEL[level]} confidence

--- a/tests/services/test_insights_llm.py
+++ b/tests/services/test_insights_llm.py
@@ -315,9 +315,7 @@ class TestPromptVersionAndBody:
         """Phase 82 (D-23): new ### Subsection: endgame_start_vs_end block is present."""
         from pathlib import Path
 
-        body_path = (
-            Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
-        )
+        body_path = Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
         with open(body_path) as f:
             body = f.read()
         assert "### Subsection: endgame_start_vs_end" in body
@@ -328,9 +326,7 @@ class TestPromptVersionAndBody:
         """Phase 82 (D-22): entry_eval_pawns glossary entry is present."""
         from pathlib import Path
 
-        body_path = (
-            Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
-        )
+        body_path = Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
         with open(body_path) as f:
             body = f.read()
         # Entry must appear under the glossary header as a bold heading
@@ -340,9 +336,7 @@ class TestPromptVersionAndBody:
         """Phase 82 (D-22): glossary entries renamed to _timeline variants."""
         from pathlib import Path
 
-        body_path = (
-            Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
-        )
+        body_path = Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
         with open(body_path) as f:
             body = f.read()
         assert "**endgame_score_timeline**" in body
@@ -352,15 +346,17 @@ class TestPromptVersionAndBody:
         """Phase 82 (D-24): endgame_start_vs_end row present in mapping table under overall."""
         from pathlib import Path
 
-        body_path = (
-            Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
-        )
+        body_path = Path(__file__).resolve().parents[2] / "app" / "prompts" / "endgame_insights.md"
         with open(body_path) as f:
             body = f.read()
         found = False
         for line in body.splitlines():
             stripped = line.strip()
-            if stripped.startswith("| endgame_start_vs_end") and stripped.endswith("|") and "overall" in stripped:
+            if (
+                stripped.startswith("| endgame_start_vs_end")
+                and stripped.endswith("|")
+                and "overall" in stripped
+            ):
                 found = True
                 break
         assert found, "missing `| endgame_start_vs_end ... | overall |` row in mapping table"
@@ -1061,17 +1057,29 @@ class TestPromptAssembly:
         def _conv(
             conv_pct: float, recov_pct: float, n_conv: int = 40, n_recov: int = 20
         ) -> ConversionRecoveryStats:
+            conv_wins = int(n_conv * conv_pct / 100)
+            conv_losses = n_conv - conv_wins
+            recov_wins = int(n_recov * recov_pct / 100 * 0.6)
+            recov_draws = int(n_recov * recov_pct / 100 * 0.4)
+            recov_losses = n_recov - recov_wins - recov_draws
+            # Phase 84 mirror-identity opponent baselines (gated on mirror bucket >= 10).
+            opp_conv = round(recov_losses / n_recov * 100, 1) if n_recov >= 10 else None
+            opp_recov = round((conv_losses + 0) / n_conv * 100, 1) if n_conv >= 10 else None
             return ConversionRecoveryStats(
                 conversion_pct=conv_pct,
                 conversion_games=n_conv,
-                conversion_wins=int(n_conv * conv_pct / 100),
+                conversion_wins=conv_wins,
                 conversion_draws=0,
-                conversion_losses=n_conv - int(n_conv * conv_pct / 100),
+                conversion_losses=conv_losses,
                 recovery_pct=recov_pct,
                 recovery_games=n_recov,
                 recovery_saves=int(n_recov * recov_pct / 100),
-                recovery_wins=int(n_recov * recov_pct / 100 * 0.6),
-                recovery_draws=int(n_recov * recov_pct / 100 * 0.4),
+                recovery_wins=recov_wins,
+                recovery_draws=recov_draws,
+                opponent_conversion_pct=opp_conv,
+                opponent_conversion_games=n_recov,
+                opponent_recovery_pct=opp_recov,
+                opponent_recovery_games=n_conv,
             )
 
         categories = [
@@ -1196,6 +1204,11 @@ class TestPromptAssembly:
             recovery_saves=6,
             recovery_wins=4,
             recovery_draws=2,
+            # Phase 84 mirror-identity opponent baselines.
+            opponent_conversion_pct=70.0,  # recovery_losses(14)/recovery_games(20)*100
+            opponent_conversion_games=20,
+            opponent_recovery_pct=33.3,  # (conversion_losses(10)+conversion_draws(0))/conversion_games(30)*100
+            opponent_recovery_games=30,
         )
         # Pawnless: zero sequences — kept for test intent (filtered anyway by the
         # pawnless endgame_class guard).
@@ -2065,8 +2078,7 @@ class TestSparseHistoryFixes:
         today = datetime.date.today()
         # All all_time points fall inside the last 90 days → C2 trims to empty.
         recent_buckets = [
-            (today - datetime.timedelta(days=days)).isoformat()
-            for days in (60, 45, 30, 15)
+            (today - datetime.timedelta(days=days)).isoformat() for days in (60, 45, 30, 15)
         ]
         all_time_finding = SubsectionFinding(
             subsection_id="score_timeline",
@@ -2081,9 +2093,7 @@ class TestSparseHistoryFixes:
             sample_quality="adequate",
             is_headline_eligible=False,
             dimension=None,
-            series=[
-                TimePoint(bucket_start=bs, value=0.55, n=10) for bs in recent_buckets
-            ],
+            series=[TimePoint(bucket_start=bs, value=0.55, n=10) for bs in recent_buckets],
         )
         last_3mo_finding = SubsectionFinding(
             subsection_id="score_timeline",
@@ -2098,9 +2108,7 @@ class TestSparseHistoryFixes:
             sample_quality="adequate",
             is_headline_eligible=False,
             dimension=None,
-            series=[
-                TimePoint(bucket_start=bs, value=0.55, n=10) for bs in recent_buckets
-            ],
+            series=[TimePoint(bucket_start=bs, value=0.55, n=10) for bs in recent_buckets],
         )
         tab = _fake_findings(filters, findings=[all_time_finding, last_3mo_finding])
         prompt = _assemble_user_prompt(tab)
@@ -2156,9 +2164,7 @@ class TestSparseHistoryFixes:
         assert "[anchor-combo platform=" not in prompt
         # all_time line must carry `quality=sparse` and MUST NOT carry trend / std.
         lines = prompt.splitlines()
-        bullet_idx = lines.index(
-            "[summary actual_elo | platform=chess.com, time_control=bullet]"
-        )
+        bullet_idx = lines.index("[summary actual_elo | platform=chess.com, time_control=bullet]")
         at_line = lines[bullet_idx + 1]
         lm_line = lines[bullet_idx + 2]
         assert "quality=sparse" in at_line

--- a/tests/services/test_insights_service_series.py
+++ b/tests/services/test_insights_service_series.py
@@ -401,6 +401,11 @@ def _make_conv_stats() -> ConversionRecoveryStats:
         recovery_saves=8,
         recovery_wins=5,
         recovery_draws=3,
+        # Phase 84 fields — not exercised by these series tests; mirror identity values.
+        opponent_conversion_pct=60.0,  # recovery_losses(12)/recovery_games(20)*100
+        opponent_conversion_games=20,
+        opponent_recovery_pct=40.0,  # (conversion_losses(6)+conversion_draws(2))/conversion_games(20)*100
+        opponent_recovery_games=20,
     )
 
 

--- a/tests/test_endgame_service.py
+++ b/tests/test_endgame_service.py
@@ -133,19 +133,29 @@ class TestClassifyEndgameBucket:
 
     def test_white_positive_cp_above_threshold_is_conversion(self):
         """White user with eval_cp=150 (above +100 threshold) is conversion."""
-        assert _classify_endgame_bucket(eval_cp=150, eval_mate=None, user_color="white") == "conversion"
+        assert (
+            _classify_endgame_bucket(eval_cp=150, eval_mate=None, user_color="white")
+            == "conversion"
+        )
 
     def test_black_user_with_white_negative_cp_is_conversion(self):
         """Black user with white-perspective eval_cp=-300 (black is +300) is conversion."""
-        assert _classify_endgame_bucket(eval_cp=-300, eval_mate=None, user_color="black") == "conversion"
+        assert (
+            _classify_endgame_bucket(eval_cp=-300, eval_mate=None, user_color="black")
+            == "conversion"
+        )
 
     def test_user_mate_for_white_is_conversion(self):
         """White user with eval_mate=3 (white mates in 3) is conversion."""
-        assert _classify_endgame_bucket(eval_cp=None, eval_mate=3, user_color="white") == "conversion"
+        assert (
+            _classify_endgame_bucket(eval_cp=None, eval_mate=3, user_color="white") == "conversion"
+        )
 
     def test_user_being_mated_is_recovery(self):
         """White user with eval_mate=-3 (white is being mated) is recovery."""
-        assert _classify_endgame_bucket(eval_cp=None, eval_mate=-3, user_color="white") == "recovery"
+        assert (
+            _classify_endgame_bucket(eval_cp=None, eval_mate=-3, user_color="white") == "recovery"
+        )
 
     def test_below_threshold_is_parity(self):
         """White user with eval_cp=50 (below +100 threshold) is parity."""
@@ -153,15 +163,22 @@ class TestClassifyEndgameBucket:
 
     def test_null_eval_is_parity(self):
         """NULL eval (engine error / not yet backfilled) defaults to parity."""
-        assert _classify_endgame_bucket(eval_cp=None, eval_mate=None, user_color="white") == "parity"
+        assert (
+            _classify_endgame_bucket(eval_cp=None, eval_mate=None, user_color="white") == "parity"
+        )
 
     def test_white_negative_cp_is_recovery(self):
         """White user with eval_cp=-200 (below -100 threshold) is recovery."""
-        assert _classify_endgame_bucket(eval_cp=-200, eval_mate=None, user_color="white") == "recovery"
+        assert (
+            _classify_endgame_bucket(eval_cp=-200, eval_mate=None, user_color="white") == "recovery"
+        )
 
     def test_threshold_boundary_inclusive_at_100(self):
         """eval_cp == +100 (exactly at threshold) is conversion (>= 100)."""
-        assert _classify_endgame_bucket(eval_cp=100, eval_mate=None, user_color="white") == "conversion"
+        assert (
+            _classify_endgame_bucket(eval_cp=100, eval_mate=None, user_color="white")
+            == "conversion"
+        )
 
     def test_threshold_boundary_exclusive_at_99(self):
         """eval_cp == +99 (just below threshold) is parity (< 100)."""
@@ -170,7 +187,9 @@ class TestClassifyEndgameBucket:
     def test_black_user_mate_for_black_is_conversion(self):
         """Black user with eval_mate=-2 (black mates in 2 from white POV) is conversion."""
         # eval_mate=-2 means white is being mated; from black's perspective this is a win
-        assert _classify_endgame_bucket(eval_cp=None, eval_mate=-2, user_color="black") == "conversion"
+        assert (
+            _classify_endgame_bucket(eval_cp=None, eval_mate=-2, user_color="black") == "conversion"
+        )
 
     def test_black_user_being_mated_is_recovery(self):
         """Black user with eval_mate=5 (white mates in 5 from white POV) is recovery."""
@@ -230,7 +249,14 @@ class TestAggregateEndgameStats:
         rows = [
             (1, 1, "1-0", "white", 500, None),  # rook, up 500cp, won → converted
             (2, 1, "0-1", "white", 350, None),  # rook, up 350cp, lost → failed conversion
-            (3, 1, "1/2-1/2", "white", 100, None),  # rook, up 100cp (threshold), draw → draw conversion
+            (
+                3,
+                1,
+                "1/2-1/2",
+                "white",
+                100,
+                None,
+            ),  # rook, up 100cp (threshold), draw → draw conversion
             (4, 1, "1-0", "white", -400, None),  # rook, down, won → not a conversion game
         ]
         result = _aggregate_endgame_stats(rows)
@@ -247,7 +273,14 @@ class TestAggregateEndgameStats:
         rows = [
             (1, 1, "1-0", "white", -400, None),  # rook, down 400cp, won → recovery win
             (2, 1, "1/2-1/2", "white", -500, None),  # rook, down 500cp, draw → recovery draw
-            (3, 1, "0-1", "white", -100, None),  # rook, down 100cp (threshold), lost → not recovered
+            (
+                3,
+                1,
+                "0-1",
+                "white",
+                -100,
+                None,
+            ),  # rook, down 100cp (threshold), lost → not recovered
         ]
         result = _aggregate_endgame_stats(rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -354,6 +387,116 @@ class TestAggregateEndgameStats:
         rook = next(c for c in result if c.endgame_class == "rook")
         assert rook.conversion.conversion_games == 0
         assert rook.conversion.recovery_games == 0
+
+    # --- Phase 84: per-type opponent baseline via same-game mirror identity ---
+
+    def test_per_type_opponent_baseline_symmetric_60_40(self):
+        """Rook conv 6W/0D/4L (60%) + recov 2W/2D/6L (40% save-rate).
+
+        Mirror identities:
+        - opp_conv == 60.0 == recov_losses(6) / recov_games(10) * 100
+        - opp_recov == 40.0 == (conv_losses(4) + conv_draws(0)) / conv_games(10) * 100
+        """
+        rows = []
+        game_id = 0
+        # 10 conversion rows (eval +150, white): 6 wins, 4 losses, 0 draws.
+        for _ in range(6):
+            game_id += 1
+            rows.append((game_id, 1, "1-0", "white", 150, None))
+        for _ in range(4):
+            game_id += 1
+            rows.append((game_id, 1, "0-1", "white", 150, None))
+        # 10 recovery rows (eval -150, white): 2 wins, 2 draws, 6 losses.
+        for _ in range(2):
+            game_id += 1
+            rows.append((game_id, 1, "1-0", "white", -150, None))
+        for _ in range(2):
+            game_id += 1
+            rows.append((game_id, 1, "1/2-1/2", "white", -150, None))
+        for _ in range(6):
+            game_id += 1
+            rows.append((game_id, 1, "0-1", "white", -150, None))
+
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        assert rook.conversion.conversion_games == 10
+        assert rook.conversion.recovery_games == 10
+        assert rook.conversion.opponent_conversion_pct == pytest.approx(60.0, abs=0.05)
+        assert rook.conversion.opponent_conversion_games == 10
+        assert rook.conversion.opponent_recovery_pct == pytest.approx(40.0, abs=0.05)
+        assert rook.conversion.opponent_recovery_games == 10
+
+    def test_per_type_opponent_baseline_below_threshold(self):
+        """Mirror bucket size below _MIN_OPPONENT_SAMPLE (10) returns None pct, raw games count."""
+        rows = []
+        game_id = 0
+        # 9 conversion rows (all losses).
+        for _ in range(9):
+            game_id += 1
+            rows.append((game_id, 1, "0-1", "white", 200, None))
+        # 9 recovery rows (all losses).
+        for _ in range(9):
+            game_id += 1
+            rows.append((game_id, 1, "0-1", "white", -200, None))
+
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        # opponent_conversion_pct gates on recovery_games (= 9 < 10) → None.
+        assert rook.conversion.opponent_conversion_pct is None
+        assert rook.conversion.opponent_conversion_games == 9
+        # opponent_recovery_pct gates on conversion_games (= 9 < 10) → None.
+        assert rook.conversion.opponent_recovery_pct is None
+        assert rook.conversion.opponent_recovery_games == 9
+
+    def test_per_type_opponent_baseline_at_threshold_10(self):
+        """Mirror bucket size at exactly 10 → pct is non-None (threshold boundary check)."""
+        rows = []
+        game_id = 0
+        for _ in range(10):
+            game_id += 1
+            rows.append((game_id, 1, "1-0", "white", 200, None))
+        for _ in range(10):
+            game_id += 1
+            rows.append((game_id, 1, "0-1", "white", -200, None))
+
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        assert rook.conversion.opponent_conversion_pct is not None
+        assert rook.conversion.opponent_conversion_games == 10
+        assert rook.conversion.opponent_recovery_pct is not None
+        assert rook.conversion.opponent_recovery_games == 10
+
+    def test_per_type_opponent_baseline_zero_sample(self):
+        """Zero-sample mirror buckets emit None pct + 0 games and raise no ZeroDivisionError."""
+        # Parity-only rows: eval in (-100, +100) → neither conversion nor recovery bucket.
+        rows = [
+            (1, 1, "1-0", "white", 0, None),
+            (2, 1, "0-1", "white", 50, None),
+            (3, 1, "1/2-1/2", "white", -50, None),
+        ]
+        # Must not raise.
+        result = _aggregate_endgame_stats(rows)
+        rook = next(c for c in result if c.endgame_class == "rook")
+        assert rook.conversion.conversion_games == 0
+        assert rook.conversion.recovery_games == 0
+        assert rook.conversion.opponent_conversion_pct is None
+        assert rook.conversion.opponent_recovery_pct is None
+        assert rook.conversion.opponent_conversion_games == 0
+        assert rook.conversion.opponent_recovery_games == 0
+
+    def test_per_type_opponent_baseline_schema_shape(self):
+        """ConversionRecoveryStats exposes the four new fields as REQUIRED."""
+        from app.schemas.endgames import ConversionRecoveryStats
+
+        fields = ConversionRecoveryStats.model_fields
+        for name in (
+            "opponent_conversion_pct",
+            "opponent_conversion_games",
+            "opponent_recovery_pct",
+            "opponent_recovery_games",
+        ):
+            assert name in fields, f"missing field: {name}"
+            assert fields[name].is_required(), f"field {name} must be required"
 
 
 class TestGetEndgameStatsSmoke:
@@ -2694,9 +2837,9 @@ class TestComputeScoreGapTimeline:
         assert series[1].non_endgame_score == pytest.approx(0.5)
         # Identity invariant: score_difference == endgame_score - non_endgame_score
         for point in series:
-            assert abs(
-                (point.endgame_score - point.non_endgame_score) - point.score_difference
-            ) < 1e-9
+            assert (
+                abs((point.endgame_score - point.non_endgame_score) - point.score_difference) < 1e-9
+            )
 
     def test_rolling_window_caps_at_window_size(self):
         """window=10: week 2's diff reflects only week-2 games per side."""
@@ -2943,8 +3086,8 @@ class TestEndgameSkillFromBucketRows:
                 "white",
                 1500,
                 1500,
-                0,      # eval_cp = 0 (parity)
-                None,   # eval_mate
+                0,  # eval_cp = 0 (parity)
+                None,  # eval_mate
                 "1-0",
             ),
             _elo_bucket_row(
@@ -2994,8 +3137,8 @@ class TestEndgameSkillFromBucketRows:
                 "white",
                 1500,
                 1500,
-                200,    # eval_cp = +200 (conversion)
-                None,   # eval_mate
+                200,  # eval_cp = +200 (conversion)
+                None,  # eval_mate
                 "1-0",
             ),
             _elo_bucket_row(
@@ -3066,7 +3209,7 @@ class TestEndgameSkillFromBucketRows:
                 "white",
                 1500,
                 1500,
-                200,    # eval_cp = +200 (conversion)
+                200,  # eval_cp = +200 (conversion)
                 None,
                 "1-0",
             ),
@@ -3088,7 +3231,7 @@ class TestEndgameSkillFromBucketRows:
                 "white",
                 1500,
                 1500,
-                0,      # eval_cp = 0 (parity)
+                0,  # eval_cp = 0 (parity)
                 None,
                 "1-0",
             ),
@@ -3910,9 +4053,7 @@ class TestEntryEvalAggregation:
 
     def test_sign_flip_for_black_users(self) -> None:
         """Black user with raw eval_cp=200 -> mean_pawns=-2.0 (user-perspective sign flip)."""
-        bucket_rows = [
-            self._bucket(game_id=i, user_color="black", eval_cp=200) for i in range(10)
-        ]
+        bucket_rows = [self._bucket(game_id=i, user_color="black", eval_cp=200) for i in range(10)]
         resp = _get_endgame_performance_from_rows(
             endgame_rows=self._wdl_rows(wins=10, draws=0, losses=0),
             non_endgame_rows=[],
@@ -4045,9 +4186,7 @@ class TestEntryExpectedScore(TestEntryEvalAggregation):
     def test_entry_expected_score_sign_flip_black(self) -> None:
         """10 rows at eval_cp=+200 with user_color=black -> sigmoid sign-flip ->
         expected score < 0.5 (specifically the (1 - white-perspective) mirror)."""
-        bucket_rows = [
-            self._bucket(game_id=i, user_color="black", eval_cp=200) for i in range(10)
-        ]
+        bucket_rows = [self._bucket(game_id=i, user_color="black", eval_cp=200) for i in range(10)]
         resp = _get_endgame_performance_from_rows(
             endgame_rows=self._wdl_rows(wins=10, draws=0, losses=0),
             non_endgame_rows=[],
@@ -4068,9 +4207,7 @@ class TestEntryExpectedScore(TestEntryEvalAggregation):
           entry_expected_score = (10 * 0.5 + 1.0) / 11 ~ 0.5454
         """
         bucket_rows = [self._bucket(game_id=i, eval_cp=0) for i in range(10)]
-        bucket_rows.append(
-            self._bucket(game_id=11, eval_cp=None, eval_mate=5, user_color="white")
-        )
+        bucket_rows.append(self._bucket(game_id=11, eval_cp=None, eval_mate=5, user_color="white"))
         resp = _get_endgame_performance_from_rows(
             endgame_rows=self._wdl_rows(wins=10, draws=0, losses=0),
             non_endgame_rows=[],
@@ -4085,11 +4222,7 @@ class TestEntryExpectedScore(TestEntryEvalAggregation):
     def test_entry_expected_score_mate_against_user_is_zero(self) -> None:
         """Mate-against-user (eval_mate=-5 for white-user) contributes 0.0."""
         # Single mate-against-user row -> score = 0.0
-        bucket_rows = [
-            self._bucket(
-                game_id=1, eval_cp=None, eval_mate=-5, user_color="white"
-            )
-        ]
+        bucket_rows = [self._bucket(game_id=1, eval_cp=None, eval_mate=-5, user_color="white")]
         resp = _get_endgame_performance_from_rows(
             endgame_rows=self._wdl_rows(wins=0, draws=0, losses=1),
             non_endgame_rows=[],
@@ -4146,12 +4279,8 @@ class TestEntryExpectedScore(TestEntryEvalAggregation):
         assert resp_ok.entry_expected_score_ci_high is not None
         assert 0.0 <= resp_ok.entry_expected_score_ci_low <= 1.0
         assert 0.0 <= resp_ok.entry_expected_score_ci_high <= 1.0
-        assert (
-            resp_ok.entry_expected_score_ci_low <= resp_ok.entry_expected_score
-        )
-        assert (
-            resp_ok.entry_expected_score_ci_high >= resp_ok.entry_expected_score
-        )
+        assert resp_ok.entry_expected_score_ci_low <= resp_ok.entry_expected_score
+        assert resp_ok.entry_expected_score_ci_high >= resp_ok.entry_expected_score
 
         # n=1 -> CI bounds are None (Wilson bounds defensive guard returns
         # (0, 1) which is not meaningful for narration)


### PR DESCRIPTION
## Summary

**Phase 84: Data plumbing — mirror-rate audit**
**Goal:** Audit that mirror-bucket peer rates (`opponent_score` / `opponent_games`) are already exposed on `/api/endgames/overview` for Section 2 (Conv/Parity/Recov + Skill components) and Section 3 (per-type Conv/Recov). Prerequisite for the peer bullets in Section 2 + 3.
**Status:** Verified ✓ (7/7 must-haves)

The phase pivoted during planning: Section 2 (`MaterialRow`) peer rates were already wired by Phase 60, but Section 3 (per-type `ConversionRecoveryStats`) was not. Plan 84-01 shipped the minimal backend extension via the same mirror-identity pattern, which the success criterion explicitly permits. The Section 2 audit is documented with file:line evidence; the Section 3 extension is implemented and tested. Phase 87 can now render per-type Conv/Recov peer bullets directly from the response payload.

## Changes

### Plan 84-01: Per-class Opponent Baselines via Mirror Identity

`ConversionRecoveryStats` now carries four new required fields populated by the same-game mirror identity in `_aggregate_endgame_stats`, gated on `_MIN_OPPONENT_SAMPLE` against the MIRROR bucket size:

- `opponent_conversion_pct: float | None` / `opponent_conversion_games: int` — opponent's win-rate when entering with eval advantage (mirror of recovery bucket).
- `opponent_recovery_pct: float | None` / `opponent_recovery_games: int` — opponent's save-rate when entering with eval deficit (mirror of conversion bucket).

Mirror formulas are asymmetric (Conv = win-rate, Recov = save-rate). No new accumulator, constant, DB query, or helper introduced. The `>= 10` threshold gate is strictly tighter than `> 0`, so no separate divide-by-zero guard is needed.

**Key files:**
- `app/schemas/endgames.py` — 4 new required fields on `ConversionRecoveryStats`
- `app/services/endgame_service.py` — mirror-identity block in `_aggregate_endgame_stats`
- `tests/test_endgame_service.py` — 5 new tests (symmetric mirror, below-threshold, at-threshold, zero-sample, schema shape)
- `tests/services/test_insights_llm.py`, `tests/services/test_insights_service_series.py` — fixture updates for the new required kwargs

## Requirements Addressed

- **DATA-02** — Mirror-bucket peer rates exposed on `/api/endgames/overview` for Conv/Parity/Recov/Skill (Section 2 audit) and per-type Conv/Recov (Section 3 extension).

## Verification

- [x] Automated verification: passed (7/7 truths verified)
- [x] `pytest tests/test_endgame_service.py` — 237 passed
- [x] Full touched-files pytest run — 327 passed
- [x] `ty check app/ tests/` — All checks passed
- [x] `ruff check` and `ruff format --check` — clean on modified files

## Key Decisions

- **Reuse `_MIN_OPPONENT_SAMPLE`** rather than introduce a parallel `PER_CLASS_OPPONENT_SAMPLE_MIN`. Per-class baseline shares the Section 2 threshold.
- **Inline ~20 lines of arithmetic** in `_aggregate_endgame_stats` over extracting a helper. Nesting depth stays at 2 inside the existing per-class loop; extracting a helper would require threading two dicts or inventing a context dataclass (violates "don't invent context dataclasses to make signatures fit").
- **Audit prose inline in `84-01-SUMMARY.md`** (single-plan default), not a separate `.planning/notes/` entry.

## Pattern Established

Asymmetric mirror formulas: Conv uses `(recovery_games - recovery_wins - recovery_draws) / recovery_games`; Recov uses `(conversion_losses + conversion_draws) / conversion_games`. The gate is on the MIRROR bucket size, not the own bucket — the mirror bucket is what supplies the opponent's sample.

## Test plan

- [x] Backend unit tests pass (327 touched-files run)
- [x] Type checks pass (ty)
- [x] Lint/format clean (ruff)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)