### PR TITLE
Release: Time Pressure 2×2 card layout fix

### DIFF
--- a/frontend/src/components/charts/EndgameTimePressureSection.tsx
+++ b/frontend/src/components/charts/EndgameTimePressureSection.tsx
@@ -5,7 +5,7 @@
  *   1 card  → half width
  *   2 cards → 2-column full width
  *   3 cards → 3-column full width
- *   4 cards → 2×2 on md, 4×1 on xl
+ *   4 cards → 2×2 on md+ (never more than 2 per row)
  *
  * Replaces the legacy line-chart EndgameTimePressureSection and the
  * EndgameClockPressureSection (both deleted in Phase 88 Plan 07).
@@ -21,7 +21,7 @@ import type { TimePressureCardsResponse } from '@/types/endgames';
 const GRID_ONE_CARD = 'w-full sm:w-1/2 mt-2';
 const GRID_TWO_CARDS = 'grid grid-cols-1 sm:grid-cols-2 gap-4 mt-2';
 const GRID_THREE_CARDS = 'grid grid-cols-1 sm:grid-cols-3 gap-4 mt-2';
-const GRID_FOUR_CARDS = 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mt-2';
+const GRID_FOUR_CARDS = 'grid grid-cols-1 md:grid-cols-2 gap-4 mt-2';
 
 export function EndgameTimePressureSection({
   data,


### PR DESCRIPTION
Promotes `main` → `production`.

Single change since last release:
- #115 — Time Pressure cards never exceed 2 per row (4 cards render 2×2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)