### PR TITLE
chore: add pre-PR ruff/ty gate to CLAUDE.md + installable pre-push hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,28 @@ gh run watch <run-id>           # Watch a run in progress
 gh pr checks <pr-number>        # Check PR status
 ```
 
+### Pre-PR checklist (MANDATORY before `git push` / `gh pr create`)
+
+Run these locally and resolve all output **before** pushing a branch that will become a PR. CI runs the same gates and will fail the build if any of them are dirty; catching them locally avoids a "fix CI" round-trip commit.
+
+```bash
+uv run ruff format app/ tests/         # apply formatting (not just --check)
+uv run ruff check app/ tests/ --fix    # apply autofixable lint
+uv run ty check app/ tests/            # type check, zero errors required
+uv run pytest -x                       # backend tests, stop on first failure
+( cd frontend && npm run lint && npm test -- --run )  # frontend lint + tests
+```
+
+If any step modifies files, commit the result with a `style(...)` or `chore(...)` prefix before pushing. Never push expecting CI to surface a formatter diff — the formatter is deterministic, so a CI "would reformat" failure is always avoidable locally. This is the single most common preventable CI failure on this project; treat the checklist as part of `git push`, not optional.
+
+**Enforcement via git hook (recommended one-time setup):**
+
+```bash
+bin/install_pre_push_hook.sh    # installs .git/hooks/pre-push
+```
+
+The hook runs `ruff format --check`, `ruff check`, and `ty check` on every `git push`, blocking the push if any gate fails. Pytest is intentionally excluded from the hook to keep pushes fast — run it manually before opening a PR. Bypass for WIP pushes with `git push --no-verify`.
+
 ## Scripts
 
 ### `bin/`

--- a/bin/install_pre_push_hook.sh
+++ b/bin/install_pre_push_hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Installs a local git pre-push hook that runs the mandatory pre-PR gates
+# documented in CLAUDE.md (ruff format / ruff check / ty / pytest).
+#
+# Usage:
+#   bin/install_pre_push_hook.sh
+#
+# The hook lives in .git/hooks/pre-push (per-clone, never committed).
+# To bypass for an exceptional push: `git push --no-verify`.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_PATH="${REPO_ROOT}/.git/hooks/pre-push"
+
+cat > "${HOOK_PATH}" <<'HOOK'
+#!/usr/bin/env bash
+# Pre-push gate — enforces CLAUDE.md "Pre-PR checklist".
+# Bypass with `git push --no-verify` only when intentionally pushing WIP.
+
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+PROTECTED_RE='^refs/heads/(main|production)$'
+
+# Skip the gate when pushing nothing or only deletes.
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ -z "${local_sha:-}" || "${local_sha}" == "0000000000000000000000000000000000000000" ]]; then
+    continue
+  fi
+  RUN_GATE=1
+done
+
+if [[ -z "${RUN_GATE:-}" ]]; then
+  exit 0
+fi
+
+echo "→ pre-push: ruff format --check"
+uv run ruff format --check app/ tests/
+
+echo "→ pre-push: ruff check"
+uv run ruff check app/ tests/
+
+echo "→ pre-push: ty check"
+uv run ty check app/ tests/
+
+echo "✓ pre-push gates passed"
+HOOK
+
+chmod +x "${HOOK_PATH}"
+echo "Installed pre-push hook at ${HOOK_PATH}"
+echo "Bypass with: git push --no-verify"


### PR DESCRIPTION
Closes the recurring 'CI failed because of ruff format' loop that hit PR #130.

**Changes:**
- CLAUDE.md gains a mandatory pre-PR checklist (ruff format / ruff check / ty / pytest / frontend) with the explicit rule that a formatter-only CI failure is always avoidable locally.
- New `bin/install_pre_push_hook.sh` — one-shot installer for a per-clone git pre-push hook that runs `ruff format --check` / `ruff check` / `ty check` on every push. Pytest is intentionally excluded from the hook (kept manual) to keep pushes fast. Bypass with `git push --no-verify` for WIP pushes.

Per-clone hook (lives in `.git/hooks/pre-push`, not committed) — opt-in by running the installer once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)