### PR TITLE
test: fix Time Pressure grid assertion for 2×2 layout

### DIFF
--- a/frontend/src/components/charts/__tests__/EndgameTimePressureSection.test.tsx
+++ b/frontend/src/components/charts/__tests__/EndgameTimePressureSection.test.tsx
@@ -237,13 +237,15 @@ describe('EndgameTimePressureSection — SC-1: dynamic grid layout', () => {
     expect(grid?.className).toContain('grid-cols-3');
   });
 
-  it('4-card payload uses xl:grid-cols-4', () => {
+  it('4-card payload uses a 2×2 grid (md:grid-cols-2, never >2 per row)', () => {
     const { container } = renderSection(
       makePayload('bullet', 'blitz', 'rapid', 'classical'),
     );
     const grid = container.querySelector(
       '[data-testid="time-pressure-cards-section"] > p + div',
     );
-    expect(grid?.className).toContain('grid-cols-4');
+    expect(grid?.className).toContain('md:grid-cols-2');
+    expect(grid?.className).not.toContain('grid-cols-3');
+    expect(grid?.className).not.toContain('grid-cols-4');
   });
 });


### PR DESCRIPTION
Follow-up to #115. The 4-card test still asserted the removed `xl:grid-cols-4` class and broke CI on the release deploy. Updated it to assert the 2×2 layout (`md:grid-cols-2`) and that the grid never exceeds 2 columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)