### PR TITLE
chore: ruff-format endgame files (CI format gate drift)

### DIFF
--- a/app/schemas/endgames.py
+++ b/app/schemas/endgames.py
@@ -129,7 +129,9 @@ class EndgameCategoryStats(BaseModel):
     eval_p_value: float | None = None
     eval_confidence: Literal["low", "medium", "high"] = "low"
     last_played_at: datetime.datetime | None = None
-    eval_baseline_pawns: float = 0.25  # always EVAL_BASELINE_PAWNS_WHITE for endgames (color-agnostic, D-02)
+    eval_baseline_pawns: float = (
+        0.25  # always EVAL_BASELINE_PAWNS_WHITE for endgames (color-agnostic, D-02)
+    )
 
 
 class EndgameStatsResponse(BaseModel):

--- a/app/services/endgame_service.py
+++ b/app/services/endgame_service.py
@@ -558,11 +558,7 @@ def _aggregate_endgame_stats(
         # Sign convention: user_cp = +eval_cp for white, -eval_cp for black
         # (mirrors _classify_endgame_bucket). Exclude mate rows, NULL evals, and
         # |cp| >= EVAL_OUTLIER_TRIM_CP (D-08 outlier trim, same as openings).
-        if (
-            eval_mate is None
-            and eval_cp is not None
-            and abs(eval_cp) < EVAL_OUTLIER_TRIM_CP
-        ):
+        if eval_mate is None and eval_cp is not None and abs(eval_cp) < EVAL_OUTLIER_TRIM_CP:
             sign = 1 if user_color == "white" else -1
             user_cp = sign * eval_cp
             eval_sum_by_class[endgame_class] += user_cp
@@ -658,7 +654,9 @@ def _aggregate_endgame_stats(
         # score_p_value retains its existing gated semantics (None when total <
         # PVALUE_RELIABILITY_MIN_N) for backward compat with EndgameTypeCard Stats subtab.
         category_last_played_at = last_played_at_by_class[endgame_class]
-        wdl_stats = _build_wdl_stats(wins, draws, losses, total, last_played_at=category_last_played_at)
+        wdl_stats = _build_wdl_stats(
+            wins, draws, losses, total, last_played_at=category_last_played_at
+        )
         score_p_value: float | None = (
             wdl_stats.p_value if total >= PVALUE_RELIABILITY_MIN_N else None
         )

--- a/tests/test_endgame_service.py
+++ b/tests/test_endgame_service.py
@@ -4011,7 +4011,7 @@ class TestEndgameCategoryStatsWdlAlignedFields:
 
         # Reference: compute_eval_confidence_bucket over 20 identical user_cp=200 values.
         eval_sum = 200.0 * 20
-        eval_sumsq = 200.0 ** 2 * 20
+        eval_sumsq = 200.0**2 * 20
         eval_n = 20
         ref_conf, ref_pval, ref_mean_cp, ref_ci_half = compute_eval_confidence_bucket(
             eval_sum, eval_sumsq, eval_n
@@ -4019,8 +4019,12 @@ class TestEndgameCategoryStatsWdlAlignedFields:
 
         assert rook.eval_n == eval_n
         assert rook.avg_eval_pawns == pytest.approx(ref_mean_cp / 100.0, abs=1e-9)
-        assert rook.eval_ci_low_pawns == pytest.approx((ref_mean_cp - ref_ci_half) / 100.0, abs=1e-9)
-        assert rook.eval_ci_high_pawns == pytest.approx((ref_mean_cp + ref_ci_half) / 100.0, abs=1e-9)
+        assert rook.eval_ci_low_pawns == pytest.approx(
+            (ref_mean_cp - ref_ci_half) / 100.0, abs=1e-9
+        )
+        assert rook.eval_ci_high_pawns == pytest.approx(
+            (ref_mean_cp + ref_ci_half) / 100.0, abs=1e-9
+        )
         assert rook.eval_p_value == pytest.approx(ref_pval, abs=1e-9)
         assert rook.eval_confidence == ref_conf
 
@@ -4039,8 +4043,8 @@ class TestEndgameCategoryStatsWdlAlignedFields:
 
         # 5 normal rows (user_cp=100) + 1 outlier (eval_cp=2000, excluded) + 1 exact boundary (2001, excluded).
         normal_rows = [(i + 1, 1, "1-0", "white", 100, None) for i in range(5)]
-        outlier_row = (6, 1, "1-0", "white", EVAL_OUTLIER_TRIM_CP, None)     # |cp|=2000 → excluded
-        over_row = (7, 1, "1-0", "white", EVAL_OUTLIER_TRIM_CP + 1, None)    # |cp|=2001 → excluded
+        outlier_row = (6, 1, "1-0", "white", EVAL_OUTLIER_TRIM_CP, None)  # |cp|=2000 → excluded
+        over_row = (7, 1, "1-0", "white", EVAL_OUTLIER_TRIM_CP + 1, None)  # |cp|=2001 → excluded
         all_rows = normal_rows + [outlier_row, over_row]
         result, _ = _aggregate_endgame_stats(all_rows)
         rook = next(c for c in result if c.endgame_class == "rook")
@@ -4051,7 +4055,9 @@ class TestEndgameCategoryStatsWdlAlignedFields:
         """Rows with eval_mate is not None must be excluded from the eval cohort."""
         # 5 normal rows + 5 mate rows (eval_mate set → excluded).
         normal_rows = [(i + 1, 1, "1-0", "white", 200, None) for i in range(5)]
-        mate_rows = [(i + 6, 1, "1-0", "white", None, 3) for i in range(5)]  # eval_mate=3 (in 3 moves)
+        mate_rows = [
+            (i + 6, 1, "1-0", "white", None, 3) for i in range(5)
+        ]  # eval_mate=3 (in 3 moves)
         result, _ = _aggregate_endgame_stats(normal_rows + mate_rows)
         rook = next(c for c in result if c.endgame_class == "rook")
         assert rook.eval_n == 5  # only the normal rows

--- a/tests/test_endgames_router.py
+++ b/tests/test_endgames_router.py
@@ -512,11 +512,20 @@ class TestEndgameCategoryStatsWdlAlignedFieldsRouter:
         from app.schemas.endgames import EndgameCategoryStats
 
         required_fields = {
-            "score", "confidence", "p_value", "ci_low", "ci_high",
-            "eval_n", "eval_confidence", "eval_baseline_pawns",
+            "score",
+            "confidence",
+            "p_value",
+            "ci_low",
+            "ci_high",
+            "eval_n",
+            "eval_confidence",
+            "eval_baseline_pawns",
             # optional-with-default fields:
-            "avg_eval_pawns", "eval_ci_low_pawns", "eval_ci_high_pawns",
-            "eval_p_value", "last_played_at",
+            "avg_eval_pawns",
+            "eval_ci_low_pawns",
+            "eval_ci_high_pawns",
+            "eval_p_value",
+            "last_played_at",
             # backward-compat field:
             "score_p_value",
         }
@@ -528,11 +537,20 @@ class TestEndgameCategoryStatsWdlAlignedFieldsRouter:
         from app.schemas.endgames import ConversionRecoveryStats
 
         stub_conversion = ConversionRecoveryStats(
-            conversion_pct=0.0, conversion_games=0, conversion_wins=0,
-            conversion_draws=0, conversion_losses=0, recovery_pct=0.0,
-            recovery_games=0, recovery_saves=0, recovery_wins=0, recovery_draws=0,
-            opponent_conversion_pct=None, opponent_conversion_games=0,
-            opponent_recovery_pct=None, opponent_recovery_games=0,
+            conversion_pct=0.0,
+            conversion_games=0,
+            conversion_wins=0,
+            conversion_draws=0,
+            conversion_losses=0,
+            recovery_pct=0.0,
+            recovery_games=0,
+            recovery_saves=0,
+            recovery_wins=0,
+            recovery_draws=0,
+            opponent_conversion_pct=None,
+            opponent_conversion_games=0,
+            opponent_recovery_pct=None,
+            opponent_recovery_games=0,
         )
         default_cat = EndgameCategoryStats(
             endgame_class="rook",


### PR DESCRIPTION
Unblocks the production deploy. Phases #119–#121 merged the endgame schema/service/tests unformatted (slipped past PR CI, force-merged), failing the deploy workflow's `ruff format --check app/ tests/` gate.

Pure `ruff format` line-wrapping, no logic change. `alembic/` and `scripts/` have similar drift but are out of CI scope (`ruff format --check app/ tests/`) — left untouched, flagged for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)