### PR TITLE
fix(88.4): reword Time Pressure title + taller Score Gap chart

### DIFF
--- a/frontend/src/components/charts/EndgameTimePressureSection.tsx
+++ b/frontend/src/components/charts/EndgameTimePressureSection.tsx
@@ -9,7 +9,7 @@
  *
  * Replaces the legacy line-chart EndgameTimePressureSection and the
  * EndgameClockPressureSection (both deleted in Phase 88 Plan 07).
- * Answers: "How does your score change as your clock runs down?"
+ * Answers: "How does your score change under time pressure?"
  */
 
 import { EndgameTimePressureCard } from '@/components/charts/EndgameTimePressureCard';
@@ -34,7 +34,7 @@ export function EndgameTimePressureSection({
       aria-label="Time pressure analysis"
     >
       <p className="text-sm text-muted-foreground">
-        How does your score change as your clock runs down?
+        How does your score change under time pressure?
       </p>
       {data.cards.length === 0 ? (
         <div

--- a/frontend/src/components/charts/ScoreGapByTimePressureChart.tsx
+++ b/frontend/src/components/charts/ScoreGapByTimePressureChart.tsx
@@ -251,7 +251,7 @@ export function ScoreGapByTimePressureChart({
     >
       <ChartContainer
         config={{}}
-        className="w-full h-56"
+        className="w-full h-64"
         data-testid="score-gap-by-time-pressure-chart-container"
       >
         <ComposedChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 24 }}>


### PR DESCRIPTION
Small UI follow-ups to the shipped Phase 88.4 Time Pressure section.

- Section title: "How does your score change as your clock runs down?" → **"How does your score change under time pressure?"** (docstring updated to match).
- Score Gap by Remaining Time chart a bit taller: `h-56` → `h-64`.

576/576 frontend tests pass; tsc / eslint / knip clean. UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)