### PR TITLE
fix: rename 'Average Clock Gap over Time' → 'Clock Gap at Endgame Entry'

### DIFF
--- a/frontend/src/components/charts/EndgameClockDiffOverTimeChart.tsx
+++ b/frontend/src/components/charts/EndgameClockDiffOverTimeChart.tsx
@@ -142,14 +142,14 @@ export function EndgameClockDiffOverTimeChart({
       <div className="mb-3">
         <h3 className="text-base font-semibold">
           <span className="inline-flex items-center gap-1">
-            Average Clock Gap over Time
+            Clock Gap at Endgame Entry
             <InfoPopover
-              ariaLabel="Average clock gap over time info"
+              ariaLabel="Clock gap at endgame entry info"
               testId="clock-diff-over-time-info"
               side="top"
             >
               <p>
-                <strong>Average Clock Gap over Time:</strong> whether you
+                <strong>Clock Gap at Endgame Entry:</strong> whether you
                 tend to enter endgames with more or less time on your clock
                 than your opponent, tracked over time. Positive means you
                 arrived with more time left.

--- a/frontend/src/components/charts/ScoreGapByTimePressureChart.tsx
+++ b/frontend/src/components/charts/ScoreGapByTimePressureChart.tsx
@@ -193,7 +193,8 @@ function toChartData(quintiles: PressureQuintileBullet[]): ChartPoint[] {
  * the old per-bucket info icons render below.
  *
  * Font-size note: this Recharts hover tooltip deliberately uses `text-xs` to
- * match the sibling "Average Clock Gap over Time" (EndgameClockDiffOverTimeChart)
+ * match the sibling "Clock Gap at Endgame Entry"
+ * (EndgameClockDiffOverTimeChart)
  * tooltip — a compact, transient, opt-in hover surface, the same rationale as
  * the CLAUDE.md popover-layer exception. User-directed (post-UAT 88.4),
  * superseding the earlier WR-01 text-sm bump; do not re-flag.

--- a/frontend/src/components/charts/__tests__/EndgameClockDiffOverTimeChart.test.tsx
+++ b/frontend/src/components/charts/__tests__/EndgameClockDiffOverTimeChart.test.tsx
@@ -86,7 +86,7 @@ describe('EndgameClockDiffOverTimeChart', () => {
   it('renders the chart container and title for non-empty timeline', () => {
     render(<EndgameClockDiffOverTimeChart timeline={THREE_POINT_FIXTURE} />);
     expect(screen.getByTestId('clock-diff-over-time-chart')).toBeTruthy();
-    expect(screen.getByText('Average Clock Gap over Time')).toBeTruthy();
+    expect(screen.getByText('Clock Gap at Endgame Entry')).toBeTruthy();
   });
 
   it('renders one bar rectangle per timeline entry', () => {
@@ -118,7 +118,7 @@ describe('EndgameClockDiffOverTimeChart', () => {
     render(<EndgameClockDiffOverTimeChart timeline={THREE_POINT_FIXTURE} />);
     // The trigger is button-shaped and reachable by aria-label.
     expect(
-      screen.getByLabelText('Average clock gap over time info'),
+      screen.getByLabelText('Clock gap at endgame entry info'),
     ).toBeTruthy();
   });
 


### PR DESCRIPTION
Renames the Endgames clock-diff timeline chart heading to **"Clock Gap at Endgame Entry"**.

Updated: chart `<h3>`, InfoPopover aria-label + bold body label, the sibling-chart docstring reference in `ScoreGapByTimePressureChart`, and the two `EndgameClockDiffOverTimeChart` test assertions (title text + aria-label).

576/576 frontend tests pass; tsc / eslint / knip clean. UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)