### PR TITLE
Release: Stockfish header polish + deploy/ops tooling

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: deploy
+description: Deploy FlawChess to production end-to-end without interruption — open a PR from main to production, fix anything CI complains about (Dependabot CVEs, ruff/ty drift, merge conflicts, branch divergence, frontend lint), squash-merge once green, run bin/deploy.sh, monitor it through to a verified server SHA on flawchess.com. Use this skill whenever the user asks to deploy, ship, release, push to prod, promote main to production, cut a release, or run bin/deploy.sh. Trigger on phrases like "deploy", "deploy to prod", "ship it", "release", "promote main", "push to production", "cut a release", "go live", or any request to get current main running on flawchess.com. This is a SET-AND-FORGET flow: stream status as milestones complete, but do not pause for user approval at any stage — only halt when a situation is genuinely ambiguous (dirty working tree that might be in-progress work, repeated unrecoverable CI failure after multiple fix attempts, server SHA mismatch after deploy) or destructive (force-push, branch deletion, manual SSH deploy).
+---
+
+# Deploy to Production
+
+End-to-end production deploy for FlawChess. Runs the full `main → production` release flow autonomously, including fixing whatever CI complains about along the way. Stream status updates so the user can see what's happening, but don't pause for approval unless something is genuinely ambiguous (see *When to halt*).
+
+## When to use
+
+- The user explicitly asks to deploy, ship, release, or push to production.
+- A milestone closes and they want it live.
+- A hotfix on `main` (or a fast-follow fix) needs to reach prod.
+
+If the user is asking about deploy *mechanics* (how it works, what the script does) without asking to actually run it, don't trigger — answer the question instead.
+
+## Mental model
+
+FlawChess uses GitLab Flow:
+- `main` = integration trunk
+- `production` = exactly what's deployed
+- A deploy = `main → production` PR, squash-merged, then `bin/deploy.sh` (which deploys the `production` branch via GitHub Actions).
+
+The full pipeline is: **preflight → open PR → CI green (fix anything that fails) → squash-merge → announce → bin/deploy.sh → monitor → verify**.
+
+This is **set-and-forget**: run the whole pipeline end-to-end without asking for approval at intermediate steps. CI babysitting, Dependabot bumps, formatter fixes, ty errors, merge conflicts, branch divergence — handle autonomously, stream a one-line status update at each milestone, and keep moving. Stop only for situations described under *When to halt* below. Never wait for a "go ahead" between merge and deploy — that defeats the purpose of the skill.
+
+## Step 1: Preflight
+
+Run these in parallel and report any blockers before doing anything else:
+
+```bash
+git status --porcelain                        # working tree must be clean
+git rev-parse --abbrev-ref HEAD               # should be main
+git fetch origin main production --quiet      # sync refs
+git log --oneline origin/production..origin/main  # what's about to ship
+ls -la .prod.env                              # required by bin/deploy.sh (scp'd to server)
+```
+
+Blockers and how to resolve:
+
+- **Dirty working tree** — stop and ask the user. Don't stash or commit on their behalf (might destroy in-progress work).
+- **Not on `main`** — switch (`git checkout main && git pull --ff-only`) only if the working tree is clean; otherwise stop.
+- **`main` behind `origin/main`** — `git pull --ff-only origin main` (resolve autonomously).
+- **`main` and `origin/main` diverged** (non-fast-forward) — see `references/ci-fixes.md` § *Git: divergence and merge conflicts*. Resolve autonomously when the fix is mechanical (rebase clean, conflict only in lockfiles or CHANGELOG); stop and report otherwise.
+- **Nothing to deploy** (`origin/production..origin/main` is empty) — tell the user, stop. Don't open an empty PR.
+- **`.prod.env` missing locally** — stop and tell the user to fetch it (`bin/download_1password.sh`). The deploy script `scp`s it to the server; without it, the deploy will fail with a confusing error mid-pipeline.
+
+Then run the pre-PR gates locally so CI doesn't have to bounce them back:
+
+```bash
+uv run ruff format app/ tests/
+uv run ruff check app/ tests/ --fix
+uv run ty check app/ tests/
+( cd frontend && npm run lint )
+```
+
+If any of these modify files, commit with a `chore(release):` or `style(release):` prefix and push to `main` before opening the release PR. Skip the test suites here — CI runs them and that's faster than running locally for a release-prep step.
+
+## Step 2: Open the release PR
+
+Compose the PR body from the squashed commit log between `production` and `main`. Group by Conventional Commit type when possible (feat / fix / refactor / chore / docs). Keep it skimmable — this becomes the squash-merge commit message and lands in `git log` on the `production` branch.
+
+```bash
+gh pr create --base production --head main \
+  --title "Release: <one-line summary of biggest change(s)>" \
+  --body "$(cat <<'EOF'
+## What's shipping
+
+<grouped bullet list from git log production..main, terse and user-facing>
+
+## Phases / PRs included
+
+<list of phase numbers or PR refs if identifiable from commit messages>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the PR number — you'll need it for the merge step.
+
+## Step 3: Watch CI, fix anything red
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+When checks complete, if anything is failing, diagnose and fix. **Do not wake the user for this** — that's the whole point of this skill running autonomously through CI. See `references/ci-fixes.md` for the common failure modes (Dependabot vulnerabilities, ruff/ty drift, frontend test flakes, etc.) and how to resolve each.
+
+For every fix:
+1. Apply the fix on `main` (not on a side branch — the release PR tracks `main`).
+2. Commit with a focused prefix: `fix(deps):`, `chore(ci):`, `style:`, etc.
+3. `git push origin main` — this updates the open PR automatically.
+4. `gh pr checks <PR#> --watch` again.
+
+If you've tried 2-3 distinct fixes for the same failure and it's still red, stop and report what you've tried. Don't churn indefinitely.
+
+## Step 4: Squash-merge
+
+Once all checks are green:
+
+```bash
+gh pr merge <PR#> --squash --delete-branch=false
+```
+
+`--delete-branch=false` is critical: deleting `main` would be catastrophic. The squash merge writes one commit onto `production` with the PR title + body as the message.
+
+After merging, sync local refs so the next `bin/deploy.sh` sees the right commit:
+
+```bash
+git fetch origin production
+```
+
+## Step 5: Announce the deploy (do not wait)
+
+Print a one-block status message so the user knows the deploy is starting, then proceed directly to step 6 in the same turn. **Do not ask "should I deploy?" — the user invoked this skill to deploy.** They can interrupt if they need to.
+
+The announcement should be terse, just enough to let the user scan and intervene if something is wrong:
+
+```
+✅ Merged PR #<N>  (<merge-sha>  →  origin/production)
+   <one-line summary of what's shipping>
+   <K> phases / <M> commits since last release
+   Caveats: <any non-obvious CI fixes applied, e.g. "bumped axios 1.7.2→1.7.9 for CVE-2025-XXXX">
+
+→ Running bin/deploy.sh now...
+```
+
+Then immediately run `bin/deploy.sh`. No question, no pause.
+
+## Step 6: Deploy
+
+```bash
+bin/deploy.sh
+```
+
+This script already does the right things: it dispatches the CI workflow on `production`, asserts the dispatched run is on `production@TARGET_SHA`, watches the run via `gh run watch --exit-status`, then SSHes to the server to verify `HEAD` matches. It self-monitors. **Don't background it** — let its output stream so the user can see progress.
+
+If `bin/deploy.sh` exits non-zero:
+
+- **`scp .prod.env` failed** — usually network or SSH. Retry once. If it fails again, stop and report.
+- **`no workflow_dispatch run found`** — race condition (rare). Re-run `bin/deploy.sh`.
+- **Dispatched run is on wrong branch / SHA** — abort and investigate. Do NOT bypass the assertion.
+- **CI failure during deploy** — check `gh run view <run-id> --log-failed`. If it's a transient flake, `gh run rerun <run-id> --failed` then re-run `bin/deploy.sh`. If it's a real failure, halt and report — fixing this is one of the few situations that needs the user to decide between forward-fix-via-main and hotfix-to-production.
+- **Server SHA mismatch at the end** — server didn't converge. Check `ssh flawchess "cd /opt/flawchess && docker compose ps"` and the deploy logs. Don't claim success.
+
+## Step 7: Post-deploy verification
+
+After `bin/deploy.sh` exits 0, do a quick liveness check and report:
+
+```bash
+curl -sS -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" https://flawchess.com/
+ssh flawchess "cd /opt/flawchess && docker compose ps --format 'table {{.Service}}\t{{.Status}}'"
+ssh flawchess "cd /opt/flawchess && docker compose logs --tail=20 backend"
+```
+
+Report: deploy succeeded, server is on `<sha>`, backend container is up, site responded 200. If the backend tail shows errors, surface them — the deploy script doesn't catch logical failures, only that containers came up.
+
+## When to halt (and when NOT to)
+
+This skill is set-and-forget. The default is: keep going, stream status, recover from anything mechanical. Halt only for these specific situations, and when you halt, surface the exact state and what you tried so the user can take over without re-investigating:
+
+**Halt — genuinely ambiguous:**
+- Dirty working tree at preflight (could be in-progress work — don't stash, don't commit on the user's behalf).
+- `main` and `origin/main` diverged with conflicts outside lockfiles / CHANGELOG / generated files (anything in `app/` or `frontend/src/` that requires semantic judgment).
+- `origin/production..origin/main` is empty (nothing to deploy — don't open an empty PR).
+- `.prod.env` missing locally (deploy script will fail mid-pipeline with a confusing error).
+- Same CI check has failed 3 times after distinct fix attempts — you're churning, escalate.
+- `bin/deploy.sh` reports server SHA mismatch at the end — deploy did not converge, do NOT claim success.
+- Deploy script aborts with "dispatched run is on wrong branch / SHA" — this is the 2026-05-16 incident's safety net firing; investigate, don't bypass.
+
+**Do NOT halt — handle autonomously:**
+- CI red because of Dependabot CVE — bump the dep (see `references/ci-fixes.md`).
+- CI red because of ruff format drift — run formatter, commit, push.
+- CI red because of ty error in code you just touched — fix and push.
+- Branch behind `origin/main` — `git pull --ff-only`.
+- Branch diverged but conflict is only in `package-lock.json` / `uv.lock` / `CHANGELOG.md` / generated files — resolve mechanically (see `references/ci-fixes.md`).
+- Frontend test that's a known flake — retry once via `gh run rerun --failed`.
+- Pre-push hook reformatting files — accept the reformat, commit, push again.
+- `bin/deploy.sh` `scp` fails on a network blip — retry once.
+
+When in doubt: prefer continuing with a noted caveat over halting. Halting wastes the "set and forget" property the user explicitly asked for.
+
+## Hard rules (never break, even in auto-mode)
+
+- **Never bypass `bin/deploy.sh`'s safety assertions** (branch check, SHA check, server SHA verify). They exist because of a 2026-05-16 incident where a deploy silently shipped unreleased `main` to prod.
+- **Never deploy via direct SSH.** Saved in user memory as a hard rule. `bin/deploy.sh` is the only sanctioned path — it runs CI tests first.
+- **Never force-push `main` or `production`.** Forward-fix instead. If a rebase would require force-push, halt and ask.
+- **Never `git push --no-verify`** unless the pre-push hook itself is broken (then fix the hook, don't skip it). The hook catches the most common preventable CI failure on this project.
+- **Never delete the `main` or `production` branch.** `gh pr merge` defaults to deleting the head branch — always pass `--delete-branch=false`.
+- **Never edit `production` directly** outside of an approved hotfix flow. Releases go `main → PR → squash-merge to production`.
+- **Hotfix path is separate.** If the user says "hotfix", route to the `hotfix/*` flow in `CLAUDE.md` (branch off `production`, PR into `production`, deploy, then forward-port to `main`). This skill is for the normal `main → production` release path.
+
+## References
+
+- `references/ci-fixes.md` — playbook for common CI failures (Dependabot, ruff, ty, frontend, etc.) that you'll resolve autonomously between steps 3 and 4.

--- a/.claude/skills/deploy/references/ci-fixes.md
+++ b/.claude/skills/deploy/references/ci-fixes.md
@@ -1,0 +1,353 @@
+# CI & Git Fix Playbook
+
+Reference for the `deploy` skill. Covers every CI failure or git situation you're expected to resolve autonomously between preflight and squash-merge. The principle: each fix is a focused commit on `main`, push, re-watch checks. No side branches, no force-pushes.
+
+## Quick diagnosis
+
+```bash
+gh pr checks <PR#>                       # which check is red
+gh run view <run-id> --log-failed        # logs of the failing job
+gh pr view <PR#> --json statusCheckRollup --jq '.statusCheckRollup[] | select(.conclusion=="FAILURE")'
+```
+
+Match the failure output to a section below. If the failure doesn't match anything here, read the log carefully, fix the root cause, and add a section to this file for next time.
+
+---
+
+## CI: Dependabot / security alerts blocking merge
+
+GitHub blocks merges to `production` if a critical Dependabot CVE is open against a dependency the PR includes. The fix is to bump the affected dep in the same release PR.
+
+**Backend (Python via uv):**
+
+```bash
+# Find which package is flagged
+gh api repos/:owner/:repo/dependabot/alerts --jq '.[] | select(.state=="open") | {package: .security_vulnerability.package.name, severity: .security_advisory.severity, summary: .security_advisory.summary}'
+
+# Bump it
+uv lock --upgrade-package <package-name>
+# Or if a specific minimum version is required by the CVE:
+uv add '<package-name>>=<safe-version>'
+
+# Verify nothing broke
+uv run pytest -x
+uv run ty check app/ tests/
+
+git add pyproject.toml uv.lock
+git commit -m "fix(deps): bump <package> to <version> for CVE-XXXX-YYYY"
+git push origin main
+```
+
+**Frontend (npm):**
+
+```bash
+# Find the issue
+( cd frontend && npm audit --audit-level=high --json | jq '.vulnerabilities | to_entries | map({name: .key, severity: .value.severity, fixAvailable: .value.fixAvailable})' )
+
+# Apply available fixes
+( cd frontend && npm audit fix )
+
+# If a transitive dep needs a manual bump:
+( cd frontend && npm install <package>@<safe-version> )
+
+# Verify
+( cd frontend && npm run lint && npm test -- --run && npm run build )
+
+git add frontend/package.json frontend/package-lock.json
+git commit -m "fix(deps): bump <package> to <version> for CVE-XXXX-YYYY"
+git push origin main
+```
+
+If `npm audit fix` proposes a `--force` resolution that introduces a breaking major bump, **halt** — that's a judgment call, not a mechanical fix.
+
+---
+
+## CI: ruff format drift
+
+Symptom: CI step "ruff format --check" fails with "Would reformat: ...".
+
+```bash
+uv run ruff format app/ tests/
+git add -u
+git commit -m "style: apply ruff format"
+git push origin main
+```
+
+This is the single most common preventable CI failure on this project — see CLAUDE.md "Pre-PR checklist". The pre-push hook should catch it; if it didn't, the hook isn't installed (`bin/install_pre_push_hook.sh`).
+
+## CI: ruff lint errors
+
+```bash
+uv run ruff check app/ tests/ --fix
+# Inspect remaining errors that --fix couldn't resolve
+uv run ruff check app/ tests/
+```
+
+Auto-fixable issues commit cleanly. For manual fixes (unused imports flagged but actually needed, type narrowing, etc.), apply the smallest change that makes the rule pass. If a rule needs to be suppressed, use `# noqa: <rule-code>` with a brief reason on the same line.
+
+```bash
+git add -u
+git commit -m "style: fix ruff lint findings"
+git push origin main
+```
+
+## CI: ty type errors
+
+```bash
+uv run ty check app/ tests/
+```
+
+Address each error. Common patterns from CLAUDE.md:
+- Function missing return annotation → add it.
+- `list[Literal[...]]` passed where invariance bites → switch parameter to `Sequence[...]`.
+- SQLAlchemy forward refs / FastAPI-Users generics → `# ty: ignore[rule-name]  # <reason>`.
+
+If a ty error is in code that pre-dates this PR (not in the diff), still fix it — CI gates the whole tree, not just the diff.
+
+```bash
+git add -u
+git commit -m "fix(types): resolve ty check errors"
+git push origin main
+```
+
+## CI: backend pytest failure
+
+```bash
+gh run view <run-id> --log-failed | grep -A 40 "FAILED tests/"
+```
+
+Reproduce locally:
+
+```bash
+docker compose -f docker-compose.dev.yml -p flawchess-dev up -d
+uv run pytest -x tests/<failing_test_file>.py::<test_name> -v
+```
+
+If the failure is a real regression in code from this PR, fix it. If it's a flaky test (network, timing, ordering), retry once:
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+If it flakes again, **halt** — flaky tests in a release PR need human judgment.
+
+## CI: frontend lint / test / build failures
+
+```bash
+cd frontend
+npm run lint            # eslint
+npm test -- --run       # vitest single-pass
+npm run build           # vite + tsc strict
+npm run knip            # dead code / unused deps
+```
+
+`knip` failures are usually leftover exports or unused deps from a removed feature. Delete them.
+
+`tsc` failures with `noUncheckedIndexedAccess` are common — narrow the index access (see CLAUDE.md Frontend section).
+
+```bash
+git add -u
+git commit -m "fix(frontend): <specific issue>"
+git push origin main
+```
+
+## CI: `endgameZones.ts` drift
+
+```
+ERROR: frontend/src/generated/endgameZones.ts is out of date
+```
+
+```bash
+uv run python scripts/gen_endgame_zones_ts.py
+git add frontend/src/generated/endgameZones.ts
+git commit -m "chore: regenerate endgameZones.ts"
+git push origin main
+```
+
+## CI: Alembic migration check
+
+If CI complains about pending migrations not detected:
+
+```bash
+uv run alembic upgrade head
+uv run alembic revision --autogenerate -m "<description>"
+# Inspect the generated file — autogenerate sometimes catches false positives
+```
+
+If autogenerate produces an empty migration, the model and schema are actually in sync — likely a CI cache issue, rerun the workflow.
+
+---
+
+## Git: branch behind origin
+
+```
+error: failed to push some refs to 'origin/main'
+hint: Updates were rejected because the remote contains work you do not have locally.
+```
+
+```bash
+git fetch origin main
+git pull --ff-only origin main
+git push origin main
+```
+
+If `--ff-only` refuses because the histories diverged, see next section.
+
+## Git: divergence and merge conflicts
+
+`main` has commits both locally and on `origin/main` (e.g. another machine pushed, or a Dependabot auto-merge landed).
+
+```bash
+git fetch origin main
+git log --oneline HEAD..origin/main      # what's on remote that you don't have
+git log --oneline origin/main..HEAD      # what's local that's not on remote
+```
+
+**Strategy: rebase local on top of remote** (keeps history linear):
+
+```bash
+git rebase origin/main
+```
+
+If the rebase is clean, just `git push origin main` and continue.
+
+If conflicts appear:
+
+```bash
+git status
+```
+
+**Auto-resolve these (mechanical, low-risk):**
+- **`uv.lock`** — accept incoming (`git checkout --theirs uv.lock`), then `uv lock` to regenerate based on current `pyproject.toml`. Stage, `git add uv.lock`, `git rebase --continue`.
+- **`frontend/package-lock.json`** — same pattern: `git checkout --theirs frontend/package-lock.json && ( cd frontend && npm install ) && git add frontend/package-lock.json && git rebase --continue`.
+- **`CHANGELOG.md`** — both sides added bullets under `## [Unreleased]`. Merge by keeping both sets of bullets in the same subsections. No semantic judgment needed.
+- **`frontend/src/generated/endgameZones.ts`** — regenerate: `uv run python scripts/gen_endgame_zones_ts.py && git add frontend/src/generated/endgameZones.ts && git rebase --continue`.
+- **Whitespace-only conflicts** — accept whichever side has the canonical formatting (usually `--theirs` since `origin/main` already passed CI).
+
+**Halt for these:**
+- Conflict in `app/**/*.py` or `frontend/src/**/*.{ts,tsx}` requires reading both sides and reasoning about intent.
+- Conflict in an Alembic migration file — migration ordering is semantic, not mechanical.
+- More than 5 conflicting files at once — likely a long-running divergence that needs a human.
+
+If you halt mid-rebase, abort cleanly so the user can pick up:
+
+```bash
+git rebase --abort
+```
+
+Then report exactly which files conflicted and what each side wanted.
+
+## Git: stale local main vs. origin after pre-push hook reformatted
+
+The pre-push hook runs `ruff format --check`. If it modified files, your push was rejected but you have a clean local state again. Just commit the reformat and push:
+
+```bash
+git status            # should show modified files
+git add -u
+git commit -m "style: apply ruff format from pre-push hook"
+git push origin main
+```
+
+## Git: pre-push hook failing on ty check
+
+If the hook blocks the push because of a ty error, fix the error (don't `--no-verify`). The hook exists to catch the most common preventable CI failure.
+
+```bash
+uv run ty check app/ tests/    # see the exact error
+# fix
+git add -u
+git commit -m "fix(types): <description>"
+git push origin main
+```
+
+## Git: PR not updating after push
+
+GitHub usually picks up new commits within seconds. If `gh pr view <PR#>` still shows the old SHA after a minute:
+
+```bash
+gh pr view <PR#> --json headRefOid,statusCheckRollup
+git rev-parse origin/main
+```
+
+If they don't match, the push didn't actually land — check `git push` exit code and retry.
+
+---
+
+## Deploy script failures (during step 6)
+
+### `scp .prod.env` fails
+
+Usually a transient network issue or SSH agent timeout.
+
+```bash
+ssh -o ConnectTimeout=5 flawchess "echo ok"    # check SSH
+bin/deploy.sh                                  # retry the whole script
+```
+
+If SSH itself fails twice in a row, halt — could be the server or could be the user's network. Report which.
+
+### "no workflow_dispatch run found on production"
+
+Race condition between `gh workflow run` dispatching and the run appearing. The script retries 15 times at 2s intervals; if it still fails:
+
+```bash
+gh run list --workflow=ci.yml --branch=production --limit=5
+```
+
+If a run is there but the script missed it, just re-run `bin/deploy.sh`. If no run appears, the dispatch silently failed — check `gh auth status` and re-run.
+
+### "dispatched run is on wrong branch / SHA"
+
+This is the 2026-05-16 safety assertion firing. **Do not bypass.** It means the workflow dispatched on something other than `production@TARGET_SHA`. Investigate:
+
+```bash
+git fetch origin production
+git rev-parse origin/production
+gh run list --workflow=ci.yml --event=workflow_dispatch --limit=3 \
+  --json databaseId,headBranch,headSha,createdAt
+```
+
+Likely cause: someone (or another deploy) pushed to `production` between the script computing `TARGET_SHA` and dispatch landing. Re-run `bin/deploy.sh` — it'll pick up the new SHA.
+
+### CI failure during deploy run
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+The deploy CI runs the same checks as PR CI. If something failed here that didn't fail on the PR, it's almost always:
+- A test that depends on production env vars not present in PR CI.
+- A timing-sensitive test that flaked.
+
+For flakes: `gh run rerun <run-id> --failed`, then `bin/deploy.sh` again once green.
+
+For real failures: the fix has to land on `main` first, then forward-merge to `production` via another PR. **Halt** and report — this is the rare case where `production` and `main` need separate fixes, and the user should make the call.
+
+### Server SHA mismatch at end of deploy
+
+```
+ERROR: server is at <X>, expected <Y>. Deploy did not converge.
+```
+
+Container probably didn't restart cleanly. Investigate:
+
+```bash
+ssh flawchess "cd /opt/flawchess && docker compose ps"
+ssh flawchess "cd /opt/flawchess && docker compose logs --tail=100 backend"
+ssh flawchess "cd /opt/flawchess && git log -1 --format='%h %s'"
+```
+
+**Halt.** This is a real production-divergence situation — the deploy "passed" CI but the server isn't on the expected commit. Do not retry blindly; report container state and recent backend logs to the user.
+
+---
+
+## What to do if a fix attempt makes things worse
+
+Every fix here is a clean commit on `main` — no force-push, no rebase of already-pushed commits, no branch deletion. If a commit you pushed turns out to be wrong, **add another commit that reverts or supersedes it**. Never `git reset --hard` a remote ref.
+
+```bash
+git revert <bad-commit-sha> --no-edit
+git push origin main
+```
+
+This keeps the audit trail intact and is always recoverable.

--- a/.planning/seeds/SEED-024-import-process-pool-for-fetch.md
+++ b/.planning/seeds/SEED-024-import-process-pool-for-fetch.md
@@ -1,0 +1,59 @@
+---
+id: SEED-024
+status: deferred (waiting on memory headroom)
+planted: 2026-05-21
+planted_during: /gsd-explore session on 2026-05-21 reviewing the Phase 91 stress-test report (reports/phase91-import-stress-test-2026-05-21.md). The report's "Next-step ideas" section flagged a `ProcessPoolExecutor` for position generation as the highest-throughput follow-up (estimated 2–3× chess.com fetch speedup). The /gsd-explore discussion concluded the CPU side is fine on a near-idle box, but the memory side is the blocker — today's run already peaked at 7.53 / 7.6 GB host memory with 2.52 GB swap, and 2–3 worker processes would add ~600 MB–1 GiB of duplicated Python + python-chess + Sentry SDK state.
+trigger_when: Either (a) prod server RAM is upgraded (Hetzner step up from 7.6 GB → 15+ GB), or (b) we measure per-worker RSS on this codebase and confirm a `forkserver`-based pool can stay under ~300 MB combined.
+scope: small (single GSD phase: pool sizing config + offload the python-chess parsing + Zobrist hashing for chess.com fetch + measurement + Sentry context for worker errors)
+priority: medium (pure performance — Phase 91 is already well within the box's headroom; this is wall-clock optimization for large imports, not a stability fix)
+references:
+  - reports/phase91-import-stress-test-2026-05-21.md   # the stress test that bounded the win at ~2× chess.com fetch
+  - logs/import-stress-20k-each-2026-05-21.log         # memory/CPU evidence
+  - app/services/import_service.py                     # current single-threaded fetch lane
+  - app/services/zobrist.py                            # `process_game_pgn` — the CPU-bound work to offload
+  - SEED-023                                           # the Phase 91 two-lane refactor this builds on
+---
+
+# SEED-024: ProcessPoolExecutor for chess.com fetch-lane parsing
+
+## Goal
+
+Move the python-chess parsing + Zobrist hashing work in the chess.com fetch lane off the single asyncio thread and onto a small `ProcessPoolExecutor`, unlocking the 2–3 idle cores during fetch. Target: ~2× chess.com fetch throughput (~11 g/s → ~22 g/s), shortening the wall-clock fetch window in a concurrent two-platform import from ~33 min to ~17–20 min. Lichess is API-bound and gets no benefit, so the pool is chess.com-only.
+
+## Why deferred
+
+The 2026-05-21 stress test established that the bottleneck case is **memory, not CPU**:
+
+| Resource | Headroom today |
+|---|---|
+| CPU | ample (drain tail peaks at 360% on a 400% box, fetch peaks at 200%; box is otherwise idle in production) |
+| RAM | **none meaningful** — host memory at 7.53 / 7.6 GB peak, 2.52 GB swap in use |
+
+Each Python worker process re-imports `app`, `python-chess`, SQLAlchemy, asyncpg, Sentry SDK on init. Empirical Python rule-of-thumb: ~150–300 MB RSS per worker on this codebase. 2–3 workers ≈ 600 MB–1 GiB additional RSS during fetch, which would push host memory past the swap-thrash threshold that triggered the 2026-05-16 OOM-kill (FLAWCHESS-56). Phase 91 fixed that failure mode by removing Stockfish from the batch transaction; we should not re-introduce a memory-pressure regression on the fetch lane.
+
+The user traffic argument doesn't save us here either: even at near-zero concurrent traffic, swap-pressure-vs-Postgres is a host-level resource auction, not a per-request constraint.
+
+## Trigger conditions (in priority order)
+
+1. **RAM upgrade.** Hetzner CX31 (7.6 GB) → CX41 (15.6 GB) or higher. Doubling RAM gives ~7.5 GB of guaranteed worker headroom and removes the swap-pressure failure mode from the threat model. This is the cleanest unblock.
+2. **Measured per-worker RSS with `forkserver`.** Before going to `spawn` (which re-imports everything) we should measure `forkserver` — workers fork from a minimal pre-fork process that hasn't imported the heavy modules, so they don't inherit the asyncio loop or open DB connections but they're cheaper than `spawn`. If `forkserver` workers stay under ~100 MB combined, the memory bill is small enough to fit today's headroom.
+3. **An observed user complaint about chess.com import wall-clock time.** Pure performance work shouldn't precede observed need.
+
+## Implementation sketch (when triggered)
+
+- Add `STOCKFISH_POOL_SIZE`-style env var: `IMPORT_PARSE_POOL_SIZE` (default 0 = disabled).
+- Use `concurrent.futures.ProcessPoolExecutor` with `mp_context=multiprocessing.get_context("forkserver")`. **Not `fork`** — forking after the asyncio loop and DB pool have been initialized causes file-descriptor and event-loop corruption.
+- Offload `process_game_pgn` (the per-game mainline walk) to the pool. The function is already pure (no DB, no engine, no logging), which is why Phase 78 refactored it into a single-pass function — it's pool-ready by design.
+- Keep the result-aggregation + DB insert on the asyncio thread (single session, no concurrency on `AsyncSession`).
+- Worker exceptions surface as `BrokenProcessPool` or per-future exceptions. Capture with `sentry_sdk.capture_exception()` in the orchestrator, tagged `source=import_parse_pool`, and fall back to in-process parsing for that batch.
+- Measure: backend RSS during fetch with pool enabled, on a 20k-game chess.com-only import, against the 2026-05-21 baseline.
+
+## Open questions for the future phase
+
+- Does the pool survive process restarts across multiple import jobs, or do we tear it down between jobs? (Trade-off: warm pool = no fork cost on each job; long-lived pool = workers accumulate any latent memory growth in python-chess.)
+- Should the pool be shared across concurrent import jobs (one pool, N workers) or per-job (each job gets its own 2-worker pool)? Shared is more efficient; per-job is simpler and bounded.
+- Interaction with the cold-drain Stockfish pool: today both run in-process under uvicorn. If both want 2 cores each, that's 4 cores total — exactly the box. Need explicit budgeting.
+
+## Why this is a seed, not a phase
+
+The trigger conditions above are not met. Promoting this to a phase before then would either be wasted work (RAM not upgraded) or premature optimization (no observed need).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,28 @@ gh run watch <run-id>           # Watch a run in progress
 gh pr checks <pr-number>        # Check PR status
 ```
 
+### Pre-PR checklist (MANDATORY before `git push` / `gh pr create`)
+
+Run these locally and resolve all output **before** pushing a branch that will become a PR. CI runs the same gates and will fail the build if any of them are dirty; catching them locally avoids a "fix CI" round-trip commit.
+
+```bash
+uv run ruff format app/ tests/         # apply formatting (not just --check)
+uv run ruff check app/ tests/ --fix    # apply autofixable lint
+uv run ty check app/ tests/            # type check, zero errors required
+uv run pytest -x                       # backend tests, stop on first failure
+( cd frontend && npm run lint && npm test -- --run )  # frontend lint + tests
+```
+
+If any step modifies files, commit the result with a `style(...)` or `chore(...)` prefix before pushing. Never push expecting CI to surface a formatter diff — the formatter is deterministic, so a CI "would reformat" failure is always avoidable locally. This is the single most common preventable CI failure on this project; treat the checklist as part of `git push`, not optional.
+
+**Enforcement via git hook (recommended one-time setup):**
+
+```bash
+bin/install_pre_push_hook.sh    # installs .git/hooks/pre-push
+```
+
+The hook runs `ruff format --check`, `ruff check`, and `ty check` on every `git push`, blocking the push if any gate fails. Pytest is intentionally excluded from the hook to keep pushes fast — run it manually before opening a PR. Bypass for WIP pushes with `git push --no-verify`.
+
 ## Scripts
 
 ### `bin/`

--- a/bin/install_pre_push_hook.sh
+++ b/bin/install_pre_push_hook.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Installs a local git pre-push hook that runs the mandatory pre-PR gates
+# documented in CLAUDE.md (ruff format / ruff check / ty / pytest).
+#
+# Usage:
+#   bin/install_pre_push_hook.sh
+#
+# The hook lives in .git/hooks/pre-push (per-clone, never committed).
+# To bypass for an exceptional push: `git push --no-verify`.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOK_PATH="${REPO_ROOT}/.git/hooks/pre-push"
+
+cat > "${HOOK_PATH}" <<'HOOK'
+#!/usr/bin/env bash
+# Pre-push gate — enforces CLAUDE.md "Pre-PR checklist".
+# Bypass with `git push --no-verify` only when intentionally pushing WIP.
+
+set -euo pipefail
+
+REMOTE="${1:-origin}"
+PROTECTED_RE='^refs/heads/(main|production)$'
+
+# Skip the gate when pushing nothing or only deletes.
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ -z "${local_sha:-}" || "${local_sha}" == "0000000000000000000000000000000000000000" ]]; then
+    continue
+  fi
+  RUN_GATE=1
+done
+
+if [[ -z "${RUN_GATE:-}" ]]; then
+  exit 0
+fi
+
+echo "→ pre-push: ruff format --check"
+uv run ruff format --check app/ tests/
+
+echo "→ pre-push: ruff check"
+uv run ruff check app/ tests/
+
+echo "→ pre-push: ty check"
+uv run ty check app/ tests/
+
+echo "✓ pre-push gates passed"
+HOOK
+
+chmod +x "${HOOK_PATH}"
+echo "Installed pre-push hook at ${HOOK_PATH}"
+echo "Bypass with: git push --no-verify"

--- a/frontend/src/components/EvalCoverageHeader.tsx
+++ b/frontend/src/components/EvalCoverageHeader.tsx
@@ -1,23 +1,12 @@
 import { Cpu } from 'lucide-react';
 import { useEvalCoverage } from '@/hooks/useEvalCoverage';
 
-/** Page-level Stockfish analysis progress banner.
+/** Global Stockfish analysis progress banner.
  *
  * Renders while Stockfish evaluation is still in progress (isPending === true).
  * Returns null at 100% so it leaves no layout gap once coverage is complete.
- *
- * Phase 91 feedback iteration:
- * - The earlier muted-text rendering was too easy to scroll past — banner now
- *   uses an amber-tinted info treatment with a pulsing Cpu icon.
- * - Percent-based progress was deceptive during a live import (the denominator
- *   grows faster than the numerator, so the bar walked backwards). The banner
- *   now leads with absolute counts ("N of M games analysed") — the analysed
- *   count grows monotonically and never regresses. The pulsing Cpu icon
- *   carries the liveness signal; no percent-driven bar.
- *
- * Mount on every page that surfaces Stockfish-dependent stats: Endgames Stats,
- * Openings Stats, Openings Explorer, Openings Insights. NOT in the global
- * topbar, NOT on the Import page (see D-02).
+ * Mounted once in ProtectedLayout so it sits above the per-page subtab nav on
+ * every protected page.
  */
 export function EvalCoverageHeader() {
   const { pendingCount, totalCount, isPending } = useEvalCoverage();
@@ -25,19 +14,17 @@ export function EvalCoverageHeader() {
   if (!isPending) return null;
 
   const analysedCount = Math.max(totalCount - pendingCount, 0);
-  const gamesLabel = totalCount === 1 ? 'game' : 'games';
   return (
     <div
       role="status"
       data-testid="eval-coverage-header"
-      className="flex items-center gap-2 rounded-md border border-amber-400/40 bg-amber-50/60 px-3 py-2 text-sm text-foreground mb-3"
+      className="flex items-center gap-2 rounded-md border border-amber-400/40 bg-amber-50/60 px-3 py-2 text-sm text-foreground mb-3 whitespace-nowrap overflow-hidden"
     >
       <Cpu className="h-4 w-4 shrink-0 text-amber-700 animate-pulse" aria-hidden="true" />
-      <span>
-        Stockfish analysis in progress:{' '}
-        <strong>{analysedCount.toLocaleString()}</strong> of{' '}
-        <strong>{totalCount.toLocaleString()}</strong> {gamesLabel} analysed
-        {' '}<span className="text-muted-foreground">({pendingCount.toLocaleString()} still pending)</span>
+      <span className="truncate">
+        Stockfish: <strong>{analysedCount.toLocaleString()}</strong>
+        {' / '}
+        <strong>{totalCount.toLocaleString()}</strong> games
       </span>
     </div>
   );

--- a/frontend/src/components/__tests__/EvalCoverageHeader.test.tsx
+++ b/frontend/src/components/__tests__/EvalCoverageHeader.test.tsx
@@ -28,7 +28,7 @@ describe('EvalCoverageHeader', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders absolute counts ("N of M games analysed") when multiple games are pending', () => {
+  it('renders compact "Stockfish: N / M games" copy when multiple games are pending', () => {
     (useEvalCoverage as Mock).mockReturnValue({
       isPending: true,
       pendingCount: 1432,
@@ -39,13 +39,11 @@ describe('EvalCoverageHeader', () => {
     render(<EvalCoverageHeader />);
     const el = screen.getByTestId('eval-coverage-header');
     expect(el).toBeTruthy();
-    expect(el.textContent).toContain('Stockfish analysis in progress');
     // analysedCount = 11000 - 1432 = 9568
-    expect(el.textContent).toContain('9,568 of 11,000 games analysed');
-    expect(el.textContent).toContain('(1,432 still pending)');
+    expect(el.textContent).toContain('Stockfish: 9,568 / 11,000 games');
   });
 
-  it('handles singular total (1 game total, 1 pending)', () => {
+  it('renders compact copy when only 1 game total', () => {
     (useEvalCoverage as Mock).mockReturnValue({
       isPending: true,
       pendingCount: 1,
@@ -55,8 +53,7 @@ describe('EvalCoverageHeader', () => {
 
     render(<EvalCoverageHeader />);
     const el = screen.getByTestId('eval-coverage-header');
-    expect(el.textContent).toContain('0 of 1 game analysed');
-    expect(el.textContent).toContain('(1 still pending)');
+    expect(el.textContent).toContain('Stockfish: 0 / 1 games');
   });
 
   it('clamps analysed count at 0 when pendingCount > totalCount (defensive race during import)', () => {
@@ -72,7 +69,7 @@ describe('EvalCoverageHeader', () => {
 
     render(<EvalCoverageHeader />);
     const el = screen.getByTestId('eval-coverage-header');
-    expect(el.textContent).toContain('0 of 5 games analysed');
+    expect(el.textContent).toContain('Stockfish: 0 / 5 games');
   });
 
   it('has role="status" and data-testid on root element', () => {

--- a/frontend/src/hooks/__tests__/useEvalCoverage.test.tsx
+++ b/frontend/src/hooks/__tests__/useEvalCoverage.test.tsx
@@ -56,7 +56,7 @@ describe('useEvalCoverage', () => {
 
     // Advance 10s to trigger first poll, then flush its promise
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(3_000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -64,7 +64,7 @@ describe('useEvalCoverage', () => {
 
     // Advance 10s to trigger second poll, then flush its promise
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(3_000);
     });
     await act(async () => {
       await Promise.resolve();
@@ -88,7 +88,7 @@ describe('useEvalCoverage', () => {
     const callCountAfterFirst = vi.mocked(apiClient.get).mock.calls.length;
     expect(callCountAfterFirst).toBe(1);
 
-    // Advance 30s — should NOT trigger more polls since pct_complete === 100
+    // Advance 30s — should NOT trigger more polls since pct_complete === 100 AND total_count > 0
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
@@ -97,6 +97,32 @@ describe('useEvalCoverage', () => {
     });
 
     expect(vi.mocked(apiClient.get).mock.calls.length).toBe(1);
+  });
+
+  it('keeps polling when total_count=0 (new user / pre-import lands on /import)', async () => {
+    // Backend short-circuits to pct=100 when the user has no games. Without
+    // continued polling, the header would never appear once an in-flight
+    // import starts landing rows.
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { pending_count: 0, total_count: 0, pct_complete: 100 },
+    });
+
+    renderHook(() => useEvalCoverage(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const callCountAfterFirst = vi.mocked(apiClient.get).mock.calls.length;
+    expect(callCountAfterFirst).toBe(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(vi.mocked(apiClient.get).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('returns safe default values before first fetch resolves', async () => {

--- a/frontend/src/hooks/useEvalCoverage.ts
+++ b/frontend/src/hooks/useEvalCoverage.ts
@@ -2,14 +2,19 @@ import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import type { EvalCoverageResponse } from '@/types/api';
 
-const EVAL_COVERAGE_POLL_INTERVAL_MS = 10_000;
-const EVAL_COVERAGE_STALE_TIME_MS = 10_000;
+const EVAL_COVERAGE_POLL_INTERVAL_MS = 3_000;
+const EVAL_COVERAGE_STALE_TIME_MS = 3_000;
 
 /** Poll GET /imports/eval-coverage every 10s while Stockfish analysis is pending.
  *
  * Defaults to pct=100 / isPending=false before the first fetch resolves, so
  * the header bar and per-metric caveats do not flash on initial page load.
- * Polling stops automatically when pct_complete reaches 100.
+ *
+ * Polling stops only when pct_complete=100 AND total_count>0 — i.e. the user
+ * has games and all of them are evaluated. A 0-game response (new user, or
+ * landing on /import before any games are imported) keeps polling, otherwise
+ * the header would never appear once an in-flight import starts landing rows
+ * (the backend short-circuits to pct=100 when total=0).
  *
  * All consumers on the same page share one in-flight request via the shared
  * queryKey ['imports', 'eval-coverage'] — TanStack Query deduplicates them.
@@ -22,8 +27,11 @@ export function useEvalCoverage() {
       return response.data;
     },
     staleTime: EVAL_COVERAGE_STALE_TIME_MS,
-    refetchInterval: (query) =>
-      query.state.data?.pct_complete === 100 ? false : EVAL_COVERAGE_POLL_INTERVAL_MS,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (data && data.pct_complete === 100 && data.total_count > 0) return false;
+      return EVAL_COVERAGE_POLL_INTERVAL_MS;
+    },
   });
 
   const data = query.data;

--- a/frontend/src/pages/Endgames.tsx
+++ b/frontend/src/pages/Endgames.tsx
@@ -358,7 +358,6 @@ export function EndgamesPage() {
 
   const statisticsContent = (
     <div className="flex flex-col gap-4">
-      <EvalCoverageHeader />
       <EndgameInsightsBlock
         appliedFilters={appliedFilters}
         rendered={matchingInsights}
@@ -730,6 +729,7 @@ export function EndgamesPage() {
           activePanel={sidebarOpen}
           onActivePanelChange={handleSidebarOpenChange}
         >
+          <EvalCoverageHeader />
           <Tabs value={activeTab} onValueChange={(val) => navigate(`/endgames/${val}`)}>
             <TabsList variant="brand" className="w-full" data-testid="endgames-tabs">
               <TabsTrigger value="stats" data-testid="tab-stats" className="flex-1">
@@ -766,6 +766,7 @@ export function EndgamesPage() {
 
         {/* Mobile: single column */}
         <div className="md:hidden flex flex-col min-w-0">
+          <EvalCoverageHeader />
           <Tabs value={activeTab} onValueChange={(val) => { navigate(`/endgames/${val}`); window.scrollTo({ top: 0 }); }}>
             {/* Sticky sub-navigation + filter button */}
             <div className="sticky top-0 z-20 flex items-center gap-2 h-[52px] bg-white/20 backdrop-blur-md rounded-md px-1 py-1" data-testid="endgames-mobile-control-row">

--- a/frontend/src/pages/GlobalStats.tsx
+++ b/frontend/src/pages/GlobalStats.tsx
@@ -9,6 +9,7 @@ import { FilterPanel, DEFAULT_FILTERS, areFiltersEqual, FILTER_DOT_FIELDS } from
 import { useFilterStore } from '@/hooks/useFilterStore';
 import { useGlobalStats, useRatingHistory } from '@/hooks/useStats';
 import { GlobalStatsCharts } from '@/components/stats/GlobalStatsCharts';
+import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 import { RatingChart } from '@/components/stats/RatingChart';
 import type { FilterState } from '@/components/filters/FilterPanel';
 
@@ -127,11 +128,13 @@ export function GlobalStatsPage() {
           activePanel={sidebarOpen}
           onActivePanelChange={setSidebarOpen}
         >
+          <EvalCoverageHeader />
           {content}
         </SidebarLayout>
 
         {/* Mobile: single column */}
         <div className="md:hidden flex flex-col gap-4 min-w-0">
+          <EvalCoverageHeader />
           {/* Sticky filter button (top right) */}
           <div className="sticky top-0 z-20 flex justify-end pb-2">
             <Tooltip content="Open filters" side="left">

--- a/frontend/src/pages/Import.tsx
+++ b/frontend/src/pages/Import.tsx
@@ -16,6 +16,7 @@ import { Tooltip } from '@/components/ui/tooltip';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useImportTrigger, useImportPolling } from '@/hooks/useImport';
+import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { useAuth } from '@/hooks/useAuth';
 import { useQueryClient } from '@tanstack/react-query';
@@ -206,6 +207,7 @@ export function ImportPage({ onImportStarted, activeJobIds, onJobDismissed }: Im
 
   return (
     <main data-testid="import-page" className="mx-auto w-full max-w-2xl px-4 py-6 md:px-6 space-y-8">
+      <EvalCoverageHeader />
       {profile?.is_guest && (
         <Alert variant="info" icon={DoorOpen} data-testid="import-guest-promo-info" className="mb-4">
           <div>

--- a/frontend/src/pages/Openings.tsx
+++ b/frontend/src/pages/Openings.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from '@/components/ui/tooltip';
 import { Input } from '@/components/ui/input';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { InfoPopover } from '@/components/ui/info-popover';
+import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
   Dialog,
@@ -772,6 +773,7 @@ export function OpeningsPage() {
             </Tooltip>
           }
         >
+          <EvalCoverageHeader />
           <Tabs
             value={activeTab}
             onValueChange={(val) => { navigate(`/openings/${val}`); window.scrollTo({ top: 0 }); }}
@@ -871,7 +873,9 @@ export function OpeningsPage() {
         </SidebarLayout>
 
         {/* Mobile: sticky subnav + non-sticky board (matches Endgames pattern, 71.1-02) */}
-        <Tabs value={activeTab} onValueChange={(val) => { navigate(`/openings/${val}`); window.scrollTo({ top: 0 }); }} className="lg:hidden flex flex-col gap-2 min-w-0">
+        <div className="lg:hidden flex flex-col min-w-0">
+          <EvalCoverageHeader />
+        <Tabs value={activeTab} onValueChange={(val) => { navigate(`/openings/${val}`); window.scrollTo({ top: 0 }); }} className="flex flex-col gap-2 min-w-0">
           {/* Sticky sub-navigation + filter button (D-05, D-11) */}
           {/* z-20 keeps subnav above ToggleGroupItem's focus:z-10 and below SidebarLayout panel z-40 */}
           <div
@@ -1177,6 +1181,7 @@ export function OpeningsPage() {
           <TabsContent value="stats" className="mt-2">{statsTabEl}</TabsContent>
           <TabsContent value="insights" className="mt-2">{insightsTabEl}</TabsContent>
         </Tabs>
+        </div>
       </main>
 
       {/* Bookmark label dialog */}

--- a/frontend/src/pages/openings/ExplorerTab.tsx
+++ b/frontend/src/pages/openings/ExplorerTab.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from 'react';
 import type { UseQueryResult } from '@tanstack/react-query';
 import { MoveExplorer } from '@/components/move-explorer/MoveExplorer';
 import { PositionResultsPanel } from '@/components/charts/PositionResultsPanel';
-import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 import type { Color, NextMovesResponse, OpeningsResponse } from '@/types/api';
 import type { HighlightedMove } from './useDeepLinkHighlight';
 
@@ -33,7 +32,6 @@ export function ExplorerTab({
 }: ExplorerTabProps) {
   return (
     <div className="flex flex-col gap-4">
-      <EvalCoverageHeader />
       {gamesData && (
         <PositionResultsPanel
           stats={gamesData.stats}

--- a/frontend/src/pages/openings/InsightsTab.tsx
+++ b/frontend/src/pages/openings/InsightsTab.tsx
@@ -1,7 +1,6 @@
 import type { FilterState } from '@/components/filters/FilterPanel';
 import type { OpeningInsightFinding } from '@/types/insights';
 import { OpeningInsightsBlock } from '@/components/insights/OpeningInsightsBlock';
-import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 
 type InsightsTabProps = {
   hasOpenings: boolean;
@@ -18,7 +17,6 @@ export function InsightsTab({
 }: InsightsTabProps) {
   return (
     <div className="flex flex-col gap-6">
-      <EvalCoverageHeader />
       {/* Phase 71: dedicated Insights subtab. */}
       {/* Hidden block + friendly empty state when user has no imported games (proxy: mostPlayedData empty). */}
       {hasOpenings ? (

--- a/frontend/src/pages/openings/StatsTab.tsx
+++ b/frontend/src/pages/openings/StatsTab.tsx
@@ -1,6 +1,5 @@
 import { BookMarked, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { EvalCoverageHeader } from '@/components/EvalCoverageHeader';
 import { InfoPopover } from '@/components/ui/info-popover';
 import { OpeningStatsSection, type OpeningStatsSectionDescriptor } from '@/components/stats/OpeningStatsSection';
 import { ScoreChart } from '@/components/charts/ScoreChart';
@@ -193,7 +192,6 @@ export function StatsTab({
 
   return (
     <div className="flex flex-col gap-6">
-      <EvalCoverageHeader />
       {/* Empty-state hint when there are no bookmarks at all */}
       {bookmarks.length === 0 && (
         <div className="charcoal-texture rounded-md p-4">

--- a/reports/phase91-import-stress-test-2026-05-21.md
+++ b/reports/phase91-import-stress-test-2026-05-21.md
@@ -1,0 +1,85 @@
+# Phase 91 import-pipeline stress test — 2026-05-21
+
+Repeat of the 2026-05-20 stress test that triggered a Postgres OOM-kill, now against the production deploy of **Phase 91 — Two-lane import: defer Stockfish eval to in-process cold drain** (PR [#130](https://github.com/flawchess/flawchess/pull/130)).
+
+**Workload:** simultaneous import of ~20k games each from chess.com and lichess for a single user (user_id 95).
+**Server:** Hetzner Cloud, 4 vCPU / 7.6 GB RAM / 4 GB swap.
+**Log:** [`logs/import-stress-20k-each-2026-05-21.log`](../logs/import-stress-20k-each-2026-05-21.log) — sampled every ~33 s.
+
+## TL;DR
+
+Phase 91 works. Yesterday's same workload OOM-killed Postgres around the 25-min mark with swap pinned at the 4 GB cap. Today's run completed end-to-end in 73 min, with swap peaking at 2.52 GB and the system never coming close to thrashing. As a side benefit, decoupling Stockfish from the fetch loop **roughly doubled chess.com fetch throughput**.
+
+## Timeline
+
+**Duration:** 04:12:07 → 05:24:58 UTC — **1 h 12 min 51 s** total.
+
+| Phase | Window (UTC) | Duration |
+|---|---|---|
+| Fetch (chess.com + lichess in parallel) | 04:12:30 → 04:45:00 | ~33 min |
+| Drain tail (post-fetch eval drain) | 04:45:00 → 05:24:58 | ~40 min |
+
+## Volume
+
+| Platform | Games imported | Games evaluated | Pending at end |
+|---|---|---|---|
+| chess.com | 20,262 | 20,262 | 0 |
+| lichess | 19,661 | 19,661 | 0 |
+| **Total** | **39,923** | **39,923** | **0** |
+
+## Throughput
+
+| Lane | Today (Phase 91) | Yesterday (Phase 41.1, inline eval) | Change |
+|---|---|---|---|
+| Fetch — chess.com | ~11 g/s | ~5.5 g/s | **2× faster** |
+| Fetch — lichess | ~11.5 g/s | ~11.6 g/s | flat (API-bound) |
+| Eval rate during fetch | ~140 evals/min combined | inline (no separate lane) | decoupled |
+| Eval rate during drain | ~700 evals/min combined | n/a | full CPU budget |
+
+### Why chess.com doubled and lichess didn't
+
+Lichess streams server-side evaluations directly in its NDJSON, so almost no local Stockfish work is needed per game and the fetch loop was never the bottleneck — both runs hit the same ~11.5 g/s NDJSON stream rate. Chess.com's API doesn't include evals, so every endgame position needs a local Stockfish call; under Phase 41.1, that ran inline in the fetch batch and serialised fetch behind eval. Phase 91 moves the Stockfish work to a parallel drain lane, freeing chess.com fetch to run at its natural API/CPU rate (~11 g/s), which happens to be roughly the lichess rate. The fact that the two converged is a coincidence of CPU contention between the two concurrent jobs, not API symmetry — a chess.com-only run would likely go faster still.
+
+## Memory — peaks vs yesterday's OOM curve
+
+| Metric | Today peak | Yesterday at OOM | Headroom today |
+|---|---|---|---|
+| backend RSS | 1.47 GiB | 1.56 GiB | comfortable, flat through run |
+| db RSS | 5.35 GiB | 5.42 GiB | comparable |
+| host mem used | 7.53 GB / 7.6 GB | 7.68 GB | ~150 MB |
+| swap used | **2.52 GB** | **4.10 GB (cap)** | **1.6 GB unused** |
+| `avail` | dipped to 212 MB once, recovered to 800+ MB | held at 62 MB before OOM | recovered cleanly |
+
+### Memory shape — what the new design does well
+
+- **Backend RSS stayed essentially flat** across the entire 73-minute run (1.30 → 1.47 GiB). The eval drain releases what it allocates each batch — no leak.
+- **Swap stabilised, did not climb without bound.** During fetch, swap climbed steadily from 327 MB to ~1.9 GB and then **plateaued** in the 1.6–2.5 GB range for the rest of the run. Yesterday's curve was monotonic growth straight to the 4 GB cap.
+- **`avail` recovered after each dip.** The kernel reclaimed page cache under pressure exactly as expected. Yesterday it stayed pinned in single-digit MB territory before Postgres got killed.
+
+## CPU profile
+
+| Phase | backend CPU | What it's doing |
+|---|---|---|
+| Idle baseline | ~0.5% | n/a |
+| Fetch (Phase 91) | 100–200% | fetch coroutines + concurrent drain workers |
+| Drain tail | 300–360% | 3+ cores on Stockfish workers, no fetch contention |
+| Fetch (yesterday, Phase 41.1) | 200–330% | fetch + inline Stockfish, contended |
+
+With the box having 4 vCPUs (400% total), Phase 91 actually uses more of the available CPU once fetch finishes — the drain lane finally gets the cores all to itself. That's why the drain phase is fast (~700 evals/min) even though the drain rate during fetch was only ~140/min.
+
+## Verdict
+
+1. **No OOM, no Postgres restart, no swap thrash.** The 2026-05-16 failure mode is fixed in production.
+2. **Throughput improved.** chess.com fetch is ~2× faster than the same workload under Phase 41.1. Lichess unchanged (it was never the bottleneck).
+3. **Failure surface is cleaner.** Backend RSS stays flat and swap reaches a steady state instead of climbing monotonically — the leading indicators that previously warned of imminent OOM no longer apply to this workload.
+4. **Trade-off is acceptable.** Phase 91 extends the wall-clock end-to-end time with a ~40-min post-fetch drain tail, but the games_imported counter advances at fetch rate (not eval rate), so user-visible "import done" arrives sooner. CPU is consumed entirely on the box during the drain, but it's bounded and predictable.
+
+## Next-step ideas (not part of this test)
+
+If chasing more throughput becomes worthwhile:
+
+- **Process-pool offload for position generation.** The fetch lane is now CPU-bound on a single asyncio thread doing python-chess parsing + Zobrist hashing. Spreading that across a `ProcessPoolExecutor` would unlock the 2–3 idle cores during fetch. Likely 2–3× chess.com fetch speedup.
+- **Bump `_BATCH_SIZE` from 12 back toward 24–28.** Safe now that Stockfish is out of the batch path. Modest win (~3–5%) because db isn't commit-bound at the current scale — db CPU sat at 20–30% throughout.
+- **`COPY` instead of `INSERT` for `game_positions`.** Worth checking if the import already uses it; the bulk-load protocol is 5–10× faster at this scale.
+
+None of these are required — the existing pipeline is now well within the box's headroom.

--- a/scripts/import_stress_monitor.py
+++ b/scripts/import_stress_monitor.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Stress-test monitor for the FlawChess import pipeline.
+
+Samples docker container memory/CPU, host memory/swap, and import-job
+progress at a fixed interval and writes the same plaintext block format as
+the historical reference logs:
+
+  - logs/import-stress-20k-each-2026-05-20.log (Phase 41.1 OOM run)
+  - logs/import-stress-20k-each-2026-05-21.log (Phase 91 follow-up)
+
+Two environments are supported:
+
+  --target dev   : sample local Docker on this machine, query the dev DB
+                   container (flawchess-dev-db-1) directly. No SSH.
+
+  --target prod  : sample Docker on the production server via SSH (default
+                   host: `flawchess`, matching CLAUDE.md), query the prod
+                   DB container (flawchess-db-1) via the same SSH session.
+                   You can sit in dev and monitor a live prod import.
+
+The script terminates automatically once every monitored import_job has
+reached a terminal status (completed/failed) AND the Stockfish eval
+pending count is zero — confirmed across two consecutive ticks to avoid
+exiting on a transient race. Override with --no-stop-on-complete to keep
+sampling indefinitely; --max-duration-min is a hard safety cap.
+
+Output block format (one block per tick):
+
+    === <ISO-8601 UTC timestamp> ===
+    flawchess-caddy-1 28.98MiB / 7.564GiB 0.37% CPU=0.00%
+    flawchess-backend-1 955.4MiB / 7.564GiB 12.33% CPU=0.19%
+    flawchess-umami-1 96.27MiB / 7.564GiB 1.24% CPU=0.00%
+    flawchess-db-1 2.705GiB / 7.564GiB 35.76% CPU=0.19%
+    mem used=4055M free=247M avail=3690M
+    swap used=327M
+    job: <uuid>|<platform>|<status>|<games_fetched>|<games_imported>|<games_evaluated>
+
+Typical use:
+
+    # Monitor a live prod import from your laptop:
+    uv run python scripts/import_stress_monitor.py --target prod
+
+    # Dev-side: run alongside a local dual-import (or measure_dual_import_rss.py):
+    uv run python scripts/import_stress_monitor.py --target dev
+
+For dev-side Phase 91 acceptance gates with structured pass/fail, use
+scripts/measure_dual_import_rss.py instead — this script is a lightweight
+black-box monitor with the historical log format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants — no magic numbers
+# ---------------------------------------------------------------------------
+
+DEFAULT_INTERVAL_S: int = 33
+DEFAULT_LOOKBACK_MIN: int = 90
+DEFAULT_LABEL: str = "import-stress"
+DEFAULT_OUT_DIR: Path = Path("logs")
+DEFAULT_MAX_DURATION_MIN: int = 240
+SHELL_TIMEOUT_S: float = 30.0
+
+# Two consecutive zero-pending readings before exit. Postgres replication of
+# evals_completed_at is not the issue here, but the cold-drain queue can
+# briefly empty between batches; one tick of grace prevents premature exit.
+REQUIRED_ZERO_STREAK: int = 2
+
+PROD_SSH_HOST: str = "flawchess"
+PROD_DB_CONTAINER: str = "flawchess-db-1"
+PROD_CONTAINER_PREFIX: str = "flawchess-"
+PROD_PG_USER_DEFAULT: str = "flawchess"
+PROD_PG_DB_DEFAULT: str = "flawchess"
+
+DEV_DB_CONTAINER: str = "flawchess-dev-db-1"
+DEV_CONTAINER_PREFIX: str = "flawchess-dev-"
+DEV_PG_USER_DEFAULT: str = "postgres"
+DEV_PG_DB_DEFAULT: str = "flawchess"
+
+TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "failed"})
+
+DOCKER_STATS_FMT: str = "{{.Name}} {{.MemUsage}} {{.MemPerc}} CPU={{.CPUPerc}}"
+
+logger = logging.getLogger("import_stress_monitor")
+
+
+# ---------------------------------------------------------------------------
+# Command runner — local or SSH
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Runner:
+    """Executes a shell command locally or via SSH.
+
+    When `ssh_host` is set, commands are forwarded with `ssh -o BatchMode=yes`,
+    which fails fast if the host requires interactive auth instead of hanging.
+    """
+
+    ssh_host: str | None
+
+    def run(self, cmd: str, timeout: float = SHELL_TIMEOUT_S) -> str:
+        if self.ssh_host:
+            argv = ["ssh", "-o", "BatchMode=yes", self.ssh_host, cmd]
+        else:
+            argv = ["bash", "-c", cmd]
+        try:
+            result = subprocess.run(
+                argv, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("command timed out after %ss: %s", timeout, cmd[:80])
+            return ""
+        except FileNotFoundError as exc:
+            logger.error("required binary missing: %s", exc)
+            return ""
+        if result.returncode != 0 and result.stderr.strip():
+            logger.debug("non-zero exit (%s): %s", result.returncode, result.stderr.strip()[:200])
+        return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Collectors
+# ---------------------------------------------------------------------------
+
+
+def collect_docker_stats(runner: Runner, prefix: str) -> str:
+    """One `docker stats` snapshot, optionally filtered to containers whose
+    name starts with `prefix`. Empty `prefix` returns all containers."""
+    raw = runner.run(f"docker stats --no-stream --format '{DOCKER_STATS_FMT}'")
+    if not raw.strip():
+        return ""
+    if not prefix:
+        return raw.strip()
+    return "\n".join(line for line in raw.splitlines() if line.startswith(prefix))
+
+
+def collect_host_memory(runner: Runner) -> str:
+    """Two lines: `mem used=... free=... avail=...` + `swap used=...` in MB.
+
+    Matches the historical log format exactly (`free -m` column layout:
+    total used free shared buff/cache available)."""
+    raw = runner.run("free -m")
+    mem_line = ""
+    swap_line = ""
+    for line in raw.splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        if parts[0] == "Mem:" and len(parts) >= 7:
+            mem_line = f"mem used={parts[2]}M free={parts[3]}M avail={parts[6]}M"
+        elif parts[0] == "Swap:" and len(parts) >= 3:
+            swap_line = f"swap used={parts[2]}M"
+    return "\n".join(x for x in (mem_line, swap_line) if x)
+
+
+def build_job_query(lookback_min: int, user_id: int | None) -> str:
+    """SQL that emits one `job: ...` line per recent import.
+
+    The third numeric column is `games_evaluated` for that user+platform —
+    i.e. games whose Stockfish eval finished. Joining via user+platform is
+    accurate because import_jobs uniquely scope a (user, platform) pair."""
+    user_filter = f" AND i.user_id = {int(user_id)}" if user_id is not None else ""
+    return f"""
+SELECT 'job: ' || i.id
+            || '|' || i.platform
+            || '|' || i.status
+            || '|' || i.games_fetched
+            || '|' || i.games_imported
+            || '|' || COALESCE((
+                 SELECT count(*) FROM games g
+                  WHERE g.user_id = i.user_id
+                    AND g.platform = i.platform
+                    AND g.evals_completed_at IS NOT NULL
+               ), 0)
+  FROM import_jobs i
+ WHERE i.started_at >= NOW() - INTERVAL '{int(lookback_min)} minutes'{user_filter}
+ ORDER BY i.started_at;
+""".strip()
+
+
+def _psql_exec(runner: Runner, db_container: str, pg_user: str, pg_db: str, sql: str) -> str:
+    cmd = (
+        f"docker exec -i {shlex.quote(db_container)} "
+        f"psql -U {shlex.quote(pg_user)} -d {shlex.quote(pg_db)} -tAc {shlex.quote(sql)}"
+    )
+    return runner.run(cmd).strip()
+
+
+def collect_jobs(
+    runner: Runner, db_container: str, pg_user: str, pg_db: str, query: str
+) -> tuple[str, list[str]]:
+    """Run the per-job query; return (raw_output, list_of_statuses)."""
+    out = _psql_exec(runner, db_container, pg_user, pg_db, query)
+    statuses: list[str] = []
+    for line in out.splitlines():
+        if not line.startswith("job: "):
+            continue
+        parts = line[len("job: ") :].split("|")
+        if len(parts) >= 3:
+            statuses.append(parts[2])
+    return out, statuses
+
+
+def collect_pending_eval_count(
+    runner: Runner,
+    db_container: str,
+    pg_user: str,
+    pg_db: str,
+    lookback_min: int,
+    user_id: int | None,
+) -> int | None:
+    """Games still pending Stockfish eval, scoped to either a specific user
+    or all users with import_jobs started in the lookback window.
+
+    Returns None if the query failed (treat as "don't exit yet")."""
+    if user_id is not None:
+        sql = (
+            f"SELECT count(*) FROM games WHERE evals_completed_at IS NULL "
+            f"AND user_id = {int(user_id)};"
+        )
+    else:
+        sql = (
+            "SELECT count(*) FROM games g WHERE g.evals_completed_at IS NULL "
+            f"AND g.user_id IN (SELECT DISTINCT user_id FROM import_jobs "
+            f"WHERE started_at >= NOW() - INTERVAL '{int(lookback_min)} minutes');"
+        )
+    out = _psql_exec(runner, db_container, pg_user, pg_db, sql)
+    try:
+        return int(out)
+    except ValueError:
+        logger.debug("could not parse pending count from psql output: %r", out)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def _iso_utc_now() -> str:
+    """ISO-8601 with `+00:00` offset (colon-separated) — matches existing log."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--target",
+        choices=["dev", "prod"],
+        default="dev",
+        help="Environment to monitor. dev=local docker, prod=SSH to flawchess host.",
+    )
+    ap.add_argument(
+        "--ssh-host",
+        default=None,
+        help=f"SSH host when --target=prod (default: {PROD_SSH_HOST}).",
+    )
+    ap.add_argument("--interval", type=int, default=DEFAULT_INTERVAL_S, help="Sample interval (s).")
+    ap.add_argument("--lookback-min", type=int, default=DEFAULT_LOOKBACK_MIN)
+    ap.add_argument("--label", default=DEFAULT_LABEL, help="Filename label when --out is omitted.")
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output log path. Defaults to logs/<label>-<env>-<date>.log.",
+    )
+    ap.add_argument("--db-container", default=None, help="Override Postgres container name.")
+    ap.add_argument(
+        "--container-prefix",
+        default=None,
+        help="Container-name prefix filter for docker stats. Pass '' for all containers.",
+    )
+    ap.add_argument("--pg-user", default=None)
+    ap.add_argument("--pg-db", default=None)
+    ap.add_argument(
+        "--user-id",
+        type=int,
+        default=None,
+        help="Restrict monitoring (and the eval-pending count) to a single user_id.",
+    )
+    ap.add_argument(
+        "--no-stop-on-complete",
+        action="store_true",
+        help="Keep sampling even after all imports are terminal and evals=0.",
+    )
+    ap.add_argument(
+        "--max-duration-min",
+        type=int,
+        default=DEFAULT_MAX_DURATION_MIN,
+        help="Safety cap on total monitor runtime (minutes).",
+    )
+    ap.add_argument("--verbose", "-v", action="store_true")
+    return ap.parse_args(argv)
+
+
+def _resolve_env_defaults(args: argparse.Namespace) -> tuple[str | None, str, str, str, str]:
+    """Return (ssh_host, db_container, container_prefix, pg_user, pg_db) for the target."""
+    is_prod = args.target == "prod"
+    ssh_host: str | None
+    if is_prod:
+        ssh_host = args.ssh_host or PROD_SSH_HOST
+    else:
+        # In dev, --ssh-host is still honoured if explicitly passed (e.g. for a
+        # remote dev box), but defaults to local execution.
+        ssh_host = args.ssh_host
+    db_container = args.db_container or (PROD_DB_CONTAINER if is_prod else DEV_DB_CONTAINER)
+    container_prefix = (
+        args.container_prefix
+        if args.container_prefix is not None
+        else (PROD_CONTAINER_PREFIX if is_prod else DEV_CONTAINER_PREFIX)
+    )
+    pg_user = args.pg_user or (PROD_PG_USER_DEFAULT if is_prod else DEV_PG_USER_DEFAULT)
+    pg_db = args.pg_db or (PROD_PG_DB_DEFAULT if is_prod else DEV_PG_DB_DEFAULT)
+    return ssh_host, db_container, container_prefix, pg_user, pg_db
+
+
+def _preflight(runner: Runner, db_container: str) -> None:
+    """Fail fast if docker isn't reachable or the DB container is missing.
+
+    Raises SystemExit with a clear message instead of silently producing empty
+    blocks every tick."""
+    docker_ok = runner.run("docker version --format '{{.Server.Version}}'").strip()
+    if not docker_ok:
+        raise SystemExit(
+            "import_stress_monitor: cannot reach docker on the target host. "
+            "Check that Docker is running and (for --target prod) that you can `ssh flawchess docker ps`."
+        )
+    inspect = runner.run(f"docker inspect -f '{{{{.State.Status}}}}' {shlex.quote(db_container)}")
+    if "running" not in inspect:
+        raise SystemExit(
+            f"import_stress_monitor: DB container {db_container!r} is not running on the target host "
+            f"(docker inspect returned: {inspect.strip() or 'no output'}). "
+            "Pass --db-container to override if your stack uses a different name."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+
+    ssh_host, db_container, container_prefix, pg_user, pg_db = _resolve_env_defaults(args)
+    runner = Runner(ssh_host=ssh_host)
+
+    out_path = args.out or (
+        DEFAULT_OUT_DIR
+        / f"{args.label}-{args.target}-{datetime.now(timezone.utc).strftime('%Y-%m-%d')}.log"
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _preflight(runner, db_container)
+
+    job_query = build_job_query(args.lookback_min, args.user_id)
+    deadline = time.monotonic() + args.max_duration_min * 60
+    eval_zero_streak = 0
+
+    logger.info(
+        "target=%s ssh=%s db=%s prefix=%r writing=%s every=%ss",
+        args.target,
+        ssh_host or "local",
+        db_container,
+        container_prefix,
+        out_path,
+        args.interval,
+    )
+
+    # Cooperative termination on SIGINT/SIGTERM — finish the current tick,
+    # flush the file, then exit. Avoids a half-written block at the tail.
+    stop_requested = False
+
+    def _request_stop(signum: int, _frame: object) -> None:
+        nonlocal stop_requested
+        logger.info("signal %s received, stopping after this tick", signum)
+        stop_requested = True
+
+    signal.signal(signal.SIGINT, _request_stop)
+    signal.signal(signal.SIGTERM, _request_stop)
+
+    exit_reason = "interrupted"
+    with out_path.open("a", encoding="utf-8") as fh:
+        while not stop_requested:
+            ts = _iso_utc_now()
+            fh.write(f"=== {ts} ===\n")
+
+            stats = collect_docker_stats(runner, container_prefix)
+            if stats:
+                fh.write(stats + "\n")
+
+            mem = collect_host_memory(runner)
+            if mem:
+                fh.write(mem + "\n")
+
+            jobs_raw, statuses = collect_jobs(runner, db_container, pg_user, pg_db, job_query)
+            if jobs_raw:
+                fh.write(jobs_raw + "\n")
+
+            fh.flush()
+
+            # Stop condition: every observed job is terminal AND eval queue is
+            # empty for two consecutive ticks. If there are zero jobs in the
+            # window we don't auto-stop (probably nothing started yet).
+            if not args.no_stop_on_complete and statuses:
+                all_terminal = all(s in TERMINAL_STATUSES for s in statuses)
+                if all_terminal:
+                    pending = collect_pending_eval_count(
+                        runner, db_container, pg_user, pg_db, args.lookback_min, args.user_id
+                    )
+                    if pending == 0:
+                        eval_zero_streak += 1
+                        logger.info(
+                            "all jobs terminal, pending evals = 0 (streak %d/%d)",
+                            eval_zero_streak,
+                            REQUIRED_ZERO_STREAK,
+                        )
+                        if eval_zero_streak >= REQUIRED_ZERO_STREAK:
+                            exit_reason = "evals complete"
+                            break
+                    else:
+                        if pending is not None:
+                            logger.info("all jobs terminal, but %d eval(s) still pending", pending)
+                        eval_zero_streak = 0
+                else:
+                    eval_zero_streak = 0
+
+            if time.monotonic() >= deadline:
+                exit_reason = "max-duration cap"
+                break
+
+            # Sleep in 1s slices so SIGINT/SIGTERM is responsive.
+            for _ in range(args.interval):
+                if stop_requested:
+                    break
+                time.sleep(1)
+
+    logger.info("exit: %s — log: %s", exit_reason, out_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What's shipping

### Fixed
- Shorter Stockfish header copy, now shown on all main pages

### Chore / Ops
- New `/deploy` skill for autonomous main→production releases
- `import_stress_monitor.py` for dev + prod import-pipeline monitoring
- Pre-PR ruff/ty gate documented in CLAUDE.md + installable pre-push hook (#132)

### Docs / Planning
- Phase 91 import-pipeline stress test report (2026-05-21)
- SEED-024: ProcessPoolExecutor for chess.com fetch

## Commits

- 017b3f26 chore: add pre-PR ruff/ty gate to CLAUDE.md + installable pre-push hook (#132)
- c3544d75 docs(reports): add Phase 91 import-pipeline stress test report (2026-05-21)
- cd58257a chore(ops): add import_stress_monitor.py for dev + prod monitoring
- 6aa1a81b fix(ui): shorten Stockfish header copy + show on all main pages
- 4c15bc53 docs(planning): plant SEED-024 (ProcessPoolExecutor for chess.com fetch)
- b8aa06e2 chore(skills): add deploy skill for autonomous main→production releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)