### PR TITLE
docs(88.4): close out HUMAN-UAT (4/4 passed)

### DIFF
--- a/.planning/milestones/v1.17-ROADMAP.md
+++ b/.planning/milestones/v1.17-ROADMAP.md
@@ -426,7 +426,7 @@ Scope amendment (Phase 88.2, INSERTED 2026-05-17 after re-verification returned 
 
 **Out of scope:** Backend stats / new statistical methods / benchmark refresh (none — pure frontend reshape of already-computed values); the Clock Gap and Net flag rate bullet primitives themselves (only their surrounding layout changes); full 375px parity audit (deferred to Phase 89, though basic responsive correctness per SC-1 is in scope).
 
-**Plans:** 3/3 complete — completed 2026-05-19 (verification: passed, 3/3 must-haves; WR-01 text-xs fixed to text-sm per user; 3 in-browser UAT visual items pending in 88.4-HUMAN-UAT.md)
+**Plans:** 3/3 complete — completed 2026-05-19, shipped in PR #109 (verification: passed, 3/3 must-haves; UAT: 4/4 passed after in-browser polish rounds; WR-01 resolved — text-xs to match the sibling chart, documented inline)
 - [x] 88.4-01-PLAN.md — New ScoreGapByTimePressureChart component + Wave 0 test scaffold (SC-3 chart)
 - [x] 88.4-02-PLAN.md — EndgameTimePressureSection dynamic responsive grid (SC-1)
 - [x] 88.4-03-PLAN.md — EndgameTimePressureCard 3-stat header row + chart integration, knip-clean (SC-2, SC-3)

--- a/.planning/milestones/v1.17-phases/88.4-time-pressure-card-layout-refactor/88.4-HUMAN-UAT.md
+++ b/.planning/milestones/v1.17-phases/88.4-time-pressure-card-layout-refactor/88.4-HUMAN-UAT.md
@@ -1,40 +1,42 @@
 ---
-status: partial
+status: passed
 phase: 88.4-time-pressure-card-layout-refactor
 source: [88.4-VERIFICATION.md]
 started: 2026-05-18T22:33:38Z
-updated: 2026-05-18T22:33:38Z
+updated: 2026-05-19T03:00:00Z
 ---
 
 ## Current Test
 
-[awaiting human testing]
+[complete]
 
 ## Tests
 
 ### 1. Visual inspection — responsive card grid at multiple breakpoints
 expected: 1 card: half-width left-aligned; 2 cards: 2-column full-width; 3 cards: 3-column; 4 cards: 2x2 on md, 4x1 on xl. No horizontal scroll at any breakpoint.
-result: [pending]
+result: passed — confirmed in-browser during post-UAT polish; mobile single-column stacking added for the 1- and 2-card layouts. Shipped in PR #109.
 
 ### 2. SC-2 header row visual layout — 3-column You/Gap/Opp row above Clock Gap bullet
 expected: 'You: X% (Ns)' left-aligned; 'Gap: ±X% <info>' centered with the MetricStatPopover icon; 'Opp: X% (Ns)' right-aligned. Font-tinting applies to the Gap value when outside the neutral band AND n sufficient AND confident.
-result: [pending]
+result: passed — confirmed in-browser. Scope amendment per UAT: raw seconds dropped, cells now show 'You: X%' / 'Opp: X%' (the percentage of starting time carries the signal). Centered Gap + MetricStatPopover and triple-gate font-tinting unchanged. Shipped in PR #109.
 
 ### 3. SC-3 line chart visual — zone bands, CI whiskers, and hover tooltip
 expected: 4 ordinal x-axis datapoints (Q0–Q3); three zone bands (danger/neutral/success at ±0.06); CI whisker on each non-null-CI point; hover tooltip shows signed score gap %, opponent score %, and n.
-result: [pending]
+result: passed — confirmed in-browser across 5 polish rounds. As-shipped refinements: bucket-center x labels (10/30/50/70%), full-bleed zone bands, dynamic y-axis with equidistant 10% ticks, compact tooltip ("Time Bucket: 0-20%" header, You/Opp/Games line, app-standard verdict line, test + CI on separate italic lines). Shipped in PR #109.
 
 ### 4. WR-01: text-xs in chart tooltip — decision on whether to extend or fix
 expected: Either tooltip body is changed to text-sm (CLAUDE.md floor), OR the user explicitly accepts the Recharts chart tooltip exception and adds a CLAUDE.md amendment or inline comment so future reviewers do not re-flag.
-result: passed — user chose "Fix to text-sm"; ScoreGapByTimePressureChart.tsx:188 changed text-xs → text-sm (commit, 9/9 chart tests + tsc clean).
+result: passed — resolved twice. Initially fixed to text-sm; later, per explicit user direction during polish, returned to text-xs to match the sibling "Average Clock Gap over Time" tooltip, with an inline comment documenting the deliberate exception (same rationale as the CLAUDE.md popover-layer exception) so reviewers do not re-flag.
 
 ## Summary
 
 total: 4
-passed: 1
+passed: 4
 issues: 0
-pending: 3
+pending: 0
 skipped: 0
 blocked: 0
 
 ## Gaps
+
+None — all four UAT items confirmed in-browser during the post-UAT polish rounds; shipped in PR #109 (squash commit e0e149d5).


### PR DESCRIPTION
Post-ship bookkeeping for Phase 88.4 (already merged via PR #109).

All four `88.4-HUMAN-UAT.md` items were confirmed in-browser during the five post-UAT polish rounds and shipped in PR #109:

1. Responsive card grid (+ mobile single-column stacking)
2. SC-2 header row (seconds dropped per UAT scope amendment)
3. SC-3 line chart + tooltip (5 rounds of refinement)
4. WR-01 — resolved (text-xs to match the sibling Average Clock Gap tooltip, documented inline)

Changes: `status: partial → passed`, all results filled in, summary `4/4 passed`; milestone ROADMAP line drops the stale "3 items pending" note. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)