### PR TITLE
Phase 95: asyncpg COPY for bulk position inserts + post-eval reload

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -22,15 +22,33 @@
 - ✅ **v1.17 Endgame Stats Card Redesign** — Phases 84-88.4 (shipped 2026-05-19; Phase 89 dropped, 87.3 superseded) — see [milestones/v1.17-ROADMAP.md](milestones/v1.17-ROADMAP.md)
 - ✅ **v1.18 Import Pipeline Hardening** — Phases 90, 91, 92 (shipped 2026-05-22; PRs #130, #137, #138 + hotfix #139) — see [milestones/v1.18-ROADMAP.md](milestones/v1.18-ROADMAP.md)
 - ✅ **v1.19 Endgame Percentiles** — Phases 93, 94, 94.1, 94.2, 94.3, 94.4 (shipped 2026-05-27; Phase 95 split into v1.20 before milestone close) — see [milestones/v1.19-ROADMAP.md](milestones/v1.19-ROADMAP.md)
-- 🔄 **v1.20 LLM Statistical Reasoning** — Phase 95 (not started)
+- 🔄 **v1.20 LLM Statistical Reasoning** — Phase 96 (not started)
 
 ## Phases
 
-- [ ] **Phase 95: LLM Endgame-Insights Statistical-Reasoning Rework** *(v1.20)* — Payload extension (p-values, CI bounds, percentiles) + prompt rewrite reasoning over CIs/percentiles with guardrails, prompt version bump from `endgame_v35`, UAT pass
+- [ ] **Phase 95: asyncpg COPY for `bulk_insert_positions`** *(standalone hardening, no milestone)* — Switch the heaviest INSERT in the import pipeline from parameterized `INSERT … VALUES(...)` to asyncpg `copy_records_to_table` (binary COPY) to cut per-backend memory pressure during dual-platform imports. Follow-up to SEED-027 Thread A (PR #144 container budget hotfix).
+- [ ] **Phase 96: LLM Endgame-Insights Statistical-Reasoning Rework** *(v1.20)* — Payload extension (p-values, CI bounds, percentiles) + prompt rewrite reasoning over CIs/percentiles with guardrails, prompt version bump from `endgame_v35`, UAT pass
 
 ## Phase Details
 
-### Phase 95: LLM Endgame-Insights Statistical-Reasoning Rework
+### Phase 95: asyncpg COPY for `bulk_insert_positions`
+
+**Goal**: Switch `bulk_insert_positions` in `app/repositories/game_repository.py` from SQLAlchemy `insert(GamePosition).values(chunk)` to asyncpg's binary `Connection.copy_records_to_table` to reduce per-backend Postgres memory during the import hot-lane burst. SEED-027 Thread A (container memory budget) shipped 2026-05-26 via hotfix PR #144 — Thread B remains and is the subject of this phase. `bulk_insert_games` stays on `pg_insert(...).values(...)` because it relies on `ON CONFLICT DO NOTHING` (COPY can't express that). Atomicity vs `bulk_insert_games` is preserved by enrolling the COPY in the active SQLAlchemy session transaction. No feature flag — rollback is a single revert away. Verify under a dual-platform stress test mirroring Phase 91's setup; acceptance is no `ConnectionDoesNotExistError` and lower peak `flawchess-db-1` cgroup memory than the pre-COPY baseline.
+**Depends on**: none (Thread A already deployed at prod SHA 65511c9)
+**Requirements**: standalone — no requirement IDs (hardening / bugfix follow-up to FLAWCHESS-3Q)
+**Success Criteria** (what must be TRUE):
+
+  1. `bulk_insert_positions` uses `asyncpg.Connection.copy_records_to_table` for the inner write path; no `INSERT … VALUES(...)` remains in the function body for the position table.
+  2. Column order passed to COPY matches `GamePosition.__table__.columns` exactly, including nullable columns (`eval_cp`, `eval_mate`, `endgame_class`, `piece_count`, …), with `None` for absent values; mapper coverage is asserted in a unit test.
+  3. The COPY runs inside the existing SQLAlchemy session transaction (rolls back atomically with `bulk_insert_games` on failure); proven by a test that triggers a post-COPY exception and asserts both tables are empty afterwards.
+  4. `bulk_insert_games` is untouched and still uses `pg_insert(...).values(...)` with `ON CONFLICT DO NOTHING`.
+  5. Dual-platform stress test on local dev DB (seeded with user 109's import workload, or a 7k+ game multi-platform user) completes with both jobs `status='completed'`, `games_imported == games_fetched`, and no `ConnectionDoesNotExistError` in either job's `error_message`. Peak `flawchess-db-1` cgroup memory stays under 9 GB (75% of the 12 GB cap shipped in PR #144).
+  6. Existing import unit + integration tests pass unchanged. New tests cover: column-order parity with `GamePosition` model, transaction rollback atomicity, empty-batch no-op, NULL handling for the eval columns.
+  7. `pg_stat_statements` top-20 mean-time check (dev DB before/after) shows no analytics-query regression > 20%. Sanity only — write-path change shouldn't affect read latency, but cheap to verify.
+
+**Plans**: TBD
+
+### Phase 96: LLM Endgame-Insights Statistical-Reasoning Rework
 
 **Goal**: Rework the endgame-insights LLM payload + prompt so the model reasons explicitly over the v1.17 statistical-rigor metric set (Phase 85.1 / 86 / 87.2 / 87.6 / 88 — Endgame Score Gap & Achievable Score family, Section 2 ΔES Score Gap family, Time Pressure hypothesis tests) using p-values, confidence interval bounds, and the new Phase 94 percentile annotations. Preserve the prior `feedback_llm_significance_signal` decision — the cohort `zone` field remains the gate on whether a metric is narrated; CIs / p-values / percentiles inform *how* once a zone-driven narration decision has been made. Bump the endgame prompt version from `endgame_v35`, leave cache invalidation to the `_PROMPT_VERSION` cache key, and validate via at least one UAT pass over representative production users.
 **Depends on**: Phase 94 (LLM-05 percentile narration requires PCTL-02 emission)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -325,7 +325,7 @@ See [milestones/v1.15-ROADMAP.md](milestones/v1.15-ROADMAP.md) for full details.
 | 90-92. v1.18 phases | v1.18 | 17/17 | Complete | 2026-05-22 |
 | 93. Global Percentile Benchmark Artifact | v1.19 | 2/2 | Complete    | 2026-05-22 |
 | 94. Backend & Frontend Percentile Annotations | v1.19 | 3/3 | Complete   | 2026-05-23 |
-| 95. LLM Endgame-Insights Statistical-Reasoning Rework | v1.20 | 0/TBD | Not started | - |
+| 95. LLM Endgame-Insights Statistical-Reasoning Rework | v1.20 | 1/2 | In Progress|  |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: LLM Statistical Reasoning
-status: "v1.19 shipped — milestone archived; v1.20 not started"
-last_updated: "2026-05-27T15:30:00.000Z"
-last_activity: 2026-05-27
+status: executing
+last_updated: "2026-05-27T17:53:37.935Z"
+last_activity: 2026-05-27 -- Phase 95 execution started
 progress:
-  total_phases: 2
+  total_phases: 6
   completed_phases: 0
-  total_plans: 0
+  total_plans: 2
   completed_plans: 0
   percent: 0
 ---
@@ -17,10 +17,10 @@ progress:
 
 ## Current Position
 
-Phase: 95 (standalone hardening — asyncpg COPY for `bulk_insert_positions`; SEED-027 Thread B)
-Plan: Not started
-Status: v1.19 shipped 2026-05-27; v1.20 LLM Statistical Reasoning Phase 96 not started. Phase 95 inserted 2026-05-27 as a standalone import-hardening phase before v1.20 kicks off — the prior Phase 95 (LLM rework) was renumbered to 96.
-Last activity: 2026-05-27
+Phase: 95 (asyncpg-copy-positions) — EXECUTING
+Plan: 1 of 2
+Status: Executing Phase 95
+Last activity: 2026-05-27 -- Phase 95 execution started
 
 ## Project Reference
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,7 +6,7 @@ status: "v1.19 shipped — milestone archived; v1.20 not started"
 last_updated: "2026-05-27T15:30:00.000Z"
 last_activity: 2026-05-27
 progress:
-  total_phases: 1
+  total_phases: 2
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -17,16 +17,16 @@ progress:
 
 ## Current Position
 
-Phase: 95
+Phase: 95 (standalone hardening — asyncpg COPY for `bulk_insert_positions`; SEED-027 Thread B)
 Plan: Not started
-Status: v1.19 shipped 2026-05-27 — milestone archived; v1.20 LLM Statistical Reasoning not started
+Status: v1.19 shipped 2026-05-27; v1.20 LLM Statistical Reasoning Phase 96 not started. Phase 95 inserted 2026-05-27 as a standalone import-hardening phase before v1.20 kicks off — the prior Phase 95 (LLM rework) was renumbered to 96.
 Last activity: 2026-05-27
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-05-27 after v1.19 milestone)
 Core value: Position-precise WDL across openings + endgames + time pressure on top of users' actual chess.com / lichess games, with personalized LLM commentary on endgame performance and an auto-generated opening-strengths/weaknesses report.
-Current focus: v1.19 Endgame Percentiles shipped 2026-05-27 — peer-relative percentile chips on Endgames page (per-(metric, ELO anchor, TC) cohort CDFs, per-user blended platform rating anchors, 4-bullet tooltip with rating-anchor disclosure, filter-independent). 12 per-TC chips on Time Pressure cards. Phase 95 split into v1.20 LLM Statistical Reasoning. Run `/gsd-discuss-phase 95` to start the LLM rework, or refine v1.20 scope first.
+Current focus: v1.19 Endgame Percentiles shipped 2026-05-27 — peer-relative percentile chips on Endgames page (per-(metric, ELO anchor, TC) cohort CDFs, per-user blended platform rating anchors, 4-bullet tooltip with rating-anchor disclosure, filter-independent). 12 per-TC chips on Time Pressure cards. The prior Phase 95 (LLM Statistical Reasoning rework) was renumbered to Phase 96 (v1.20) on 2026-05-27 to make room for a standalone hardening phase. New Phase 95 (SEED-027 Thread B) switches `bulk_insert_positions` to asyncpg `copy_records_to_table` to finish closing FLAWCHESS-3Q — Thread A (container memory budget) shipped 2026-05-26 via hotfix PR #144 at prod SHA 65511c9. Run `/gsd-plan-phase 95` next, then `/gsd-discuss-phase 96` for the LLM rework.
 
 ## Milestone Progress
 

--- a/.planning/phases/95-asyncpg-copy-positions/95-01-PLAN.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-01-PLAN.md
@@ -1,0 +1,228 @@
+---
+phase: 95-asyncpg-copy-positions
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - app/repositories/game_repository.py
+  - tests/test_game_repository_bulk_insert_positions.py
+autonomous: true
+requirements: []
+
+must_haves:
+  truths:
+    - "bulk_insert_positions calls asyncpg Connection.copy_records_to_table — no insert(GamePosition).values(...) remains in the function body."
+    - "The asyncpg Connection is acquired from the SQLAlchemy AsyncSession via (await session.connection()).get_raw_connection().driver_connection — not a fresh engine connection."
+    - "The explicit columns tuple in bulk_insert_positions is set-equal to {c.name for c in GamePosition.__table__.columns if c.name != 'id'} — asserted by a unit test."
+    - "Records are tuples of dict.get(col) values; missing optional keys become None — asserted by a unit test that inserts rows with only required fields."
+    - "bulk_insert_games is byte-identical to its pre-phase form — still uses pg_insert(...).values(...).on_conflict_do_nothing(constraint='uq_games_user_platform_game_id').returning(Game.id)."
+    - "The COPY runs inside the existing session transaction — proven by a test that triggers a post-COPY exception in the same session and asserts both `games` and `game_positions` are empty after rollback."
+    - "Empty position_rows is a no-op (early return, no asyncpg round-trip)."
+    - "Chunking at chunk_size=1700 is retained for asyncio yield + Python memory ceiling; comment is rewritten to reflect the new rationale (not the 32k-param ceiling, which no longer applies under COPY)."
+  artifacts:
+    - path: app/repositories/game_repository.py
+      provides: bulk_insert_positions reimplemented on asyncpg copy_records_to_table
+      contains: "copy_records_to_table"
+    - path: tests/test_game_repository_bulk_insert_positions.py
+      provides: column-coverage + round-trip + null-optional + empty-batch + rollback + chunking tests
+      contains: "def test_bulk_insert_positions_column_coverage"
+  key_links:
+    - from: app/repositories/game_repository.py
+      to: app/models/game_position.py
+      via: "explicit columns tuple in bulk_insert_positions"
+      pattern: "set-equality asserted by test_bulk_insert_positions_column_coverage"
+    - from: app/repositories/game_repository.py
+      to: app/services/import_service.py
+      via: "unchanged signature (session, position_rows) -> None"
+      pattern: "caller at import_service.py:686 needs no change"
+---
+
+<objective>
+Reimplement `bulk_insert_positions` in `app/repositories/game_repository.py` on top of asyncpg's binary `Connection.copy_records_to_table` and prove the change is correct via six unit/integration tests covering column coverage, round-trip, NULL handling, empty-batch no-op, transaction-rollback atomicity, and chunking across the `chunk_size` boundary.
+
+Purpose: close the per-backend memory pressure leg of FLAWCHESS-3Q. The current `insert(GamePosition).values(chunk)` materialises ~32k bound parameters per 1700-row chunk in Postgres's parser/executor memory; the COPY protocol streams the same rows as a binary blob in roughly constant per-backend memory. SEED-027 Thread A (container memory budget) shipped 2026-05-26 in PR #144 — this plan finishes Thread B.
+
+Output: one modified repository function, one new test file. No caller-side changes; `bulk_insert_games` untouched; no schema or migration.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/seeds/SEED-027-db-memory-budget-and-positions-copy.md
+@.planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md
+@app/repositories/game_repository.py
+@app/models/game_position.py
+@app/services/import_service.py
+@tests/test_reclassify.py
+
+<interfaces>
+<!-- Public surface of game_repository.py (unchanged externally; bulk_insert_positions internals are reshaped). -->
+
+async def bulk_insert_games(session: AsyncSession, game_rows: list[dict]) -> list[int]  # UNTOUCHED
+async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]) -> None  # RESHAPED body — same signature
+
+Acquired from SQLAlchemy AsyncSession:
+  raw_conn = (await session.connection()).get_raw_connection().driver_connection
+  # raw_conn is an asyncpg.Connection; participates in the session's transaction.
+
+asyncpg API used:
+  await raw_conn.copy_records_to_table(
+      "game_positions",
+      records=[tuple(...), ...],
+      columns=("game_id", "user_id", "ply", ...),
+  )
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Write the six failing tests first</name>
+  <files>tests/test_game_repository_bulk_insert_positions.py</files>
+  <read_first>
+    - app/repositories/game_repository.py (current bulk_insert_positions at lines 161-187 — full file)
+    - app/models/game_position.py (full file — column list is the source of truth)
+    - tests/test_reclassify.py (lines 60-110 — existing call-pattern fixture for bulk_insert_games + bulk_insert_positions; reuse the user/game shape)
+    - tests/conftest.py if exists, otherwise tests/__init__.py — find the existing async session fixture name (likely `db_session` based on test_reclassify.py:75)
+    - .planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md (D-2 column policy, D-3 NULL policy, D-7 rollback strategy)
+  </read_first>
+  <action>
+    Create a new test file `tests/test_game_repository_bulk_insert_positions.py` with six async tests that share the project's existing `db_session` (or equivalent) async fixture. The file must import `bulk_insert_positions` and `bulk_insert_games` from `app.repositories.game_repository`, `GamePosition` from `app.models.game_position`, and `Game` from `app.models.game`. All tests run against the live dev Postgres (no mocks of the DB; use the same fixture that `tests/test_reclassify.py` uses). Each test gets a freshly inserted user + game via `bulk_insert_games` so position rows have valid FK targets.
+
+    Test bodies (one test per behavior assertion below; write the test that currently fails, do not implement the production change yet):
+
+    1. `test_bulk_insert_positions_column_coverage` — import `GamePosition` and `bulk_insert_positions`. Open the source of `bulk_insert_positions` (via `inspect.getsource`) and parse the explicit `columns` tuple literal — OR (preferred) expose `_POSITION_COPY_COLUMNS` as a module-level constant in step 2 and import it directly. Assert `set(_POSITION_COPY_COLUMNS) == {c.name for c in GamePosition.__table__.columns if c.name != "id"}`. The constant must NOT contain `"id"` (autogenerated PK).
+
+    2. `test_bulk_insert_positions_round_trip` — insert one Game via `bulk_insert_games` to get a real `game_id`. Build 3 `position_rows` dicts populating **every** non-id column with deterministic test values (e.g. `ply` 0, 1, 2; distinct hashes; populated `eval_cp`, `eval_mate`, `endgame_class`, etc.). Call `bulk_insert_positions(session, rows)` then `session.flush()`. SELECT all GamePosition rows where `game_id == new_game_id` ordered by `ply`. Assert exactly 3 rows returned and every column round-trips byte-for-byte against the input dict.
+
+    3. `test_bulk_insert_positions_null_optional_fields` — insert one Game. Build 2 `position_rows` dicts containing ONLY the required keys (`game_id`, `user_id`, `ply`, `full_hash`, `white_hash`, `black_hash`). Omit every optional key (`move_san`, `clock_seconds`, `material_count`, `material_signature`, `material_imbalance`, `has_opposite_color_bishops`, `piece_count`, `backrank_sparse`, `mixedness`, `phase`, `eval_cp`, `eval_mate`, `endgame_class`). Call `bulk_insert_positions`. SELECT back. Assert every optional column reads back as `None`.
+
+    4. `test_bulk_insert_positions_empty_batch_noop` — call `bulk_insert_positions(session, [])`. Assert no exception, no DB round-trip (use `unittest.mock.patch` on `AsyncSession.connection` to assert it is **not** called when the input list is empty — proves the early return short-circuits before connection acquisition).
+
+    5. `test_bulk_insert_positions_rollback_atomicity` — open a session, insert a Game via `bulk_insert_games`, insert 5 positions via `bulk_insert_positions`, then within the **same** session, deliberately trigger an `IntegrityError` (e.g. attempt a second `bulk_insert_games` of the SAME `(user_id, platform, platform_game_id)` triple with `pg_insert(Game).values(...)` WITHOUT `on_conflict_do_nothing`, or use a manual `INSERT INTO games (id) VALUES (1)` to violate the PK). Catch the exception, call `session.rollback()`. Open a fresh session and SELECT — assert both `games` and `game_positions` are empty for this user. Proves the COPY enrolled in the session transaction (per D-7).
+
+    6. `test_bulk_insert_positions_chunking_across_chunk_size` — insert one Game. Build `chunk_size + 1` (= 1701) position rows with sequential `ply` values 0..1700 and unique `full_hash` values (`ply | 0xFF00000000000000` works). Call `bulk_insert_positions`. SELECT `COUNT(*)` for the game_id — assert exactly 1701. Proves the chunk loop is correct after the protocol-param-ceiling reason for chunking went away (COPY has no 32k-param limit; the loop is still load-bearing for asyncio yields and bounded Python memory).
+  </action>
+  <acceptance_criteria>
+    - File `tests/test_game_repository_bulk_insert_positions.py` exists and contains exactly six async test functions named per Task 1 above.
+    - `uv run pytest tests/test_game_repository_bulk_insert_positions.py --collect-only` reports 6 tests collected with no collection errors.
+    - `uv run pytest tests/test_game_repository_bulk_insert_positions.py -x` fails (RED) — tests reference behaviors not yet implemented (the `_POSITION_COPY_COLUMNS` constant doesn't exist; the empty-batch test asserts `session.connection` is NOT called which may pass against the current implementation but other tests fail).
+    - `uv run ruff check tests/test_game_repository_bulk_insert_positions.py` passes (zero lint).
+    - `uv run ruff format --check tests/test_game_repository_bulk_insert_positions.py` passes.
+  </acceptance_criteria>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Reimplement bulk_insert_positions on asyncpg COPY</name>
+  <files>app/repositories/game_repository.py</files>
+  <read_first>
+    - app/repositories/game_repository.py (full file — modify in place)
+    - app/models/game_position.py (column list — source of truth for the explicit `_POSITION_COPY_COLUMNS` tuple)
+    - .planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md (D-1 connection acquisition chain, D-2 column policy, D-3 NULL handling, D-5 empty-batch)
+  </read_first>
+  <action>
+    Replace the body of `bulk_insert_positions` in `app/repositories/game_repository.py` (currently lines 161-187) with the asyncpg COPY path. Concrete shape:
+
+    1. At module scope, define `_POSITION_COPY_COLUMNS: tuple[str, ...] = ("game_id", "user_id", "ply", "full_hash", "white_hash", "black_hash", "move_san", "clock_seconds", "material_count", "material_signature", "material_imbalance", "has_opposite_color_bishops", "piece_count", "backrank_sparse", "mixedness", "phase", "eval_cp", "eval_mate", "endgame_class")`. The set must equal `{c.name for c in GamePosition.__table__.columns if c.name != "id"}` — Task 1's first test enforces this.
+
+    2. Keep `bulk_insert_positions`'s signature `(session: AsyncSession, position_rows: list[dict]) -> None` exactly. Keep the `if not position_rows: return` early return at the top — it must short-circuit BEFORE `session.connection()` is awaited (Task 1 test 4).
+
+    3. Acquire the asyncpg Connection inside the function (NOT at module scope):
+
+       ```python
+       raw_conn = (await session.connection()).get_raw_connection().driver_connection
+       ```
+
+       This pulls the asyncpg `Connection` out of SQLAlchemy's async wrapper while keeping the session's active transaction.
+
+    4. Keep `chunk_size = 1700` and the existing `for i in range(0, len(position_rows), chunk_size)` loop shape. Inside the loop, build `records = [tuple(row.get(col) for col in _POSITION_COPY_COLUMNS) for row in chunk]` and call:
+
+       ```python
+       await raw_conn.copy_records_to_table(
+           "game_positions",
+           records=records,
+           columns=_POSITION_COPY_COLUMNS,
+       )
+       ```
+
+    5. Keep the trailing `await session.flush()` so the session's pending state is consistent for the caller (matches the current behavior; cheap when there's nothing else to flush).
+
+    6. Rewrite the function docstring's chunk-size comment to reflect the new rationale: chunking now exists to bound peak Python list memory and to give asyncio a yield point between chunks, NOT to dodge the 32k-param protocol limit (which COPY does not have). One short comment, no fence.
+
+    7. Update the module's top imports if needed (`from sqlalchemy import ...` may no longer need `insert` — check whether `insert` is still used elsewhere in the file; `bulk_insert_games` uses `pg_insert` from `sqlalchemy.dialects.postgresql`, so the bare `insert` import may become unused. If unused, remove it. If still used, leave it.)
+
+    Do not touch `bulk_insert_games`, `count_games_for_user`, `count_pending_evals`, `users_with_zero_pending`, `delete_user_games`, `count_games_by_platform`, or any other function in the file. The diff for `bulk_insert_positions` itself should be ~25 lines net (replace 27 lines of body with the COPY path).
+  </action>
+  <acceptance_criteria>
+    - `app/repositories/game_repository.py` contains a module-level `_POSITION_COPY_COLUMNS` tuple with 19 entries, no `"id"`.
+    - `grep -n "copy_records_to_table" app/repositories/game_repository.py` returns exactly one match inside `bulk_insert_positions`.
+    - `grep -n "insert(GamePosition)" app/repositories/game_repository.py` returns zero matches.
+    - `grep -n "pg_insert(Game)" app/repositories/game_repository.py` still returns at least one match (in `bulk_insert_games`, untouched).
+    - `uv run pytest tests/test_game_repository_bulk_insert_positions.py -x` passes all 6 tests (GREEN).
+    - `uv run pytest tests/test_reclassify.py tests/test_import_service.py -x` still passes — these reference `bulk_insert_positions` and must continue to work under the new implementation.
+    - `uv run ruff check app/repositories/game_repository.py` passes.
+    - `uv run ruff format --check app/repositories/game_repository.py` passes.
+    - `uv run ty check app/repositories/game_repository.py` passes with zero errors.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full backend test suite + lint + typecheck gate</name>
+  <files></files>
+  <read_first>
+    - CLAUDE.md (the "Pre-PR checklist" section — run all gates locally before claiming the task done)
+  </read_first>
+  <action>
+    Run the full pre-PR checklist locally to prove no regression elsewhere in the backend:
+
+    ```bash
+    uv run ruff format app/ tests/
+    uv run ruff check app/ tests/ --fix
+    uv run ty check app/ tests/
+    uv run pytest -x
+    ```
+
+    If any step modifies files, stage the changes — they will be committed as part of this plan's atomic commit by `gsd-executor`. If `pytest -x` reveals a regression in an unrelated test, debug + fix it in this plan only if the root cause is the COPY change; otherwise stop and flag a deviation rather than expanding scope.
+  </action>
+  <acceptance_criteria>
+    - `uv run ruff format --check app/ tests/` exits 0.
+    - `uv run ruff check app/ tests/` exits 0.
+    - `uv run ty check app/ tests/` exits 0 (zero errors per CLAUDE.md hard requirement).
+    - `uv run pytest -x` exits 0 — entire backend test suite green.
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<verification>
+  <gate_1_no_orm_insert_path>
+    - `app/repositories/game_repository.py` does not contain `insert(GamePosition).values(` anywhere in the file (full-text grep).
+    - `app/repositories/game_repository.py` contains exactly one call to `copy_records_to_table`, located inside `bulk_insert_positions`.
+  </gate_1_no_orm_insert_path>
+  <gate_2_column_contract_enforced>
+    - `_POSITION_COPY_COLUMNS` is a module-level `tuple[str, ...]` in `app/repositories/game_repository.py`.
+    - `test_bulk_insert_positions_column_coverage` passes — proves the tuple is set-equal to `GamePosition.__table__.columns` minus `id`.
+    - If a future contributor adds a column to `GamePosition` without updating the tuple, the test fails — converting a silent data-corruption bug into a CI failure.
+  </gate_2_column_contract_enforced>
+  <gate_3_atomicity_preserved>
+    - `test_bulk_insert_positions_rollback_atomicity` passes — a session-level rollback after `bulk_insert_positions` empties both `games` and `game_positions`. Proves the COPY ran on the session's connection inside the session's transaction.
+  </gate_3_atomicity_preserved>
+  <gate_4_bulk_insert_games_untouched>
+    - `git diff main -- app/repositories/game_repository.py` shows zero changes inside `bulk_insert_games` (function body byte-identical).
+    - `bulk_insert_games` still uses `pg_insert(Game).values(...).on_conflict_do_nothing(constraint="uq_games_user_platform_game_id").returning(Game.id)`.
+  </gate_4_bulk_insert_games_untouched>
+  <gate_5_no_caller_change>
+    - `app/services/import_service.py:686` still reads `await game_repository.bulk_insert_positions(session, rows_result.position_rows)` — no caller-side change.
+    - `tests/test_import_service.py` mocks of `bulk_insert_positions` still pass without modification.
+  </gate_5_no_caller_change>
+  <gate_6_lint_typecheck_test_clean>
+    - `uv run ruff check app/ tests/`, `uv run ruff format --check app/ tests/`, `uv run ty check app/ tests/`, `uv run pytest -x` all exit 0.
+  </gate_6_lint_typecheck_test_clean>
+</verification>

--- a/.planning/phases/95-asyncpg-copy-positions/95-01-SUMMARY.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-01-SUMMARY.md
@@ -64,7 +64,7 @@ Switch `bulk_insert_positions` from `insert(GamePosition).values(chunk)` to asyn
 
 ### tests/test_game_repository_bulk_insert_positions.py
 
-Six async integration tests against the live dev Postgres:
+Six async integration tests against the test Postgres DB (`flawchess_test`) via the `db_session` fixture (which auto-rolls-back each test):
 
 | Test | What it asserts |
 |------|-----------------|

--- a/.planning/phases/95-asyncpg-copy-positions/95-01-SUMMARY.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-01-SUMMARY.md
@@ -1,0 +1,133 @@
+---
+phase: 95-asyncpg-copy-positions
+plan: "01"
+subsystem: backend/repositories
+tags:
+  - asyncpg
+  - bulk-insert
+  - copy-protocol
+  - import-pipeline
+  - memory-optimization
+dependency_graph:
+  requires: []
+  provides:
+    - bulk_insert_positions now uses asyncpg binary COPY protocol
+    - _POSITION_COPY_COLUMNS module-level constant for column coverage CI enforcement
+  affects:
+    - app/services/import_service.py (caller unchanged)
+    - tests/test_reclassify.py (still passes — no caller change needed)
+    - tests/test_import_service.py (still passes — mocks unchanged)
+tech_stack:
+  added: []
+  patterns:
+    - asyncpg Connection.copy_records_to_table for bulk position writes
+    - SQLAlchemy async session.connection().get_raw_connection() for raw driver access
+key_files:
+  created:
+    - tests/test_game_repository_bulk_insert_positions.py
+  modified:
+    - app/repositories/game_repository.py
+decisions:
+  - "D-1: Acquire asyncpg Connection via (await (await session.connection()).get_raw_connection()).driver_connection — stays in session transaction"
+  - "D-2: Explicit _POSITION_COPY_COLUMNS tuple (not runtime introspection) — enforced by CI test"
+  - "D-3: dict.get(col) for each column — missing optional keys become None"
+  - "D-5: Empty position_rows short-circuits before connection acquisition"
+  - "get_raw_connection() requires await in SQLAlchemy 2.x asyncpg adapter (deviation from context skeleton which showed single-await chain)"
+metrics:
+  duration_minutes: 25
+  completed_date: "2026-05-27"
+  tasks_completed: 3
+  files_modified: 2
+---
+
+# Phase 95 Plan 01: asyncpg COPY for bulk_insert_positions — Summary
+
+Switch `bulk_insert_positions` from `insert(GamePosition).values(chunk)` to asyncpg's binary `Connection.copy_records_to_table`, with six integration tests proving column coverage, round-trip fidelity, NULL handling, empty-batch no-op, rollback atomicity, and chunking correctness.
+
+## What Was Built
+
+### app/repositories/game_repository.py
+
+`bulk_insert_positions` body replaced with asyncpg COPY path:
+
+1. Module-level `_POSITION_COPY_COLUMNS: tuple[str, ...] = (...)` with 19 entries matching all non-id columns of `GamePosition`. The test enforces set-equality against `GamePosition.__table__.columns` so any future column drift becomes a CI failure rather than silent data corruption.
+
+2. `if not position_rows: return` short-circuits before any DB connection is acquired (test 4 asserts `session.connection` is not called on empty input).
+
+3. Connection acquisition: `sa_conn = await session.connection(); raw_wrapper = await sa_conn.get_raw_connection(); raw_conn = raw_wrapper.driver_connection`. Both `session.connection()` and `get_raw_connection()` are async in SQLAlchemy 2.x with the asyncpg adapter — the context skeleton in `95-CONTEXT.md` showed a single-await chain that would have produced an `AttributeError`.
+
+4. Chunk loop unchanged at 1700 rows. Inside: `records = [tuple(row.get(col) for col in _POSITION_COPY_COLUMNS) for row in chunk]` then `await raw_conn.copy_records_to_table("game_positions", records=records, columns=_POSITION_COPY_COLUMNS)`.
+
+5. Trailing `await session.flush()` retained for session-state consistency.
+
+6. Unused `insert` import removed (only `pg_insert` from `sqlalchemy.dialects.postgresql` is now needed for `bulk_insert_games`).
+
+### tests/test_game_repository_bulk_insert_positions.py
+
+Six async integration tests against the live dev Postgres:
+
+| Test | What it asserts |
+|------|-----------------|
+| `test_bulk_insert_positions_column_coverage` | `_POSITION_COPY_COLUMNS` set-equals `GamePosition.__table__.columns` minus `id` |
+| `test_bulk_insert_positions_round_trip` | 3 fully-populated rows round-trip byte-for-byte (REAL float tolerance for `clock_seconds`) |
+| `test_bulk_insert_positions_null_optional_fields` | 2 required-only rows have all optional columns read back as `None` |
+| `test_bulk_insert_positions_empty_batch_noop` | `session.connection` is not called when input is empty |
+| `test_bulk_insert_positions_rollback_atomicity` | COPY enrolled in session transaction — rollback after duplicate-PK violation removes both games and positions |
+| `test_bulk_insert_positions_chunking_across_chunk_size` | 1701 rows (chunk_size+1) all land in the table |
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Double-await required for get_raw_connection()**
+
+- **Found during:** Task 2 (GREEN phase), first test run
+- **Issue:** The context skeleton in `95-CONTEXT.md` and the PLAN showed `(await session.connection()).get_raw_connection().driver_connection` — a single-await chain. In practice, `get_raw_connection()` is also an async method in SQLAlchemy 2.x's asyncpg adapter, so calling it without `await` returns a coroutine object, and `.driver_connection` on a coroutine raises `AttributeError: 'coroutine' object has no attribute 'driver_connection'`.
+- **Fix:** Split into three lines: `sa_conn = await session.connection()`, `raw_wrapper = await sa_conn.get_raw_connection()`, `raw_conn = raw_wrapper.driver_connection`.
+- **Files modified:** `app/repositories/game_repository.py`
+- **Commit:** included in `feat(95-01)` commit (3f7500a1)
+
+**2. [Rule 1 - Bug] Test helper used invalid gameresult enum value**
+
+- **Found during:** Task 2, second test run
+- **Issue:** `_make_game_row` used `result="*"` which is not in the Postgres `gameresult` enum (`"1-0"`, `"0-1"`, `"1/2-1/2"`). This caused `asyncpg.exceptions.InvalidTextRepresentationError` when calling `bulk_insert_games`.
+- **Fix:** Changed to `result="1/2-1/2"`.
+- **Files modified:** `tests/test_game_repository_bulk_insert_positions.py`
+- **Commit:** included in `feat(95-01)` commit
+
+**3. [Rule 1 - Bug] Signed int64 overflow in chunking test hash values**
+
+- **Found during:** Task 2, third test run
+- **Issue:** Hash values `ply | 0xFF00000000000000` exceed the signed int64 range (Python integers are arbitrary precision, but Postgres BIGINT is signed int64). asyncpg raised `OverflowError: value out of int64 range` when encoding the hash column.
+- **Fix:** Changed to `0x7F00000000000000 | ply` (and similar 0x5A/0x3B prefixes for white/black hashes) which stay within signed int64 range.
+- **Files modified:** `tests/test_game_repository_bulk_insert_positions.py`
+- **Commit:** included in `feat(95-01)` commit
+
+**4. [Rule 2 - Missing critical functionality] Type narrowing for driver_connection**
+
+- **Found during:** Task 2 ty check
+- **Issue:** `ty` flagged `raw_wrapper.driver_connection` as `Any | None`, which propagated to a `copy_records_to_table` call on a potentially-None value — an `unresolved-attribute` error.
+- **Fix:** Added `assert raw_conn is not None, "asyncpg driver_connection must not be None"` after the assignment, which narrows the type and provides a clear runtime error if the dialect changes.
+- **Files modified:** `app/repositories/game_repository.py`
+- **Commit:** included in `feat(95-01)` commit
+
+## Known Stubs
+
+None.
+
+## Threat Flags
+
+None. No new network endpoints, auth paths, or schema changes. This is an internal implementation swap on an existing write path.
+
+## Self-Check: PASSED
+
+- [x] `tests/test_game_repository_bulk_insert_positions.py` exists
+- [x] `app/repositories/game_repository.py` contains `_POSITION_COPY_COLUMNS`
+- [x] `grep -n "copy_records_to_table" app/repositories/game_repository.py` — 1 match
+- [x] `grep -n "insert(GamePosition)" app/repositories/game_repository.py` — 0 matches
+- [x] All 6 new tests pass
+- [x] Full test suite: 2193 passed, 16 skipped, 3 warnings
+- [x] `uv run ruff check app/ tests/` — clean
+- [x] `uv run ruff format --check app/ tests/` — clean
+- [x] `uv run ty check app/ tests/` — zero errors
+- [x] Commits: cb403018 (RED tests), 3f7500a1 (GREEN implementation)

--- a/.planning/phases/95-asyncpg-copy-positions/95-02-PLAN.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-02-PLAN.md
@@ -1,0 +1,237 @@
+---
+phase: 95-asyncpg-copy-positions
+plan: 02
+type: execute
+wave: 2
+depends_on: [01]
+files_modified:
+  - scripts/stress_test_dual_platform_import.py
+  - reports/phase95-import-stress-test-{date}.md
+autonomous: false
+requirements: []
+
+must_haves:
+  truths:
+    - "A reusable stress-test driver lives at scripts/stress_test_dual_platform_import.py, parameterized so the same script can run against any (chess.com_username, lichess_username) pair against a configurable dev DB."
+    - "The driver runs two concurrent imports (chess.com + lichess) for the same FlawChess user and captures docker stats + pg_stat_activity at 5 s intervals."
+    - "A baseline run on the pre-COPY commit (HEAD~1 relative to this plan's wave) and a post-COPY run on this plan's wave produce comparable CSV traces."
+    - "A report at reports/phase95-import-stress-test-{YYYY-MM-DD}.md summarises peak `flawchess-dev-db-1` memory pre vs post, peak backend count, and pass/fail of the SEED-027 verification criteria (no ConnectionDoesNotExistError, peak memory below baseline)."
+    - "The report's pass/fail verdict is unambiguous: if peak memory dropped and no ConnectionDoesNotExistError fired, this phase is ready for prod deploy review; if not, deviation is documented and the phase is flagged for follow-up."
+  artifacts:
+    - path: scripts/stress_test_dual_platform_import.py
+      provides: dual-platform import stress driver with metric capture
+      contains: "async def run_stress_test"
+    - path: reports/phase95-import-stress-test-{YYYY-MM-DD}.md
+      provides: pre/post memory comparison + verdict against SEED-027 acceptance
+      contains: "## Verdict"
+  key_links:
+    - from: scripts/stress_test_dual_platform_import.py
+      to: app/services/import_service.py
+      via: "calls import_service.run_import directly with seeded user + platform credentials"
+      pattern: "import via `from app.services import import_service` and invoke run_import twice with asyncio.gather"
+    - from: reports/phase95-import-stress-test-{YYYY-MM-DD}.md
+      to: reports/phase91-import-stress-test-2026-05-21.md
+      via: "mirrors the v1.18 stress-test report structure for continuity"
+      pattern: "same headings: Setup, Methodology, Results table, Verdict, Follow-ups"
+---
+
+<objective>
+Build a reusable dual-platform import stress driver, run it against both the pre-COPY baseline and the post-COPY (this plan's wave) state on local dev DB, capture memory + connection traces, and write a report at `reports/phase95-import-stress-test-{date}.md` whose verdict gates the prod deploy decision.
+
+Purpose: prove (or disprove) that Plan 01's COPY conversion actually reduces per-backend Postgres memory under the dual-platform workload that triggered FLAWCHESS-3Q on 2026-05-26. The report is the empirical answer to "did we close the third recurrence of this OOM family?" and is what the user reads before invoking `/deploy`.
+
+Output: one new script under `scripts/`, one report under `reports/`. No production code changes. `autonomous: false` because the verdict step requires the user's interpretation of the memory traces — the script runs autonomously, the verdict is a human read.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/seeds/SEED-027-db-memory-budget-and-positions-copy.md
+@.planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md
+@.planning/phases/95-asyncpg-copy-positions/95-01-PLAN.md
+@reports/phase91-import-stress-test-2026-05-21.md
+@app/services/import_service.py
+@docker-compose.dev.yml
+
+<interfaces>
+<!-- Stress driver public surface (new). -->
+
+# scripts/stress_test_dual_platform_import.py
+
+async def run_stress_test(
+    *,
+    user_id: int,                       # FlawChess internal user PK; the user whose chess.com + lichess accounts get imported
+    chesscom_username: str,
+    lichess_username: str,
+    sample_interval_s: float = 5.0,
+    db_container_name: str = "flawchess-dev-db-1",
+    output_dir: Path = Path("reports/phase95-stress-data"),
+) -> StressTestResult
+
+# Captures:
+#   - docker stats <db_container_name> --no-stream every sample_interval_s (parsed) -> CSV
+#   - SELECT pid, state, query_start, query FROM pg_stat_activity WHERE datname='flawchess_dev' every sample_interval_s -> CSV
+#   - Final ImportJob status + error_message for both jobs
+
+# CLI entrypoint:
+#   uv run python -m scripts.stress_test_dual_platform_import \
+#       --user-id 42 --chesscom-username GmAhmedAli --lichess-username PhAhmedAlssiad \
+#       --output-tag pre-copy   # or --output-tag post-copy
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Build the stress test driver</name>
+  <files>scripts/stress_test_dual_platform_import.py</files>
+  <read_first>
+    - app/services/import_service.py (lines 600-850 — the run_import entrypoint signature and how it manages sessions; understand how to invoke it from a script context)
+    - scripts/backfill_eval.py (existing async script pattern — argparse + asyncio.run + AsyncSession bootstrap to mirror)
+    - scripts/reimport_games.py (another async script pattern for user-scoped operations)
+    - reports/phase91-import-stress-test-2026-05-21.md (the v1.18 stress test report — mirror its structure for continuity)
+    - .planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md (Plan 02 stress test design block)
+  </read_first>
+  <action>
+    Create `scripts/stress_test_dual_platform_import.py` as a standalone async script. Concrete shape:
+
+    1. Argparse CLI accepting `--user-id INT`, `--chesscom-username STR`, `--lichess-username STR`, `--output-tag STR` (e.g. "pre-copy" or "post-copy"), `--sample-interval SECONDS` (default 5.0), `--db-container STR` (default `flawchess-dev-db-1`), `--output-dir PATH` (default `reports/phase95-stress-data`).
+
+    2. Async `main()` orchestrates three concurrent tasks via `asyncio.gather`:
+       - Task A: `import_service.run_import(user_id, platform="chess.com", username=chesscom_username, ...)` — call the existing entrypoint exactly as the production API does (look up the right signature in `import_service.py`; do not invent a new path).
+       - Task B: same for `platform="lichess"`, `username=lichess_username`.
+       - Task C: metric sampler — every `sample_interval` seconds, run `docker stats {db_container} --no-stream --format "{{.MemUsage}}\t{{.MemPerc}}\t{{.CPUPerc}}"` via `asyncio.create_subprocess_exec`, parse, append a row to `{output_dir}/{output_tag}-docker-stats.csv` with columns `timestamp_iso, mem_usage_bytes, mem_perc, cpu_perc`. Same cadence: connect to dev DB via a fresh `AsyncEngine` (not the import sessions' engine, to avoid contention), run `SELECT pid, state, EXTRACT(EPOCH FROM (NOW() - query_start)) AS query_age_s, LEFT(query, 80) AS query_excerpt FROM pg_stat_activity WHERE datname = 'flawchess_dev'` and append to `{output_dir}/{output_tag}-pg-activity.csv`. The sampler runs until BOTH import tasks complete (or one raises), then writes a final summary row.
+
+       Use `asyncio.gather(import_a, import_b, return_exceptions=True)` to ensure the sampler can observe failures without crashing the whole gather. After the gather completes (success or exception), cancel the sampler task and await its cleanup.
+
+    3. After all tasks settle, write a small JSON summary at `{output_dir}/{output_tag}-summary.json` containing: start/end timestamps, both ImportJob final `status` (`completed`/`failed`), both ImportJob `error_message` if any, peak observed `mem_usage_bytes` from the docker-stats CSV, peak observed connection count (rows in pg-activity CSV per timestamp group), and total wall-clock duration.
+
+    4. The script MUST be safe to ctrl-C — wrap the gather in try/except and ensure the sampler subtask is cancelled cleanly so partial CSVs are flushed to disk.
+
+    5. Database connection — the script needs an async engine pointing at dev (`DATABASE_URL` env var, same pattern as `scripts/backfill_eval.py`). Use `--target dev` semantics if the existing scripts have a target flag; otherwise hardcode dev and document the override env var in the script's module docstring.
+
+    Keep the script under ~300 lines. Do not refactor `import_service` to expose a "stress mode" — call `run_import` exactly as the API does. If `run_import` requires a Request/User scope that the script can't easily provide, look for a lower-level entrypoint in `import_service.py` (search for `async def run_import`, `async def _run_import_inner`, or similar) and call that instead. Document the chosen entrypoint in the script's module docstring with a one-line rationale.
+  </action>
+  <acceptance_criteria>
+    - File `scripts/stress_test_dual_platform_import.py` exists, has a module docstring naming the chosen `import_service` entrypoint and rationale.
+    - `uv run python -m scripts.stress_test_dual_platform_import --help` exits 0 and shows the argparse usage with all flags documented above.
+    - `uv run ruff check scripts/stress_test_dual_platform_import.py` and `uv run ruff format --check` both pass.
+    - `uv run ty check scripts/stress_test_dual_platform_import.py` passes with zero errors.
+    - Dry-run with `--user-id 999999` (nonexistent user) fails fast with a clear error message (no silent hangs).
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 2: Run baseline (pre-COPY) and post-COPY stress tests</name>
+  <files>
+    - reports/phase95-stress-data/pre-copy-docker-stats.csv
+    - reports/phase95-stress-data/pre-copy-pg-activity.csv
+    - reports/phase95-stress-data/pre-copy-summary.json
+    - reports/phase95-stress-data/post-copy-docker-stats.csv
+    - reports/phase95-stress-data/post-copy-pg-activity.csv
+    - reports/phase95-stress-data/post-copy-summary.json
+  </files>
+  <read_first>
+    - scripts/stress_test_dual_platform_import.py (the script Task 1 just produced)
+    - .planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md (D-6 verification posture)
+    - CLAUDE.md (the "Dev database" section — how to ensure Docker dev DB is running before the stress test)
+  </read_first>
+  <action>
+    Two-pass execution to produce paired traces. Both passes run against the same dev DB (`docker compose -f docker-compose.dev.yml -p flawchess-dev up -d`).
+
+    **Pre-COPY baseline pass:**
+    1. Ensure the working tree is clean (`git status` empty).
+    2. Reset dev DB to a clean state — drop the FlawChess test user's games via `scripts/reimport_games.py --delete-only` or equivalent. Recreate the FlawChess user account locally (matching `--user-id` argument; use a real chess.com + lichess username pair the developer has access to, OR seed with the production user 109 PGN fixtures if available locally).
+    3. Stash any Plan 01 changes if they're already applied: `git stash` or `git checkout HEAD~1 -- app/repositories/game_repository.py` to revert ONLY the position-INSERT path to pre-COPY shape. (Document the exact command run in the report's Methodology section.)
+    4. Run: `uv run python -m scripts.stress_test_dual_platform_import --user-id <ID> --chesscom-username <USER> --lichess-username <USER> --output-tag pre-copy`
+    5. Confirm `reports/phase95-stress-data/pre-copy-*.csv` and `pre-copy-summary.json` written.
+
+    **Post-COPY pass:**
+    1. Restore Plan 01's changes: `git checkout main -- app/repositories/game_repository.py` (or `git stash pop`).
+    2. Reset the same dev DB to a clean state (delete the user's games again).
+    3. Run: `uv run python -m scripts.stress_test_dual_platform_import --user-id <ID> --chesscom-username <USER> --lichess-username <USER> --output-tag post-copy`
+    4. Confirm `reports/phase95-stress-data/post-copy-*.csv` and `post-copy-summary.json` written.
+
+    Both runs should target the same user with the same game-count workload to make the comparison meaningful. If the two platforms have wildly different game counts for the chosen user, document it in the report's Setup section — the comparison is still valid as long as the SAME user is imported in both runs.
+
+    Total wall-clock for both runs combined: estimated 20-40 minutes depending on game count. Run during a quiet local-machine window (no other heavy processes).
+  </action>
+  <acceptance_criteria>
+    - Six files exist under `reports/phase95-stress-data/`: `pre-copy-{docker-stats.csv, pg-activity.csv, summary.json}` and `post-copy-{docker-stats.csv, pg-activity.csv, summary.json}`.
+    - Each `summary.json` contains valid JSON with `peak_mem_usage_bytes`, `peak_connection_count`, both ImportJob `status` values, and `total_duration_s`.
+    - Both `post-copy` and `pre-copy` ImportJob status values are `completed` — if either is `failed`, document why in the report and flag as deviation (a failed import on the baseline pass under known-broken conditions is informative; a failed import on the post-copy pass is a regression that blocks the phase).
+    - The two passes used the same `--user-id` and the same `--chesscom-username` + `--lichess-username` pair.
+  </acceptance_criteria>
+</task>
+
+<task type="auto">
+  <name>Task 3: Write the stress test report and verdict</name>
+  <files>reports/phase95-import-stress-test-{YYYY-MM-DD}.md</files>
+  <read_first>
+    - reports/phase95-stress-data/pre-copy-summary.json (peak memory + peak connection numbers)
+    - reports/phase95-stress-data/post-copy-summary.json (peak memory + peak connection numbers)
+    - reports/phase91-import-stress-test-2026-05-21.md (the v1.18 report — match its heading structure: Setup, Methodology, Results, Verdict, Follow-ups)
+    - .planning/seeds/SEED-027-db-memory-budget-and-positions-copy.md §"Verification plan" (SEED-027's stated acceptance criteria)
+  </read_first>
+  <action>
+    Write `reports/phase95-import-stress-test-{today}.md` (use today's date in `YYYY-MM-DD` format). Required sections in this order:
+
+    1. **Setup** — Hardware (developer laptop: model, RAM, disk), dev DB container resource cap (`mem_limit` from `docker-compose.dev.yml`), test user identity (chess.com + lichess usernames + total games per platform), date of run.
+
+    2. **Methodology** — Two-pass design (pre-COPY baseline on revert, post-COPY on this branch), exact git commands used to toggle, sampler cadence, what was measured.
+
+    3. **Results** — A table:
+       | Metric | Pre-COPY | Post-COPY | Δ |
+       |---|---|---|---|
+       | Peak `flawchess-dev-db-1` mem (MB) | ... | ... | ... |
+       | Peak connection count | ... | ... | ... |
+       | Both ImportJobs `completed` | ... | ... | ... |
+       | `ConnectionDoesNotExistError` count | ... | ... | ... |
+       | Total wall-clock (s) | ... | ... | ... |
+
+       Plus a paragraph interpreting the table — peak memory should drop measurably; wall-clock should be flat or slightly faster; connection count should be unchanged.
+
+    4. **Verdict** — A `## Verdict` heading followed by ONE of:
+       - `**PASS** — post-COPY peak memory is N MB below baseline, no ConnectionDoesNotExistError observed in either pass. Ready for prod deploy review.`
+       - `**INCONCLUSIVE** — memory delta is < 10% or within noise; recommend re-running with a larger game-count workload before deploying.`
+       - `**FAIL** — post-COPY pass produced [specific failure mode]. Block deploy; investigate before proceeding.`
+
+    5. **Follow-ups** — items deferred or surfaced during the run (e.g. "memory-pressure alerting still warranted as separate seed", "asyncpg COPY edge case observed on column X — flagged for follow-up").
+
+    Keep the report under ~400 lines. Inline relevant excerpts from the summary JSONs; do not embed full CSVs (link to them in the `reports/phase95-stress-data/` directory).
+  </action>
+  <acceptance_criteria>
+    - File `reports/phase95-import-stress-test-{YYYY-MM-DD}.md` exists with the five required headings (`## Setup`, `## Methodology`, `## Results`, `## Verdict`, `## Follow-ups`).
+    - The `## Verdict` section contains one of the three labeled outcomes (PASS / INCONCLUSIVE / FAIL).
+    - The Results table is populated with real numbers from the summary JSONs (not placeholders).
+    - The report links to `reports/phase95-stress-data/` for raw CSVs.
+    - `uv run ruff format --check reports/` is N/A (markdown), but the file passes a basic markdown lint (no broken table syntax, headings render cleanly when previewed).
+  </acceptance_criteria>
+</task>
+
+</tasks>
+
+<verification>
+  <gate_1_driver_exists_and_runs>
+    - `scripts/stress_test_dual_platform_import.py` exists, passes ruff + ty, runs via `uv run python -m scripts.stress_test_dual_platform_import --help`.
+  </gate_1_driver_exists_and_runs>
+  <gate_2_paired_traces_captured>
+    - Six trace files exist under `reports/phase95-stress-data/` (3 per pass × 2 passes).
+    - Both passes ran against the same user with the same platform-username pair.
+  </gate_2_paired_traces_captured>
+  <gate_3_report_with_verdict>
+    - `reports/phase95-import-stress-test-{YYYY-MM-DD}.md` exists with all five required headings and a labeled `## Verdict` line.
+    - The verdict reflects the actual observed data — not a guess.
+  </gate_3_report_with_verdict>
+  <gate_4_seed_acceptance_addressed>
+    - The report's Verdict explicitly addresses SEED-027's verification plan items 1-4: peak memory < threshold, no `ConnectionDoesNotExistError`, no analytics-query regression (sanity-only — separate `pg_stat_statements` check if the developer wants), and UAT-equivalent (both jobs `status='completed'`).
+  </gate_4_seed_acceptance_addressed>
+  <gate_5_human_uat_handoff>
+    - On a PASS verdict, the report's last line invites the user to run `/deploy` to ship the COPY change to production.
+    - On INCONCLUSIVE or FAIL, the report names the specific next step (re-run with bigger workload / investigate failure).
+  </gate_5_human_uat_handoff>
+</verification>

--- a/.planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-CONTEXT.md
@@ -1,0 +1,166 @@
+# Phase 95: asyncpg COPY for `bulk_insert_positions` — Context
+
+**Gathered:** 2026-05-27
+**Status:** Ready for planning
+**Source:** SEED-027 §Thread B (Thread A already shipped via PR #144 / prod SHA 65511c9 on 2026-05-26)
+
+<domain>
+## Phase Boundary
+
+Switch the position-row bulk write path from SQLAlchemy `insert(GamePosition).values(chunk)` to asyncpg's binary `Connection.copy_records_to_table` so each Postgres backend's per-statement parser/executor memory becomes roughly constant in the chunk size instead of scaling with `rows × columns` (currently up to 1700 × 19 ≈ 32k bound parameters per statement). `bulk_insert_positions` is the heaviest INSERT path in the import pipeline; concurrent dual-platform imports were observed to push the Postgres container to its `mem_limit` cgroup cap in the 2026-05-26 user-109 incident (FLAWCHESS-3Q, third recurrence).
+
+Thread A (SEED-027) — `shared_buffers=2GB`, `effective_cache_size=8GB`, container `mem_limit=12g` — is **already deployed** via hotfix PR #144 (production at SHA `65511c9`, verified live). This phase is Thread B only and has no Thread A overlap.
+
+**Locked carryover:**
+- `bulk_insert_positions` callable signature stays the same (`session: AsyncSession, position_rows: list[dict]) -> None`) so `app/services/import_service.py:686` and `tests/test_reclassify.py:100` need no caller-side change.
+- `bulk_insert_games` is **untouched** — it uses `pg_insert(...).values(...).on_conflict_do_nothing(...)` for dedup, which COPY cannot express. Only `bulk_insert_positions` moves to COPY.
+- Atomicity vs `bulk_insert_games` is preserved by enrolling the COPY in the active SQLAlchemy session transaction (asyncpg COPY participates in the transaction held by the connection it runs on).
+- Chunking stays at `chunk_size = 1700` — no longer for the 32k-param ceiling (COPY has no such ceiling), but to bound peak Python-side memory and yield to the asyncio loop between chunks. Comment is rewritten to reflect the new rationale.
+
+**Out of scope:**
+- Per-user concurrent-platform serialization (Thread C in SEED-027 post-mortem) — deferred to a separate seed if this phase doesn't close FLAWCHESS-3Q under dual-platform stress.
+- Switching `bulk_insert_games` to COPY (loses `ON CONFLICT DO NOTHING`).
+- Memory-pressure alerting (Sentry/Grafana threshold on cgroup memory > 80% of `mem_limit`) — observability concern, separate seed.
+- Stockfish pool sizing — the failing SQL in the incident was the position INSERT, not the `evals_completed_at` UPDATE.
+- Production deploy — Plan 02 verifies on local dev DB only; production deploy is a separate `/deploy` invocation by the user after sign-off.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### asyncpg connection acquisition (locked from seed)
+
+- **D-1: Acquire the raw asyncpg `Connection` from the SQLAlchemy `AsyncSession` via the documented chain.** SQLAlchemy async wrapper exposes the underlying asyncpg `Connection` through `(await session.connection()).get_raw_connection().driver_connection` (SQLAlchemy 2.x async API). Do not bypass the session by acquiring a separate connection from the engine — that would put COPY in a different transaction and break atomicity with `bulk_insert_games`.
+  - **Why:** asyncpg's `copy_records_to_table` runs on a `Connection`, not on a SQLAlchemy `Session`. The session's active transaction is held on its own connection; the COPY must run on that same connection to participate in the transaction.
+
+### Column order policy (locked)
+
+- **D-2: Column order passed to `copy_records_to_table(columns=[...])` is enumerated explicitly in `bulk_insert_positions`, NOT introspected at runtime from `GamePosition.__table__.columns`.** The explicit list is the **functional contract** the COPY relies on — drift between Python-side ordering and Postgres column order would silently miswrite data.
+  - **Why:** introspection through `__table__.columns` reflects declaration order in the SQLAlchemy model and would change if a future column is added in the middle of the model class. An explicit hard-coded list makes the contract visible at the call site and the test asserts that every model column appears in the list.
+  - **How to apply:** the unit test `test_bulk_insert_positions_column_coverage` introspects `GamePosition.__table__.columns` and asserts the explicit list is `set-equal` to it (excluding the auto-`id` primary key). If a new column is added to `GamePosition`, the test fails until the explicit list is updated. This converts "column drift" from a silent data-corruption bug into a CI failure.
+
+### NULL handling (locked)
+
+- **D-3: Records passed to `copy_records_to_table` are tuples (not dicts) with `None` for missing optional fields.** `bulk_insert_positions` receives `list[dict]` from `import_service` where some keys (`material_count`, `material_signature`, `material_imbalance`, `has_opposite_color_bishops`, `piece_count`, `backrank_sparse`, `mixedness`, `phase`, `eval_cp`, `eval_mate`, `endgame_class`) may be absent for older code paths or sparse data. Translate `dict.get(col, None)` for every column.
+  - **Why:** asyncpg's COPY protocol needs positional tuples in column order. A missing dict key would either raise `KeyError` (if accessed via `[]`) or silently substitute `None` (if `.get()`). We want `None`, but want it explicit.
+
+### Feature flag question (decided NO)
+
+- **D-4: No feature flag for the COPY path.** SEED-027 §"Open questions" raised whether to gate behind `IMPORT_POSITIONS_COPY=1`. Decision: **no flag**.
+  - **Why:** (a) rollback is one `git revert` of the PR — same blast radius as a flag toggle; (b) feature flags rot and accumulate as tech debt; (c) the COPY path is well-trodden asyncpg territory (documented fastest path for bulk insert in asyncpg's own benchmarks), not an experimental code path; (d) `git revert` after a verified production deploy is fundamentally the same recovery posture as the v1.18 hotfixes (#139, #144), which also shipped without flags.
+  - **How to apply:** the plan ships a direct cutover. If a regression surfaces post-deploy, recovery is `git revert` + redeploy, not a flag flip.
+
+### Empty-batch behavior (locked)
+
+- **D-5: Empty `position_rows` is a no-op, same as today.** Current implementation returns early on `if not position_rows: return`. The COPY version preserves this — asyncpg's `copy_records_to_table` with an empty iterable would be a wasted round-trip, and the early-return is also the documented pattern.
+
+### Verification posture (locked)
+
+- **D-6: Verification is a local-dev-DB dual-platform stress test, NOT a prod run.** Production deploy of this phase is the user's call after Plan 02 produces a report showing acceptance criteria are met on dev. The stress test seeds dev DB with two real production accounts' game ranges (e.g. user 109's GmAhmedAli / PhAhmedAlssiad split) replayed locally, or synthesizes a 7k+ game multi-platform dataset.
+  - **Why:** the FLAWCHESS-3Q failure mode is reproducible under sufficient memory pressure with concurrent imports; dev DB on a developer laptop has less RAM than prod but the same `bulk_insert_positions` hot path. A locally observed reduction in per-backend anon-rss during a synthetic stress run is sufficient signal to deploy.
+  - **How to apply:** Plan 02's script captures `docker stats` at 5 s intervals + `pg_stat_activity` snapshots; report writes to `reports/phase95-import-stress-test-{date}.md` (mirrors Phase 91's report naming convention).
+
+### Test transaction-rollback strategy (locked)
+
+- **D-7: The transaction-rollback atomicity test uses an explicit failed flush after `bulk_insert_positions` completes, within the same session.** Test flow: open async session, call `bulk_insert_games` + `bulk_insert_positions` (both succeed), then trigger a constraint-violating second insert in the same session, assert rollback leaves both `games` and `game_positions` empty for the test user.
+  - **Why:** the COPY's transaction enrollment is the load-bearing invariant for atomicity. A direct integration test that exercises rollback is the cheapest proof that the COPY committed to the right transaction.
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Seed & post-mortem
+- `.planning/seeds/SEED-027-db-memory-budget-and-positions-copy.md` — full incident + decision context, including the OOM-killer dmesg, why v1.18's PR #139 didn't fix it, the column-order trap on hotfix forward-ports, and the Thread A/B split rationale
+- `reports/phase91-import-stress-test-2026-05-21.md` — baseline import throughput numbers (~11 g/s dual-platform); Plan 02 mirrors this report's shape
+
+### Code (the modification surface)
+- `app/repositories/game_repository.py:161-187` — current `bulk_insert_positions` implementation (the only function changed in Plan 01)
+- `app/repositories/game_repository.py:14-38` — `bulk_insert_games` (untouched; kept on `pg_insert` for `ON CONFLICT DO NOTHING`)
+- `app/services/import_service.py:680-689` — caller of `bulk_insert_positions` inside the import hot lane (Phase 91 two-lane split)
+- `app/models/game_position.py` — `GamePosition` model with the 19-ish columns; canonical column ordering source
+
+### Tests (the test surface)
+- `tests/test_reclassify.py:66-100` — existing call site through `bulk_insert_games + bulk_insert_positions`; useful as a real-data fixture for Plan 01's integration tests
+- `tests/test_import_service.py:471-720` — existing mocks of `bulk_insert_positions` (must keep passing after refactor)
+
+### Production environment (already at Thread A baseline)
+- `docker-compose.yml` § `db` service — `shared_buffers=2GB`, `effective_cache_size=8GB`, `mem_limit=12g`, `memswap_limit=12g`, `max_connections=30` (live as of PR #144 / prod SHA 65511c9)
+- `CLAUDE.md` § "Production Server" — OOM history table; this phase closes the 2026-05-26 user-109 entry
+
+### asyncpg API surface
+- asyncpg `Connection.copy_records_to_table(table_name, *, records, columns=None, schema_name=None, timeout=None)` — binary COPY protocol, runs in the active transaction of the connection it's called on
+- SQLAlchemy async `(await session.connection()).get_raw_connection().driver_connection` — documented path to the underlying asyncpg `Connection`
+
+</canonical_refs>
+
+<specifics>
+## Specific Ideas
+
+**Implementation skeleton (target shape — full code to be written in Plan 01):**
+
+```python
+# app/repositories/game_repository.py
+async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]) -> None:
+    if not position_rows:
+        return
+
+    columns = (
+        "game_id", "user_id", "ply",
+        "full_hash", "white_hash", "black_hash",
+        "move_san", "clock_seconds",
+        "material_count", "material_signature", "material_imbalance",
+        "has_opposite_color_bishops",
+        "piece_count", "backrank_sparse", "mixedness", "phase",
+        "eval_cp", "eval_mate", "endgame_class",
+    )
+
+    raw_conn = (await session.connection()).get_raw_connection().driver_connection
+
+    chunk_size = 1700  # Yield to event loop between chunks; bound peak Python memory.
+    for i in range(0, len(position_rows), chunk_size):
+        chunk = position_rows[i : i + chunk_size]
+        records = [tuple(row.get(col) for col in columns) for row in chunk]
+        await raw_conn.copy_records_to_table(
+            "game_positions", records=records, columns=columns
+        )
+    await session.flush()
+```
+
+**Unit test additions (target — full file Δ in Plan 01):**
+
+- `test_bulk_insert_positions_column_coverage` — asserts the explicit `columns` tuple set-equals `{c.name for c in GamePosition.__table__.columns if c.name != "id"}`
+- `test_bulk_insert_positions_round_trip` — insert a 3-row batch with all optional fields populated, SELECT them back, assert every column matches
+- `test_bulk_insert_positions_null_optional_fields` — insert a 2-row batch with **only** required fields (game_id, user_id, ply, hashes), assert SELECT returns `None` for every optional column
+- `test_bulk_insert_positions_empty_batch_noop` — call with `[]`, assert no SQL was issued (mock or pg_stat_statements scratch)
+- `test_bulk_insert_positions_rollback_atomicity` — insert games + positions, then trigger a post-COPY violation, assert both tables empty after rollback (per D-7)
+- `test_bulk_insert_positions_chunking_across_chunk_size` — insert `chunk_size + 1` rows (1701), assert all 1701 land in the table (proves the chunk loop is correct after the protocol-limit reason for chunking went away)
+
+**Stress test design (target — Plan 02):**
+
+- Seed dev DB with a synthetic ~7000-game dataset (or replay user 109's range from local PGN fixtures if available)
+- Spawn two concurrent `import_service.run_import` tasks (one chess.com, one lichess) via a dedicated test script under `scripts/stress_test_dual_platform_import.py`
+- Sample `docker stats flawchess-dev-db-1` at 5 s intervals → CSV
+- Sample `SELECT pid, state, query_start FROM pg_stat_activity WHERE datname='flawchess_dev'` at 5 s intervals → CSV
+- Report comparison: pre-COPY baseline (re-run on the previous commit) vs post-COPY measurement on this branch
+- Acceptance: post-COPY peak `flawchess-dev-db-1` memory < pre-COPY peak by a measurable margin; zero `ConnectionDoesNotExistError` in either job's `error_message`
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- **Memory-pressure alerting** (Sentry/Grafana cgroup memory > 80% of `mem_limit`) — captured in SEED-027 §Open Questions; separate observability seed
+- **Per-user concurrent-platform serialization** — only revisit if Thread B doesn't close FLAWCHESS-3Q under dual-platform stress
+- **Switch `bulk_insert_games` to COPY** — explicitly out of scope; loses `ON CONFLICT DO NOTHING`
+- **Replace `bulk_insert_positions` with `INSERT ... ON CONFLICT DO NOTHING` via COPY-to-staging-table pattern** — not needed; positions are only inserted for newly-inserted game IDs (per the existing docstring), so dedup is unnecessary
+
+</deferred>
+
+---
+
+*Phase: 95-asyncpg-copy-positions*
+*Context gathered: 2026-05-27 directly from SEED-027 §Thread B (no discuss-phase — seed is comprehensive)*

--- a/.planning/phases/95-asyncpg-copy-positions/95-REVIEW-FIX.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-REVIEW-FIX.md
@@ -1,24 +1,27 @@
 ---
 phase: 95-asyncpg-copy-positions
-fixed_at: 2026-05-27T18:45:00Z
+fixed_at: 2026-05-27T20:00:00Z
 review_path: .planning/phases/95-asyncpg-copy-positions/95-REVIEW.md
-iteration: 1
-findings_in_scope: 5
-fixed: 5
-skipped: 7
+iteration: 2
+findings_in_scope: 12
+fixed: 12
+skipped: 0
 status: all_fixed
 ---
 
 # Phase 95: Code Review Fix Report
 
-**Fixed at:** 2026-05-27T18:45:00Z
+**Fixed at:** 2026-05-27T20:00:00Z
 **Source review:** `.planning/phases/95-asyncpg-copy-positions/95-REVIEW.md`
-**Iteration:** 1
+**Iteration:** 2
 
 **Summary:**
-- Findings in scope: 5 (Warnings WR-01 through WR-05)
-- Fixed: 5
-- Skipped: 7 (all out-of-scope Info findings)
+- Findings in scope: 12 (5 Warnings + 7 Info)
+- Fixed: 12
+- Skipped: 0
+
+Iteration 1 fixed the 5 Warnings (WR-01..WR-05). Iteration 2 extended scope to `all`
+and addressed the 7 Info findings (IN-01..IN-07).
 
 ## Fixed Issues
 
@@ -52,52 +55,50 @@ status: all_fixed
 **Commit:** `50842cc7`
 **Applied fix:** Updated the module docstring to "Uses the test Postgres DB (`flawchess_test`) via the `db_session` fixture, which auto-rolls-back each test (no DB mocks)." Also updated the matching phrasing in `95-01-SUMMARY.md` line 67 from "live dev Postgres" to "test Postgres DB (`flawchess_test`) via the `db_session` fixture (which auto-rolls-back each test)" — the reviewer flagged the SUMMARY phrasing explicitly as well.
 
-## Skipped Issues
-
 ### IN-01: `chunk_size = 1700` is a magic number with a multi-line rationale
 
-**File:** `app/repositories/game_repository.py:223`
-**Reason:** out of scope (info)
-**Original issue:** The constant is duplicated across `game_repository.py` (local `chunk_size = 1700`) and `tests/test_game_repository_bulk_insert_positions.py` (`_CHUNK_SIZE = 1700`). Should be promoted to a module-level `_POSITION_CHUNK_SIZE` and imported from the test.
+**Files modified:** `app/repositories/game_repository.py`, `tests/test_game_repository_bulk_insert_positions.py`
+**Commit:** `e8f1e61e`
+**Applied fix:** Promoted the local `chunk_size = 1700` inside `bulk_insert_positions` to a module-level constant `_POSITION_CHUNK_SIZE: int = 1700` with a brief rationale comment. Updated the chunking docstring to reference the new constant name. In the test file, replaced the duplicated `_CHUNK_SIZE = 1700` literal with a direct import of `_POSITION_CHUNK_SIZE` from `app.repositories.game_repository`, then used it in the chunking-boundary test (`n_rows = _POSITION_CHUNK_SIZE + 1`). The chunk-boundary test now tracks tuning changes automatically.
 
 ### IN-02: `_POSITION_COPY_COLUMNS` referenced with `# noqa: SLF001` in tests
 
-**File:** `tests/test_game_repository_bulk_insert_positions.py:102, 136`
-**Reason:** out of scope (info)
-**Original issue:** Test imports a single-underscore-prefixed name and silences `SLF001` twice. Should rename to public `POSITION_COPY_COLUMNS` since it is a CI contract.
+**Files modified:** `app/repositories/game_repository.py`, `tests/test_game_repository_bulk_insert_positions.py`
+**Commit:** `f57d4768`
+**Applied fix:** Renamed `_POSITION_COPY_COLUMNS` → `POSITION_COPY_COLUMNS` (dropped the leading underscore — the constant is a CI-enforced public contract, not a private implementation detail) at every reference site (definition, both internal usages in `bulk_insert_positions`, and both test references). Removed the two `# noqa: SLF001` suppressions in the test file along with the corresponding docstring/assert message references to the old name. Did NOT touch references in `95-01-PLAN.md` / `95-01-SUMMARY.md` — those are historical planning artifacts that describe the originally-implemented name and should remain as historical context.
 
 ### IN-03: `assert raw_conn is not None` runs in production with assertions disabled under `python -O`
 
-**File:** `app/repositories/game_repository.py:221`
-**Reason:** out of scope (info)
-**Original issue:** Type-narrowing `assert` is stripped under `python -O`; should be replaced with `if raw_conn is None: raise RuntimeError(...)`. Project doesn't currently use `-O`, so this is informational.
+**Files modified:** `app/repositories/game_repository.py`
+**Commit:** `24f95546` (plus formatter follow-up `22fab4c3`)
+**Applied fix:** Replaced `assert raw_conn is not None, "..."` with an explicit `if raw_conn is None: raise RuntimeError("asyncpg driver_connection is None — SQLAlchemy adapter changed")`. The new guard survives `python -O` / `PYTHONOPTIMIZE=1` (which strips asserts) and gives a specific, debuggable error if SQLAlchemy's asyncpg adapter ever changes the contract. Added an inline comment explaining why an explicit check is preferred over assert for type narrowing. Ruff format collapsed the multi-line raise into a single line in a follow-up `style(95)` commit.
 
 ### IN-04: Sampler keyword-only param `output_tag` has no default and follows params that do
 
-**File:** `scripts/stress_test_dual_platform_import.py:338-347`
-**Reason:** out of scope (info)
-**Original issue:** Required kw-only `output_tag` is positioned after kw-only args that have defaults; convention is required-first within a kw-only block.
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `074efca5`
+**Applied fix:** Moved `output_tag: str` (required, no default) to immediately after `lichess_username: str` in `run_stress_test`'s keyword-only block, in front of the kw-only args that have defaults (`sample_interval_s`, `db_container_name`, `output_dir`). The call site in `main()` already uses keyword arguments throughout, so the reorder is API-compatible for all current callers.
 
 ### IN-05: `PG_DBNAME` constant disagrees with the original plan (cosmetic)
 
-**File:** `scripts/stress_test_dual_platform_import.py:57`
-**Reason:** out of scope (info)
-**Original issue:** Plan said `flawchess_dev` (typo); code correctly uses `flawchess`. Reviewer suggested adding a one-line comment explaining the discrepancy.
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `26c04eab`
+**Applied fix:** Added a two-line comment above `PG_DBNAME: str = "flawchess"` explaining that the dev DB name comes from `app.core.config.settings.DATABASE_URL` and that the plan (95-02-PLAN.md line 107) said `flawchess_dev` as a plan-side typo. A future maintainer cross-referencing the plan against the code will see the discrepancy is intentional.
 
 ### IN-06: `_sample_pg_activity` opens a new connection per sample tick
 
-**File:** `scripts/stress_test_dual_platform_import.py:314`
-**Reason:** out of scope (info)
-**Original issue:** Each sample tick opens/closes a pooled connection. Should hold one connection open for the lifetime of the sampler. Pure efficiency improvement, not a correctness issue.
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `e3981f3a`
+**Applied fix:** Hoisted the pg connection out of `_sample_pg_activity` and into the outer `_sample_metrics` context via `async with metric_engine.connect() as pg_conn:`, wrapping the existing `with (...docker_fh, ...pg_fh):` block. Changed `_sample_pg_activity`'s signature from `engine: object` to `conn: object` (typed as `AsyncConnection` at runtime via `isinstance` narrowing) and dropped the `async with engine.connect()` block inside the helper. The connection is now reused across every sample tick, eliminating the per-tick TCP handshake + auth round-trip and avoiding the +1 connection churn in `pg_stat_activity`.
 
 ### IN-07: `_sample_pg_activity` row count includes the sampler's own backend
 
-**File:** `scripts/stress_test_dual_platform_import.py:301-330`
-**Reason:** out of scope (info)
-**Original issue:** `peak_connection_count` is inflated by +1 from the sampler's own pg_stat_activity row. Pre/post comparison still valid (both include the +1). Pure observability noise.
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `92905db5`
+**Applied fix:** Appended `AND pid != pg_backend_pid()` to the `WHERE` clause in `_sample_pg_activity`'s SQL so the sampler's own backend is excluded from the row count. `peak_connection_count` now reflects only import-driven connections; the pre-copy vs post-copy comparison in the verdict report is no longer offset by +1 from observability noise. Added a one-line comment referencing IN-07 above the new WHERE term.
 
 ---
 
-_Fixed: 2026-05-27T18:45:00Z_
+_Fixed: 2026-05-27T20:00:00Z_
 _Fixer: Claude (gsd-code-fixer)_
-_Iteration: 1_
+_Iteration: 2_

--- a/.planning/phases/95-asyncpg-copy-positions/95-REVIEW-FIX.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-REVIEW-FIX.md
@@ -1,0 +1,103 @@
+---
+phase: 95-asyncpg-copy-positions
+fixed_at: 2026-05-27T18:45:00Z
+review_path: .planning/phases/95-asyncpg-copy-positions/95-REVIEW.md
+iteration: 1
+findings_in_scope: 5
+fixed: 5
+skipped: 7
+status: all_fixed
+---
+
+# Phase 95: Code Review Fix Report
+
+**Fixed at:** 2026-05-27T18:45:00Z
+**Source review:** `.planning/phases/95-asyncpg-copy-positions/95-REVIEW.md`
+**Iteration:** 1
+
+**Summary:**
+- Findings in scope: 5 (Warnings WR-01 through WR-05)
+- Fixed: 5
+- Skipped: 7 (all out-of-scope Info findings)
+
+## Fixed Issues
+
+### WR-01: Docker stats subprocess invoked twice per sample tick
+
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `787c1d0c`
+**Applied fix:** `_sample_docker` now returns the parsed `mem_bytes` so the CSV write and the peak tracker share a single docker stats observation. Removed the redundant `_get_docker_mem_bytes` helper entirely (its functionality is subsumed by `_sample_docker`'s new return value). This halves per-sample subprocess cost (one `docker stats --no-stream` per tick instead of two) and eliminates the per-sample CSV/peak divergence under live memory pressure.
+
+### WR-02: Dead parameters threaded through sampler helpers
+
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `787c1d0c` (combined with WR-01)
+**Applied fix:** Removed unused `fh` and `peak_mem_bytes` parameters from `_sample_docker` and unused `fh` from `_sample_pg_activity`. The `peak_mem_bytes` removal happened naturally as part of the WR-01 fix (the helper now returns the value instead of pretending to update it). Committed together with WR-01 because both fixes touch the same function signatures and the changes are inseparable.
+
+### WR-03: Bare `except Exception` swallows all errors with no logging
+
+**Files modified:** `scripts/stress_test_dual_platform_import.py`
+**Commit:** `b7cdd1c7`
+**Applied fix:** Added `print(f"[sampler] {kind} sample failed: {exc!r}", file=sys.stderr)` inside the `except Exception` blocks of both `_sample_docker` and `_sample_pg_activity`. Also added a dedicated `except FileNotFoundError: raise` branch in `_sample_docker` so a missing `docker` binary aborts the run immediately rather than silently producing 0-byte traces. The `_get_docker_mem_bytes` helper that the reviewer also flagged was removed by WR-01, so its `except` no longer exists. Did not add a `sample_failures` counter to the summary JSON (reviewer flagged that as a bonus suggestion, not required) — the stderr logging satisfies the "some operator-visible signal" requirement.
+
+### WR-04: Rollback-atomicity test leaks committed user across the session-scoped engine
+
+**Files modified:** `tests/test_game_repository_bulk_insert_positions.py`
+**Commit:** `8a4f0a54` (plus formatter follow-up `ec631ec5`)
+**Applied fix:** Chose reviewer's recommended option (a): wrapped the test body in `try/finally` and added a cleanup block that opens a fresh `session_maker()`, executes `DELETE FROM users WHERE id = :uid` for `user_id=2003`, and commits. The cleanup runs regardless of test outcome. Added an explanatory comment referencing WR-04. A follow-up `style(95)` commit picked up a ruff format unwrap of a multi-line assert (pure formatter output, no behavior change).
+
+### WR-05: Test file docstring claims "live dev Postgres" but tests run against `flawchess_test`
+
+**Files modified:** `tests/test_game_repository_bulk_insert_positions.py`, `.planning/phases/95-asyncpg-copy-positions/95-01-SUMMARY.md`
+**Commit:** `50842cc7`
+**Applied fix:** Updated the module docstring to "Uses the test Postgres DB (`flawchess_test`) via the `db_session` fixture, which auto-rolls-back each test (no DB mocks)." Also updated the matching phrasing in `95-01-SUMMARY.md` line 67 from "live dev Postgres" to "test Postgres DB (`flawchess_test`) via the `db_session` fixture (which auto-rolls-back each test)" — the reviewer flagged the SUMMARY phrasing explicitly as well.
+
+## Skipped Issues
+
+### IN-01: `chunk_size = 1700` is a magic number with a multi-line rationale
+
+**File:** `app/repositories/game_repository.py:223`
+**Reason:** out of scope (info)
+**Original issue:** The constant is duplicated across `game_repository.py` (local `chunk_size = 1700`) and `tests/test_game_repository_bulk_insert_positions.py` (`_CHUNK_SIZE = 1700`). Should be promoted to a module-level `_POSITION_CHUNK_SIZE` and imported from the test.
+
+### IN-02: `_POSITION_COPY_COLUMNS` referenced with `# noqa: SLF001` in tests
+
+**File:** `tests/test_game_repository_bulk_insert_positions.py:102, 136`
+**Reason:** out of scope (info)
+**Original issue:** Test imports a single-underscore-prefixed name and silences `SLF001` twice. Should rename to public `POSITION_COPY_COLUMNS` since it is a CI contract.
+
+### IN-03: `assert raw_conn is not None` runs in production with assertions disabled under `python -O`
+
+**File:** `app/repositories/game_repository.py:221`
+**Reason:** out of scope (info)
+**Original issue:** Type-narrowing `assert` is stripped under `python -O`; should be replaced with `if raw_conn is None: raise RuntimeError(...)`. Project doesn't currently use `-O`, so this is informational.
+
+### IN-04: Sampler keyword-only param `output_tag` has no default and follows params that do
+
+**File:** `scripts/stress_test_dual_platform_import.py:338-347`
+**Reason:** out of scope (info)
+**Original issue:** Required kw-only `output_tag` is positioned after kw-only args that have defaults; convention is required-first within a kw-only block.
+
+### IN-05: `PG_DBNAME` constant disagrees with the original plan (cosmetic)
+
+**File:** `scripts/stress_test_dual_platform_import.py:57`
+**Reason:** out of scope (info)
+**Original issue:** Plan said `flawchess_dev` (typo); code correctly uses `flawchess`. Reviewer suggested adding a one-line comment explaining the discrepancy.
+
+### IN-06: `_sample_pg_activity` opens a new connection per sample tick
+
+**File:** `scripts/stress_test_dual_platform_import.py:314`
+**Reason:** out of scope (info)
+**Original issue:** Each sample tick opens/closes a pooled connection. Should hold one connection open for the lifetime of the sampler. Pure efficiency improvement, not a correctness issue.
+
+### IN-07: `_sample_pg_activity` row count includes the sampler's own backend
+
+**File:** `scripts/stress_test_dual_platform_import.py:301-330`
+**Reason:** out of scope (info)
+**Original issue:** `peak_connection_count` is inflated by +1 from the sampler's own pg_stat_activity row. Pre/post comparison still valid (both include the +1). Pure observability noise.
+
+---
+
+_Fixed: 2026-05-27T18:45:00Z_
+_Fixer: Claude (gsd-code-fixer)_
+_Iteration: 1_

--- a/.planning/phases/95-asyncpg-copy-positions/95-REVIEW.md
+++ b/.planning/phases/95-asyncpg-copy-positions/95-REVIEW.md
@@ -1,0 +1,131 @@
+---
+phase: 95-asyncpg-copy-positions
+created: 2026-05-27T00:00:00Z
+reviewed: 2026-05-27T00:00:00Z
+depth: standard
+files_reviewed: 3
+files_reviewed_list:
+  - app/repositories/game_repository.py
+  - tests/test_game_repository_bulk_insert_positions.py
+  - scripts/stress_test_dual_platform_import.py
+findings:
+  critical: 0
+  warning: 5
+  info: 7
+  total: 12
+status: issues_found
+---
+
+# Phase 95: Code Review Report
+
+**Reviewed:** 2026-05-27
+**Depth:** standard
+**Files Reviewed:** 3
+**Status:** issues_found
+
+## Summary
+
+The asyncpg COPY conversion in `bulk_insert_positions` is correctly implemented: the column tuple matches the model, the connection acquisition chain enrolls the COPY in the active SQLAlchemy transaction (validated by a rollback-atomicity test), and NULL handling via `dict.get(col)` is sound. `bulk_insert_games` is byte-identical to its pre-phase form.
+
+No Critical issues found. Five Warnings, mostly in the stress driver (`scripts/stress_test_dual_platform_import.py`): the metric sampler runs `docker stats` twice per sampling tick (doubling the per-sample subprocess cost), several dead parameters get plumbed through helpers, broad `except Exception` blocks silently swallow sampler errors without any logging, and the rollback-atomicity test leaks a committed test user across the session-scoped engine. The stress driver is a one-off measurement tool, so the bar is "produces correct numbers without hanging" rather than production-grade, but the dead parameters and silent error swallowing make debugging harder if something goes wrong mid-run.
+
+## Warnings
+
+### WR-01: Docker stats subprocess invoked twice per sample tick
+
+**File:** `scripts/stress_test_dual_platform_import.py:189-202`
+**Issue:** `_sample_metrics` calls `_sample_docker(...)` (which spawns `docker stats --no-stream`) and then immediately calls `_get_docker_mem_bytes(...)` (which spawns `docker stats --no-stream` again) just to capture the peak. Each `docker stats --no-stream` invocation takes roughly 1-2 seconds, so every 5-second sample window now spends 2-4 s waiting on Docker — half of every sampling tick. The peak memory captured by the second invocation can disagree with the value written to the CSV by the first invocation (the two reads are seconds apart under live memory pressure), so the CSV trace and the `peak_mem_usage_bytes` field in the summary JSON are *not* sourced from the same observation. This complicates report interpretation: the table value and the per-row trace can legitimately diverge by hundreds of MB during an OOM spike.
+**Fix:** Have `_sample_docker` return the parsed `mem_bytes` and use that single value both for the CSV write and the peak tracker. Remove `_get_docker_mem_bytes` entirely (or keep it as a thin helper that `_sample_docker` calls internally).
+```python
+# scripts/stress_test_dual_platform_import.py — sketch
+async def _sample_docker(...) -> int:
+    # ... existing parse logic ...
+    writer.writerow({...})
+    return mem_bytes  # return the observation
+
+# in _sample_metrics:
+mem_bytes = await _sample_docker(ts=ts, db_container=db_container, writer=docker_writer)
+if mem_bytes > peak_mem_bytes:
+    peak_mem_bytes = mem_bytes
+# delete the second `await _get_docker_mem_bytes(...)` call
+```
+
+### WR-02: Dead parameters threaded through sampler helpers
+
+**File:** `scripts/stress_test_dual_platform_import.py:251-291` and `294-330`
+**Issue:** `_sample_docker(...)` accepts `fh` and `peak_mem_bytes` parameters that are never read inside the function body. `_sample_pg_activity(...)` accepts an `fh` parameter that is never read. The `peak_mem_bytes` arg is particularly misleading because it suggests the helper *updates* the peak — but the helper only writes a row; the actual peak update happens in the caller via the redundant `_get_docker_mem_bytes` call (WR-01). A future reader will spend time tracing why the peak tracker doesn't appear to be mutated through the helper signature it pretends to use.
+**Fix:** Remove the unused parameters. The `fh.flush()` calls already happen in `_sample_metrics` after both helpers return, so the file handles do not need to be passed in. Drop `peak_mem_bytes` from `_sample_docker`'s signature in tandem with WR-01.
+
+### WR-03: Bare `except Exception` in sampler helpers swallows all errors with no logging
+
+**File:** `scripts/stress_test_dual_platform_import.py:247-248`, `290-291`, `328-329`
+**Issue:** `_get_docker_mem_bytes`, `_sample_docker`, and `_sample_pg_activity` each wrap their full body in `try/except Exception: pass` (or `return 0`). If the `docker` binary is missing, the container name is wrong, asyncpg disconnects mid-run, or the pg query times out, the sampler silently keeps writing empty CSVs — the user only finds out at the end when the summary JSON shows `peak_mem_usage_bytes: 0` with no explanation. CLAUDE.md is explicit that scripts (not services) need not call `sentry_sdk.capture_exception`, but they still need *some* operator-visible signal. Right now there is no `print`, no `logging`, and the script doesn't even keep a counter of how many sample ticks failed.
+**Fix:** Add a one-line `print(f"[sampler] {kind} sample failed: {exc!r}", file=sys.stderr)` inside each except, and consider tracking a `sample_failures` counter in the summary JSON so a run that produced suspect data is flagged in the verdict report. Bonus: distinguish `FileNotFoundError` (missing `docker` binary, fatal) from transient errors (worth retrying) by re-raising the former.
+
+### WR-04: Rollback-atomicity test leaks committed user across the session-scoped engine
+
+**File:** `tests/test_game_repository_bulk_insert_positions.py:199-256`
+**Issue:** `test_bulk_insert_positions_rollback_atomicity` opens its own `async_sessionmaker(test_engine, ...)` to bypass the `db_session` rollback wrapper (correct, per D-7), and explicitly commits the test user via `await setup_session.commit()` before the inner rollback experiment. Because `test_engine` is **session-scoped** (see `tests/conftest.py:78`), this committed user (id=2003) persists for the rest of the pytest session. A future test that picks the same id, or any test that does a `SELECT COUNT(*) FROM users`, will see this leak. The `_truncate_all_tables` step in `conftest.py:101` only runs **once** at the start of the session, before any test executes — it does not run between tests.
+The test as written passes today by luck (no other test happens to use id=2003 or assert on a clean users table), but the leak is real. The same risk applies to id=2001/2002/2004 from the other tests, except those use the rollback-wrapped `db_session` so they auto-clean.
+**Fix:** Either (a) wrap the user creation in a `try/finally` that explicitly `DELETE FROM users WHERE id = 2003` in a fresh session at test teardown, or (b) use a random user_id per run (e.g. derived from `uuid.uuid4().int % 2**31`) so id collisions become statistically impossible, or (c) add a `@pytest.fixture(autouse=True)` to this test file that cleans up the test users on teardown. Option (a) is the cleanest.
+
+### WR-05: Test file docstring claims "live dev Postgres", but tests run against `flawchess_test`
+
+**File:** `tests/test_game_repository_bulk_insert_positions.py:1-6`
+**Issue:** The module docstring says "Uses the live test Postgres DB via the db_session fixture (no DB mocks)" — but earlier in the same docstring the wording is "live test Postgres DB". The phase summary's text says "6 integration tests against dev Postgres" (95-01-SUMMARY.md). The actual fixture (`tests/conftest.py:78-108`) creates an engine bound to `settings.TEST_DATABASE_URL` (`flawchess_test`), not the dev DB. The confusion matters because a developer reading the failing test output may try to debug against the dev DB schema and miss that schema drift could exist between the two databases (alembic_version aside, both are migrated by `alembic upgrade head` against the same migrations, so they should match — but the assertion is implicit, not enforced).
+**Fix:** Update the docstring to "Uses the test Postgres DB (`flawchess_test`) via the `db_session` fixture, which auto-rolls-back each test." Fix the same phrasing in `95-01-SUMMARY.md` if accuracy matters there.
+
+## Info
+
+### IN-01: `chunk_size = 1700` is a magic number with a multi-line rationale
+
+**File:** `app/repositories/game_repository.py:223`
+**Issue:** The constant is defined as a local variable inside `bulk_insert_positions` with the rationale captured only in the function-level docstring. The number is also referenced by tests as `_CHUNK_SIZE = 1700` (a separate copy in `tests/test_game_repository_bulk_insert_positions.py:24`). If a future tuning change updates one but not the other, the chunking-boundary test silently stops exercising the boundary.
+**Fix:** Promote `chunk_size` to a module-level constant `_POSITION_CHUNK_SIZE: int = 1700` and import it from the test file. This is a small lift and removes the duplication.
+
+### IN-02: `_POSITION_COPY_COLUMNS` referenced with `# noqa: SLF001` in tests
+
+**File:** `tests/test_game_repository_bulk_insert_positions.py:102, 136`
+**Issue:** The test imports a single-underscore-prefixed name (`_POSITION_COPY_COLUMNS`) and silences `SLF001` (private member access) twice. The leading underscore signals "module-private", but the test's whole purpose is to assert a CI contract on this constant — so either it's a public CI artifact (drop the underscore) or it's private (then expose a public helper like `get_position_copy_columns()` for the test to call). Either pattern is cleaner than `# noqa: SLF001` repeated at every access site.
+**Fix:** Rename to `POSITION_COPY_COLUMNS` (public) — this signals "this is the contract enforced by CI" and removes the `noqa` clutter. Existing callers in this file are the only consumers.
+
+### IN-03: `assert raw_conn is not None` runs in production with assertions disabled under `python -O`
+
+**File:** `app/repositories/game_repository.py:221`
+**Issue:** The `assert` is added (per the summary) to satisfy `ty` type narrowing on a `Connection | None` slot. Under `python -O` or `PYTHONOPTIMIZE=1`, asserts are stripped — the code would silently call `.copy_records_to_table` on `None` and raise `AttributeError: 'NoneType' object has no attribute 'copy_records_to_table'` at runtime. The current project doesn't use `-O` (verified via the docker entrypoint and CLAUDE.md commands), so this is informational rather than a bug — but the pattern of "assert for type narrowing" is fragile.
+**Fix:** Replace with an explicit check that always runs:
+```python
+if raw_conn is None:
+    raise RuntimeError("asyncpg driver_connection is None — SQLAlchemy adapter changed")
+```
+This survives `-O` and gives a more specific runtime error if the dialect ever changes (which the comment already anticipates).
+
+### IN-04: Sampler keyword-only param `output_tag` has no default and follows params that do
+
+**File:** `scripts/stress_test_dual_platform_import.py:338-347`
+**Issue:** `run_stress_test(*, user_id, chesscom_username, lichess_username, sample_interval_s=5.0, db_container_name="...", output_dir=Path(...), output_tag)` has `output_tag` (no default) **after** several keyword-only args that *do* have defaults. This is legal Python (all are keyword-only after `*`), but the ordering misleads readers: by convention, required-without-default args come first within a keyword-only block. A reader scanning the signature could miss that `output_tag` is required.
+**Fix:** Move `output_tag` to immediately after the other required args (`user_id`, `chesscom_username`, `lichess_username`).
+
+### IN-05: `PG_DBNAME` constant disagrees with the original plan (cosmetic)
+
+**File:** `scripts/stress_test_dual_platform_import.py:57`
+**Issue:** The plan (`95-02-PLAN.md` line 107) specified `WHERE datname='flawchess_dev'`, but the actual dev database name is `flawchess` (verified via `app/core/config.py:DATABASE_URL`). The author correctly identified and fixed this — but there's no comment explaining the discrepancy. A future maintainer reading 95-02-PLAN.md against the code will wonder if the value is a typo or intentional.
+**Fix:** Add a one-line comment: `# Dev DB name is "flawchess" per app.core.config.settings.DATABASE_URL; the plan said "flawchess_dev" which was a plan-side typo.`
+
+### IN-06: `_sample_pg_activity` opens a new connection per sample tick
+
+**File:** `scripts/stress_test_dual_platform_import.py:314`
+**Issue:** Each sample tick calls `async with engine.connect() as conn:` — opens and closes a connection from the pool every 5 seconds. With `pool_size=1, max_overflow=0` (line 171), this is one of two pooled connections cycling; each cycle does a TCP handshake and authentication round-trip. Not a correctness issue (the result row counts will be the same), but each sampler tick now counts the sampler's own connection in `pg_stat_activity`, slightly inflating `peak_connection_count`. Hold the connection open for the lifetime of the sampler instead.
+**Fix:** Open one connection in the outer `with` block in `_sample_metrics` and pass it to `_sample_pg_activity`, mirroring how `docker_writer` is opened once and reused.
+
+### IN-07: Out-of-scope: `_sample_pg_activity` row count includes the sampler's own backend
+
+**File:** `scripts/stress_test_dual_platform_import.py:301-330`
+**Issue:** `peak_connection_count` will be at least 1 even with no imports running (the sampler's own SELECT shows up in `pg_stat_activity`). The pre-copy vs post-copy comparison is still valid (both runs include the +1), but the absolute number reported in the verdict report should be documented as "includes sampler backend." Pure observability noise — not a correctness issue.
+**Fix:** Either filter out the sampler's PID via `AND pid != pg_backend_pid()` in the WHERE clause, or document the +1 offset in the report's Methodology section.
+
+---
+
+_Reviewed: 2026-05-27_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/app/repositories/game_repository.py
+++ b/app/repositories/game_repository.py
@@ -3,12 +3,40 @@
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from sqlalchemy import delete, func, insert, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game import Game
 from app.models.game_position import GamePosition
+
+# Explicit column list for asyncpg copy_records_to_table. Must be set-equal to
+# {c.name for c in GamePosition.__table__.columns if c.name != "id"} — enforced
+# by test_bulk_insert_positions_column_coverage. The ordering here is the
+# functional contract: each row tuple is built by iterating over this tuple, so
+# if a future column is added to GamePosition without updating this constant the
+# CI test will fail and surfaced as a column-drift error before any data is written.
+_POSITION_COPY_COLUMNS: tuple[str, ...] = (
+    "game_id",
+    "user_id",
+    "ply",
+    "full_hash",
+    "white_hash",
+    "black_hash",
+    "move_san",
+    "clock_seconds",
+    "material_count",
+    "material_signature",
+    "material_imbalance",
+    "has_opposite_color_bishops",
+    "piece_count",
+    "backrank_sparse",
+    "mixedness",
+    "phase",
+    "eval_cp",
+    "eval_mate",
+    "endgame_class",
+)
 
 
 async def bulk_insert_games(session: AsyncSession, game_rows: list[dict]) -> list[int]:
@@ -159,29 +187,46 @@ async def count_games_by_platform(session: AsyncSession, user_id: int) -> dict[s
 
 
 async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]) -> None:
-    """Bulk insert GamePosition rows for the given game.
+    """Bulk insert GamePosition rows via asyncpg's binary COPY protocol.
 
     Should only be called for game IDs returned by bulk_insert_games (new games only).
     No conflict handling — positions are only inserted for newly inserted games.
 
+    Uses asyncpg's copy_records_to_table, which streams rows as a binary blob
+    and runs with roughly constant per-backend Postgres parser/executor memory
+    regardless of row count — unlike INSERT ... VALUES which materialises up to
+    rows × columns bound parameters in Postgres memory.
+
+    The COPY runs on the asyncpg Connection underlying the SQLAlchemy AsyncSession,
+    so it participates in the session's active transaction. A session-level rollback
+    after a successful COPY will undo the inserted rows.
+
+    Chunking at chunk_size=1700 is retained to bound peak Python-side list memory
+    and to give asyncio a yield point between chunks. The 32k-bound-parameter
+    ceiling of INSERT ... VALUES does not apply to COPY.
+
     Args:
         session: AsyncSession to use for the insert.
-        position_rows: List of dicts with keys: game_id, user_id, ply,
-                       full_hash, white_hash, black_hash, move_san, clock_seconds,
-                       and optionally: material_count, material_signature,
-                       material_imbalance, has_opposite_color_bishops,
-                       eval_cp, eval_mate, endgame_class, piece_count.
+        position_rows: List of dicts with keys matching _POSITION_COPY_COLUMNS.
+                       Missing optional keys default to None.
     """
     if not position_rows:
         return
 
-    # PostgreSQL asyncpg limits query arguments to 32,767.
-    # Each position row has 19 columns (8 original + 5 position metadata + 2 phase detection + 2 eval + 1 endgame_class + 1 piece_count),
-    # so max rows per chunk = 32767 / 19 = 1724.
-    # Use 1700 for safety margin.
+    sa_conn = await session.connection()
+    raw_wrapper = await sa_conn.get_raw_connection()
+    # driver_connection is the asyncpg.Connection inside SQLAlchemy's async wrapper.
+    # It is always set after get_raw_connection() when using the asyncpg dialect.
+    raw_conn = raw_wrapper.driver_connection
+    assert raw_conn is not None, "asyncpg driver_connection must not be None"
+
     chunk_size = 1700
     for i in range(0, len(position_rows), chunk_size):
         chunk = position_rows[i : i + chunk_size]
-        stmt = insert(GamePosition).values(chunk)
-        await session.execute(stmt)
+        records = [tuple(row.get(col) for col in _POSITION_COPY_COLUMNS) for row in chunk]
+        await raw_conn.copy_records_to_table(
+            "game_positions",
+            records=records,
+            columns=_POSITION_COPY_COLUMNS,
+        )
     await session.flush()

--- a/app/repositories/game_repository.py
+++ b/app/repositories/game_repository.py
@@ -16,6 +16,12 @@ from app.models.game_position import GamePosition
 # functional contract: each row tuple is built by iterating over this tuple, so
 # if a future column is added to GamePosition without updating this constant the
 # CI test will fail and surfaced as a column-drift error before any data is written.
+# IN-01 fix: promote the chunk size to a module-level constant so the test file
+# can import it instead of duplicating the literal (`_CHUNK_SIZE = 1700` in
+# tests/test_game_repository_bulk_insert_positions.py). Keeps the chunking
+# boundary test honest if this value is ever tuned.
+_POSITION_CHUNK_SIZE: int = 1700
+
 _POSITION_COPY_COLUMNS: tuple[str, ...] = (
     "game_id",
     "user_id",
@@ -201,7 +207,7 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
     so it participates in the session's active transaction. A session-level rollback
     after a successful COPY will undo the inserted rows.
 
-    Chunking at chunk_size=1700 is retained to bound peak Python-side list memory
+    Chunking at _POSITION_CHUNK_SIZE (1700) is retained to bound peak Python-side list memory
     and to give asyncio a yield point between chunks. The 32k-bound-parameter
     ceiling of INSERT ... VALUES does not apply to COPY.
 
@@ -220,9 +226,8 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
     raw_conn = raw_wrapper.driver_connection
     assert raw_conn is not None, "asyncpg driver_connection must not be None"
 
-    chunk_size = 1700
-    for i in range(0, len(position_rows), chunk_size):
-        chunk = position_rows[i : i + chunk_size]
+    for i in range(0, len(position_rows), _POSITION_CHUNK_SIZE):
+        chunk = position_rows[i : i + _POSITION_CHUNK_SIZE]
         records = [tuple(row.get(col) for col in _POSITION_COPY_COLUMNS) for row in chunk]
         await raw_conn.copy_records_to_table(
             "game_positions",

--- a/app/repositories/game_repository.py
+++ b/app/repositories/game_repository.py
@@ -224,7 +224,17 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
     # driver_connection is the asyncpg.Connection inside SQLAlchemy's async wrapper.
     # It is always set after get_raw_connection() when using the asyncpg dialect.
     raw_conn = raw_wrapper.driver_connection
-    assert raw_conn is not None, "asyncpg driver_connection must not be None"
+    # IN-03 fix: explicit runtime check (not `assert`) so the guard survives
+    # `python -O` / `PYTHONOPTIMIZE=1`, which strips asserts. Under -O the
+    # original `assert` would silently call `.copy_records_to_table` on None
+    # and raise an unhelpful AttributeError. This branch should be unreachable
+    # in practice (SQLAlchemy's asyncpg adapter always sets driver_connection
+    # after get_raw_connection()), but if the adapter ever changes we get a
+    # specific, debuggable error instead.
+    if raw_conn is None:
+        raise RuntimeError(
+            "asyncpg driver_connection is None — SQLAlchemy adapter changed"
+        )
 
     for i in range(0, len(position_rows), _POSITION_CHUNK_SIZE):
         chunk = position_rows[i : i + _POSITION_CHUNK_SIZE]

--- a/app/repositories/game_repository.py
+++ b/app/repositories/game_repository.py
@@ -232,9 +232,7 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
     # after get_raw_connection()), but if the adapter ever changes we get a
     # specific, debuggable error instead.
     if raw_conn is None:
-        raise RuntimeError(
-            "asyncpg driver_connection is None — SQLAlchemy adapter changed"
-        )
+        raise RuntimeError("asyncpg driver_connection is None — SQLAlchemy adapter changed")
 
     for i in range(0, len(position_rows), _POSITION_CHUNK_SIZE):
         chunk = position_rows[i : i + _POSITION_CHUNK_SIZE]

--- a/app/repositories/game_repository.py
+++ b/app/repositories/game_repository.py
@@ -22,7 +22,7 @@ from app.models.game_position import GamePosition
 # boundary test honest if this value is ever tuned.
 _POSITION_CHUNK_SIZE: int = 1700
 
-_POSITION_COPY_COLUMNS: tuple[str, ...] = (
+POSITION_COPY_COLUMNS: tuple[str, ...] = (
     "game_id",
     "user_id",
     "ply",
@@ -213,7 +213,7 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
 
     Args:
         session: AsyncSession to use for the insert.
-        position_rows: List of dicts with keys matching _POSITION_COPY_COLUMNS.
+        position_rows: List of dicts with keys matching POSITION_COPY_COLUMNS.
                        Missing optional keys default to None.
     """
     if not position_rows:
@@ -228,10 +228,10 @@ async def bulk_insert_positions(session: AsyncSession, position_rows: list[dict]
 
     for i in range(0, len(position_rows), _POSITION_CHUNK_SIZE):
         chunk = position_rows[i : i + _POSITION_CHUNK_SIZE]
-        records = [tuple(row.get(col) for col in _POSITION_COPY_COLUMNS) for row in chunk]
+        records = [tuple(row.get(col) for col in POSITION_COPY_COLUMNS) for row in chunk]
         await raw_conn.copy_records_to_table(
             "game_positions",
             records=records,
-            columns=_POSITION_COPY_COLUMNS,
+            columns=POSITION_COPY_COLUMNS,
         )
     await session.flush()

--- a/frontend/src/hooks/useEvalCoverage.ts
+++ b/frontend/src/hooks/useEvalCoverage.ts
@@ -1,9 +1,14 @@
+import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { apiClient } from '@/api/client';
 import type { EvalCoverageResponse } from '@/types/api';
 
 const EVAL_COVERAGE_POLL_INTERVAL_MS = 3_000;
 const EVAL_COVERAGE_STALE_TIME_MS = 3_000;
+
+// Module-level guard so the reload only fires once across all hook consumers
+// in a single page lifetime. Reset implicitly when the page reloads.
+let evalCompletionReloadFired = false;
 
 /** Poll GET /imports/eval-coverage every 10s while Stockfish analysis is pending.
  *
@@ -35,11 +40,35 @@ export function useEvalCoverage() {
   });
 
   const data = query.data;
+  const isPending = (data?.pct_complete ?? 100) < 100;
+
+  // Reload the page once Stockfish finishes so eval-dependent stats
+  // (Conversion/Parity/Recovery, etc.) refresh without manual reload.
+  // Only triggers on a true pending→complete transition observed in this
+  // session — never on initial load when eval is already at 100%.
+  const wasPendingRef = useRef(false);
+  useEffect(() => {
+    if (isPending) {
+      wasPendingRef.current = true;
+      return;
+    }
+    if (
+      wasPendingRef.current &&
+      !evalCompletionReloadFired &&
+      data &&
+      data.total_count > 0 &&
+      data.pct_complete === 100
+    ) {
+      evalCompletionReloadFired = true;
+      window.location.reload();
+    }
+  }, [isPending, data]);
+
   return {
     pendingCount: data?.pending_count ?? 0,
     totalCount: data?.total_count ?? 0,
     pct: data?.pct_complete ?? 100,
-    isPending: (data?.pct_complete ?? 100) < 100,
+    isPending,
     isLoading: query.isLoading,
   };
 }

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -188,16 +188,16 @@ async def _sample_metrics(
 
         while not stop_event.is_set():
             ts = _ts_iso_utc()
-            await _sample_docker(
+            # WR-01 fix: _sample_docker now returns the parsed mem_bytes so the
+            # CSV write and peak tracker share a single docker stats observation
+            # (previously a second docker stats invocation captured the peak,
+            # causing the CSV trace and peak_mem_usage_bytes to diverge under
+            # live memory pressure, and doubling per-sample subprocess cost).
+            mem_bytes = await _sample_docker(
                 ts=ts,
                 db_container=db_container,
                 writer=docker_writer,
-                fh=docker_fh,
-                peak_mem_bytes=peak_mem_bytes,
             )
-            # Capture peak mem from the last written row (mutate via closure).
-            # Re-read from the CSV buffer approach is messy; track inline.
-            mem_bytes = await _get_docker_mem_bytes(db_container)
             if mem_bytes > peak_mem_bytes:
                 peak_mem_bytes = mem_bytes
 
@@ -205,7 +205,6 @@ async def _sample_metrics(
                 ts=ts,
                 engine=metric_engine,
                 writer=pg_writer,
-                fh=pg_fh,
             )
             if conn_count > peak_conn_count:
                 peak_conn_count = conn_count
@@ -224,39 +223,19 @@ async def _sample_metrics(
     return peak_mem_bytes, peak_conn_count
 
 
-async def _get_docker_mem_bytes(db_container: str) -> int:
-    """Return the current memory usage of db_container in bytes (0 on error)."""
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "docker",
-            "stats",
-            db_container,
-            "--no-stream",
-            "--format",
-            "{{.MemUsage}}",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
-        line = stdout.decode().strip()
-        if not line:
-            return 0
-        # "1.23GiB / 7.5GiB" — take the used (left) part.
-        used_part = line.split("/")[0].strip()
-        return _parse_mem_bytes(used_part)
-    except Exception:
-        return 0
-
-
 async def _sample_docker(
     *,
     ts: str,
     db_container: str,
     writer: "csv.DictWriter[str]",
-    fh: "object",
-    peak_mem_bytes: int,
-) -> None:
-    """Run docker stats --no-stream, parse, write one CSV row."""
+) -> int:
+    """Run docker stats --no-stream, parse, write one CSV row. Returns mem_bytes (0 on error).
+
+    WR-01 fix: single source of truth for both the CSV write and peak tracking —
+    previously the peak was captured by a second `_get_docker_mem_bytes` call,
+    which doubled the per-sample subprocess cost and could disagree with the
+    CSV row under live memory pressure.
+    """
     try:
         proc = await asyncio.create_subprocess_exec(
             "docker",
@@ -271,10 +250,10 @@ async def _sample_docker(
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
         line = stdout.decode().strip()
         if not line:
-            return
+            return 0
         parts = line.split("\t")
         if len(parts) < 3:
-            return
+            return 0
         mem_used = parts[0].split("/")[0].strip()
         mem_bytes = _parse_mem_bytes(mem_used)
         mem_perc = _parse_perc(parts[1])
@@ -287,8 +266,9 @@ async def _sample_docker(
                 "cpu_perc": f"{cpu_perc:.2f}",
             }
         )
+        return mem_bytes
     except Exception:
-        pass
+        return 0
 
 
 async def _sample_pg_activity(
@@ -296,7 +276,6 @@ async def _sample_pg_activity(
     ts: str,
     engine: object,
     writer: "csv.DictWriter[str]",
-    fh: "object",
 ) -> int:
     """Query pg_stat_activity, write one CSV row per backend, return row count."""
     sql = text(

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -267,7 +267,15 @@ async def _sample_docker(
             }
         )
         return mem_bytes
-    except Exception:
+    except FileNotFoundError:
+        # WR-03 fix: missing `docker` binary is fatal — re-raise so the run
+        # aborts immediately rather than silently producing 0-byte traces.
+        raise
+    except Exception as exc:
+        # WR-03 fix: surface the failure to stderr so the operator sees why
+        # the CSV trace has gaps. Previously this `except Exception: pass`
+        # made sampler failures invisible until the final summary.
+        print(f"[sampler] docker sample failed: {exc!r}", file=sys.stderr)
         return 0
 
 
@@ -304,8 +312,12 @@ async def _sample_pg_activity(
                     "query_excerpt": (row.query_excerpt or "").replace("\n", " "),
                 }
             )
-    except Exception:
-        pass
+    except Exception as exc:
+        # WR-03 fix: surface sampler failures to stderr instead of silently
+        # swallowing them. A pg disconnect or query timeout would otherwise
+        # leave the verdict report with peak_connection_count=0 and no clue
+        # why.
+        print(f"[sampler] pg_stat_activity sample failed: {exc!r}", file=sys.stderr)
     return conn_count
 
 

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -331,10 +331,10 @@ async def run_stress_test(
     user_id: int,
     chesscom_username: str,
     lichess_username: str,
+    output_tag: str,
     sample_interval_s: float = DEFAULT_SAMPLE_INTERVAL_S,
     db_container_name: str = DEFAULT_DB_CONTAINER,
     output_dir: Path = DEFAULT_OUTPUT_DIR,
-    output_tag: str,
 ) -> StressTestResult:
     """Orchestrate dual-platform import + metric capture for one tagged run.
 

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -175,51 +175,57 @@ async def _sample_metrics(
         pool_pre_ping=True,
     )
 
-    with (
-        docker_csv_path.open("w", newline="", encoding="utf-8") as docker_fh,
-        pg_csv_path.open("w", newline="", encoding="utf-8") as pg_fh,
-    ):
-        docker_writer: csv.DictWriter[str] = csv.DictWriter(
-            docker_fh, fieldnames=_DOCKER_CSV_HEADER
-        )
-        pg_writer: csv.DictWriter[str] = csv.DictWriter(pg_fh, fieldnames=_PG_CSV_HEADER)
-        docker_writer.writeheader()
-        pg_writer.writeheader()
-        docker_fh.flush()
-        pg_fh.flush()
-
-        while not stop_event.is_set():
-            ts = _ts_iso_utc()
-            # WR-01 fix: _sample_docker now returns the parsed mem_bytes so the
-            # CSV write and peak tracker share a single docker stats observation
-            # (previously a second docker stats invocation captured the peak,
-            # causing the CSV trace and peak_mem_usage_bytes to diverge under
-            # live memory pressure, and doubling per-sample subprocess cost).
-            mem_bytes = await _sample_docker(
-                ts=ts,
-                db_container=db_container,
-                writer=docker_writer,
+    # IN-06 fix: open a single pg connection for the lifetime of the sampler
+    # instead of opening/closing one per sample tick. Previously each tick did
+    # a TCP handshake + auth round-trip and contributed an extra row to
+    # pg_stat_activity (mildly inflating peak_connection_count). Mirrors the
+    # docker_writer pattern (open once, reuse).
+    async with metric_engine.connect() as pg_conn:
+        with (
+            docker_csv_path.open("w", newline="", encoding="utf-8") as docker_fh,
+            pg_csv_path.open("w", newline="", encoding="utf-8") as pg_fh,
+        ):
+            docker_writer: csv.DictWriter[str] = csv.DictWriter(
+                docker_fh, fieldnames=_DOCKER_CSV_HEADER
             )
-            if mem_bytes > peak_mem_bytes:
-                peak_mem_bytes = mem_bytes
-
-            conn_count = await _sample_pg_activity(
-                ts=ts,
-                engine=metric_engine,
-                writer=pg_writer,
-            )
-            if conn_count > peak_conn_count:
-                peak_conn_count = conn_count
-
+            pg_writer: csv.DictWriter[str] = csv.DictWriter(pg_fh, fieldnames=_PG_CSV_HEADER)
+            docker_writer.writeheader()
+            pg_writer.writeheader()
             docker_fh.flush()
             pg_fh.flush()
 
-            # Sleep in small slices so we respond to stop_event quickly.
-            elapsed = 0.0
-            slice_s = min(0.5, sample_interval)
-            while elapsed < sample_interval and not stop_event.is_set():
-                await asyncio.sleep(slice_s)
-                elapsed += slice_s
+            while not stop_event.is_set():
+                ts = _ts_iso_utc()
+                # WR-01 fix: _sample_docker now returns the parsed mem_bytes so the
+                # CSV write and peak tracker share a single docker stats observation
+                # (previously a second docker stats invocation captured the peak,
+                # causing the CSV trace and peak_mem_usage_bytes to diverge under
+                # live memory pressure, and doubling per-sample subprocess cost).
+                mem_bytes = await _sample_docker(
+                    ts=ts,
+                    db_container=db_container,
+                    writer=docker_writer,
+                )
+                if mem_bytes > peak_mem_bytes:
+                    peak_mem_bytes = mem_bytes
+
+                conn_count = await _sample_pg_activity(
+                    ts=ts,
+                    conn=pg_conn,
+                    writer=pg_writer,
+                )
+                if conn_count > peak_conn_count:
+                    peak_conn_count = conn_count
+
+                docker_fh.flush()
+                pg_fh.flush()
+
+                # Sleep in small slices so we respond to stop_event quickly.
+                elapsed = 0.0
+                slice_s = min(0.5, sample_interval)
+                while elapsed < sample_interval and not stop_event.is_set():
+                    await asyncio.sleep(slice_s)
+                    elapsed += slice_s
 
     await metric_engine.dispose()
     return peak_mem_bytes, peak_conn_count
@@ -284,10 +290,15 @@ async def _sample_docker(
 async def _sample_pg_activity(
     *,
     ts: str,
-    engine: object,
+    conn: object,
     writer: "csv.DictWriter[str]",
 ) -> int:
-    """Query pg_stat_activity, write one CSV row per backend, return row count."""
+    """Query pg_stat_activity, write one CSV row per backend, return row count.
+
+    IN-06 fix: takes a long-lived ``AsyncConnection`` instead of opening one per
+    call. The connection is owned by the outer ``_sample_metrics`` ``with`` block
+    and reused across every sample tick, eliminating per-tick connect/auth cost.
+    """
     sql = text(
         "SELECT pid, state, "
         "EXTRACT(EPOCH FROM (NOW() - query_start)) AS query_age_s, "
@@ -297,12 +308,11 @@ async def _sample_pg_activity(
     )
     conn_count = 0
     try:
-        from sqlalchemy.ext.asyncio import AsyncEngine  # noqa: PLC0415
+        from sqlalchemy.ext.asyncio import AsyncConnection  # noqa: PLC0415
 
-        assert isinstance(engine, AsyncEngine)
-        async with engine.connect() as conn:
-            result = await conn.execute(sql, {"dbname": PG_DBNAME})
-            rows = result.fetchall()
+        assert isinstance(conn, AsyncConnection)
+        result = await conn.execute(sql, {"dbname": PG_DBNAME})
+        rows = result.fetchall()
         for row in rows:
             conn_count += 1
             writer.writerow(

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -54,6 +54,8 @@ from app.services.import_service import JobState, create_job, get_job, run_impor
 DEFAULT_SAMPLE_INTERVAL_S: float = 5.0
 DEFAULT_DB_CONTAINER: str = "flawchess-dev-db-1"
 DEFAULT_OUTPUT_DIR: Path = Path("reports/phase95-stress-data")
+# Dev DB name is "flawchess" per app.core.config.settings.DATABASE_URL;
+# the plan (95-02-PLAN.md line 107) said "flawchess_dev" which was a plan-side typo.
 PG_DBNAME: str = "flawchess"
 
 # Columns for the docker-stats CSV.

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -304,7 +304,9 @@ async def _sample_pg_activity(
         "EXTRACT(EPOCH FROM (NOW() - query_start)) AS query_age_s, "
         "LEFT(query, 80) AS query_excerpt "
         "FROM pg_stat_activity "
-        "WHERE datname = :dbname"
+        # IN-07 fix: filter out the sampler's own backend so peak_connection_count
+        # reflects only import-driven connections, not the +1 from this SELECT.
+        "WHERE datname = :dbname AND pid != pg_backend_pid()"
     )
     conn_count = 0
     try:

--- a/scripts/stress_test_dual_platform_import.py
+++ b/scripts/stress_test_dual_platform_import.py
@@ -1,0 +1,619 @@
+"""Dual-platform import stress driver for Phase 95 COPY-conversion verification.
+
+Purpose: Spawn two concurrent import_service.run_import() calls (chess.com + lichess)
+for a real FlawChess user while sampling docker stats + pg_stat_activity at a
+configurable interval. Produces three output files per run:
+
+    {output_dir}/{output_tag}-docker-stats.csv
+    {output_dir}/{output_tag}-pg-activity.csv
+    {output_dir}/{output_tag}-summary.json
+
+The summary JSON exposes the peak memory, peak connection count, both ImportJob
+final statuses, and total wall-clock duration — the numbers that feed the
+phase95-import-stress-test-{date}.md verdict report.
+
+Entrypoint used: import_service.run_import(job_id: str) -> None
+Rationale: run_import is the exact code path the API calls via asyncio.create_task;
+calling it directly from a script exercises the identical hot lane without
+any mocking or simplified shim. create_job() seeds the in-memory registry with
+the job spec and returns the UUID that run_import consumes.
+
+DB connection for metric sampling: a dedicated AsyncEngine built from the
+DATABASE_URL env var (defaults to the dev DB at localhost:5432). This is
+separate from import_service's own sessions to avoid contention.
+
+Override env var: DATABASE_URL  (inherits from settings.DATABASE_URL default)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Bootstrap project root so `app.*` imports resolve when running as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text  # noqa: E402
+from sqlalchemy.ext.asyncio import create_async_engine  # noqa: E402
+
+from app.core.config import settings  # noqa: E402
+from app.services.import_service import JobState, create_job, get_job, run_import  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants — no magic numbers
+# ---------------------------------------------------------------------------
+
+DEFAULT_SAMPLE_INTERVAL_S: float = 5.0
+DEFAULT_DB_CONTAINER: str = "flawchess-dev-db-1"
+DEFAULT_OUTPUT_DIR: Path = Path("reports/phase95-stress-data")
+PG_DBNAME: str = "flawchess"
+
+# Columns for the docker-stats CSV.
+_DOCKER_CSV_HEADER = [
+    "timestamp_iso",
+    "mem_usage_bytes",
+    "mem_perc",
+    "cpu_perc",
+]
+
+# Columns for the pg-activity CSV.
+_PG_CSV_HEADER = [
+    "timestamp_iso",
+    "pid",
+    "state",
+    "query_age_s",
+    "query_excerpt",
+]
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StressTestResult:
+    """Summary of a completed stress test run."""
+
+    start_iso: str
+    end_iso: str
+    total_duration_s: float
+    chesscom_status: str
+    lichess_status: str
+    chesscom_error: str | None
+    lichess_error: str | None
+    peak_mem_usage_bytes: int
+    peak_connection_count: int
+    output_dir: Path
+    output_tag: str
+
+
+# ---------------------------------------------------------------------------
+# Docker stats parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_mem_bytes(raw: str) -> int:
+    """Parse a docker stats memory string (e.g. '1.23GiB') to bytes.
+
+    Returns 0 on parse failure.
+    """
+    raw = raw.strip()
+    match = re.match(r"([\d.]+)\s*(GiB|MiB|KiB|GB|MB|KB|B)", raw, re.IGNORECASE)
+    if not match:
+        return 0
+    value = float(match.group(1))
+    unit = match.group(2).lower()
+    factors: dict[str, float] = {
+        "gib": 1024**3,
+        "mib": 1024**2,
+        "kib": 1024.0,
+        "gb": 1_000_000_000.0,
+        "mb": 1_000_000.0,
+        "kb": 1_000.0,
+        "b": 1.0,
+    }
+    return int(value * factors.get(unit, 1.0))
+
+
+def _parse_perc(raw: str) -> float:
+    """Parse a percentage string like '12.3%' to a float. Returns 0.0 on failure."""
+    raw = raw.strip().rstrip("%")
+    try:
+        return float(raw)
+    except ValueError:
+        return 0.0
+
+
+def _ts_iso_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Metric sampler coroutine
+# ---------------------------------------------------------------------------
+
+
+async def _sample_metrics(
+    *,
+    output_dir: Path,
+    output_tag: str,
+    db_container: str,
+    sample_interval: float,
+    stop_event: asyncio.Event,
+) -> tuple[int, int]:
+    """Sample docker stats + pg_stat_activity until stop_event is set.
+
+    Appends rows to the two CSVs. Returns (peak_mem_bytes, peak_pg_connections).
+
+    The sampler opens its own AsyncEngine to avoid sharing sessions with the
+    import hot-lane. It connects to the default dev DATABASE_URL.
+    """
+    docker_csv_path = output_dir / f"{output_tag}-docker-stats.csv"
+    pg_csv_path = output_dir / f"{output_tag}-pg-activity.csv"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    peak_mem_bytes: int = 0
+    peak_conn_count: int = 0
+
+    # Build a separate engine for metric queries (pool_size=1 is enough).
+    metric_engine = create_async_engine(
+        settings.DATABASE_URL,
+        pool_size=1,
+        max_overflow=0,
+        pool_pre_ping=True,
+    )
+
+    with (
+        docker_csv_path.open("w", newline="", encoding="utf-8") as docker_fh,
+        pg_csv_path.open("w", newline="", encoding="utf-8") as pg_fh,
+    ):
+        docker_writer: csv.DictWriter[str] = csv.DictWriter(
+            docker_fh, fieldnames=_DOCKER_CSV_HEADER
+        )
+        pg_writer: csv.DictWriter[str] = csv.DictWriter(pg_fh, fieldnames=_PG_CSV_HEADER)
+        docker_writer.writeheader()
+        pg_writer.writeheader()
+        docker_fh.flush()
+        pg_fh.flush()
+
+        while not stop_event.is_set():
+            ts = _ts_iso_utc()
+            await _sample_docker(
+                ts=ts,
+                db_container=db_container,
+                writer=docker_writer,
+                fh=docker_fh,
+                peak_mem_bytes=peak_mem_bytes,
+            )
+            # Capture peak mem from the last written row (mutate via closure).
+            # Re-read from the CSV buffer approach is messy; track inline.
+            mem_bytes = await _get_docker_mem_bytes(db_container)
+            if mem_bytes > peak_mem_bytes:
+                peak_mem_bytes = mem_bytes
+
+            conn_count = await _sample_pg_activity(
+                ts=ts,
+                engine=metric_engine,
+                writer=pg_writer,
+                fh=pg_fh,
+            )
+            if conn_count > peak_conn_count:
+                peak_conn_count = conn_count
+
+            docker_fh.flush()
+            pg_fh.flush()
+
+            # Sleep in small slices so we respond to stop_event quickly.
+            elapsed = 0.0
+            slice_s = min(0.5, sample_interval)
+            while elapsed < sample_interval and not stop_event.is_set():
+                await asyncio.sleep(slice_s)
+                elapsed += slice_s
+
+    await metric_engine.dispose()
+    return peak_mem_bytes, peak_conn_count
+
+
+async def _get_docker_mem_bytes(db_container: str) -> int:
+    """Return the current memory usage of db_container in bytes (0 on error)."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "stats",
+            db_container,
+            "--no-stream",
+            "--format",
+            "{{.MemUsage}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        line = stdout.decode().strip()
+        if not line:
+            return 0
+        # "1.23GiB / 7.5GiB" — take the used (left) part.
+        used_part = line.split("/")[0].strip()
+        return _parse_mem_bytes(used_part)
+    except Exception:
+        return 0
+
+
+async def _sample_docker(
+    *,
+    ts: str,
+    db_container: str,
+    writer: "csv.DictWriter[str]",
+    fh: "object",
+    peak_mem_bytes: int,
+) -> None:
+    """Run docker stats --no-stream, parse, write one CSV row."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "stats",
+            db_container,
+            "--no-stream",
+            "--format",
+            "{{.MemUsage}}\t{{.MemPerc}}\t{{.CPUPerc}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        line = stdout.decode().strip()
+        if not line:
+            return
+        parts = line.split("\t")
+        if len(parts) < 3:
+            return
+        mem_used = parts[0].split("/")[0].strip()
+        mem_bytes = _parse_mem_bytes(mem_used)
+        mem_perc = _parse_perc(parts[1])
+        cpu_perc = _parse_perc(parts[2])
+        writer.writerow(
+            {
+                "timestamp_iso": ts,
+                "mem_usage_bytes": mem_bytes,
+                "mem_perc": f"{mem_perc:.2f}",
+                "cpu_perc": f"{cpu_perc:.2f}",
+            }
+        )
+    except Exception:
+        pass
+
+
+async def _sample_pg_activity(
+    *,
+    ts: str,
+    engine: object,
+    writer: "csv.DictWriter[str]",
+    fh: "object",
+) -> int:
+    """Query pg_stat_activity, write one CSV row per backend, return row count."""
+    sql = text(
+        "SELECT pid, state, "
+        "EXTRACT(EPOCH FROM (NOW() - query_start)) AS query_age_s, "
+        "LEFT(query, 80) AS query_excerpt "
+        "FROM pg_stat_activity "
+        "WHERE datname = :dbname"
+    )
+    conn_count = 0
+    try:
+        from sqlalchemy.ext.asyncio import AsyncEngine  # noqa: PLC0415
+
+        assert isinstance(engine, AsyncEngine)
+        async with engine.connect() as conn:
+            result = await conn.execute(sql, {"dbname": PG_DBNAME})
+            rows = result.fetchall()
+        for row in rows:
+            conn_count += 1
+            writer.writerow(
+                {
+                    "timestamp_iso": ts,
+                    "pid": row.pid,
+                    "state": row.state or "",
+                    "query_age_s": f"{row.query_age_s:.1f}" if row.query_age_s is not None else "",
+                    "query_excerpt": (row.query_excerpt or "").replace("\n", " "),
+                }
+            )
+    except Exception:
+        pass
+    return conn_count
+
+
+# ---------------------------------------------------------------------------
+# Main stress test orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def run_stress_test(
+    *,
+    user_id: int,
+    chesscom_username: str,
+    lichess_username: str,
+    sample_interval_s: float = DEFAULT_SAMPLE_INTERVAL_S,
+    db_container_name: str = DEFAULT_DB_CONTAINER,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    output_tag: str,
+) -> StressTestResult:
+    """Orchestrate dual-platform import + metric capture for one tagged run.
+
+    Spawns three tasks via asyncio.gather:
+      - Task A: run_import for chess.com
+      - Task B: run_import for lichess
+      - Task C: metric sampler (docker stats + pg_stat_activity at sample_interval_s)
+
+    Returns a StressTestResult with peak memory, peak connection count, and
+    both ImportJob final statuses.
+
+    Raises RuntimeError with a clear message if user_id is not found in the
+    dev DB (fast failure path).
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fast-fail check: verify the user exists before starting a 20-40 min run.
+    await _verify_user_exists(user_id)
+
+    start_epoch = time.monotonic()
+    start_iso = _ts_iso_utc()
+    print(f"[{start_iso}] Starting stress test: user_id={user_id} tag={output_tag!r}")
+    print(f"[{start_iso}]   chess.com username: {chesscom_username!r}")
+    print(f"[{start_iso}]   lichess   username: {lichess_username!r}")
+    print(f"[{start_iso}]   sample interval:   {sample_interval_s}s")
+    print(f"[{start_iso}]   db container:      {db_container_name!r}")
+    print(f"[{start_iso}]   output dir:        {output_dir}/")
+
+    # Create import jobs (registers in-memory state; run_import reads from registry).
+    chesscom_job_id = create_job(
+        user_id=user_id,
+        platform="chess.com",
+        username=chesscom_username,
+    )
+    lichess_job_id = create_job(
+        user_id=user_id,
+        platform="lichess",
+        username=lichess_username,
+    )
+
+    stop_event = asyncio.Event()
+
+    # Task C: sampler runs until imports finish.
+    sampler_task = asyncio.create_task(
+        _sample_metrics(
+            output_dir=output_dir,
+            output_tag=output_tag,
+            db_container=db_container_name,
+            sample_interval=sample_interval_s,
+            stop_event=stop_event,
+        )
+    )
+
+    # Tasks A and B: run_import never raises; failures land in job.status/error.
+    try:
+        results = await asyncio.gather(
+            run_import(chesscom_job_id),
+            run_import(lichess_job_id),
+            return_exceptions=True,
+        )
+    finally:
+        # Signal sampler to stop and wait for clean shutdown regardless of outcome.
+        stop_event.set()
+        try:
+            peak_mem_bytes, peak_conn_count = await asyncio.wait_for(sampler_task, timeout=15.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            sampler_task.cancel()
+            peak_mem_bytes = 0
+            peak_conn_count = 0
+
+    end_iso = _ts_iso_utc()
+    total_s = time.monotonic() - start_epoch
+
+    # Retrieve final job state from the in-memory registry.
+    chesscom_job: JobState | None = get_job(chesscom_job_id)
+    lichess_job: JobState | None = get_job(lichess_job_id)
+
+    chesscom_status = chesscom_job.status.value if chesscom_job else "unknown"
+    lichess_status = lichess_job.status.value if lichess_job else "unknown"
+    chesscom_error = chesscom_job.error if chesscom_job else None
+    lichess_error = lichess_job.error if lichess_job else None
+
+    # Log any gather-level exceptions (run_import shouldn't raise, but be safe).
+    for i, exc in enumerate(results):
+        if isinstance(exc, BaseException):
+            platform = "chess.com" if i == 0 else "lichess"
+            print(f"[{end_iso}] WARNING: {platform} run_import raised: {exc}")
+
+    result = StressTestResult(
+        start_iso=start_iso,
+        end_iso=end_iso,
+        total_duration_s=total_s,
+        chesscom_status=chesscom_status,
+        lichess_status=lichess_status,
+        chesscom_error=chesscom_error,
+        lichess_error=lichess_error,
+        peak_mem_usage_bytes=peak_mem_bytes,
+        peak_connection_count=peak_conn_count,
+        output_dir=output_dir,
+        output_tag=output_tag,
+    )
+
+    _write_summary_json(result)
+    _print_summary(result)
+    return result
+
+
+async def _verify_user_exists(user_id: int) -> None:
+    """Raise RuntimeError with a clear message if user_id is absent from the dev DB.
+
+    Uses a short-lived connection so failure is fast (< 1s) and the main run
+    never starts a 20-40 min import for a nonexistent user.
+    """
+    engine = create_async_engine(settings.DATABASE_URL, pool_pre_ping=True)
+    try:
+        async with engine.connect() as conn:
+            row = await conn.execute(text("SELECT id FROM users WHERE id = :uid"), {"uid": user_id})
+            found = row.fetchone()
+    finally:
+        await engine.dispose()
+
+    if found is None:
+        raise RuntimeError(
+            f"user_id={user_id} does not exist in the dev database "
+            f"({settings.DATABASE_URL}). "
+            "Create the user first or use a valid user_id."
+        )
+
+
+def _write_summary_json(result: StressTestResult) -> None:
+    """Write the run summary to {output_dir}/{output_tag}-summary.json."""
+    summary = {
+        "start_iso": result.start_iso,
+        "end_iso": result.end_iso,
+        "total_duration_s": round(result.total_duration_s, 1),
+        "output_tag": result.output_tag,
+        "chesscom_status": result.chesscom_status,
+        "lichess_status": result.lichess_status,
+        "chesscom_error": result.chesscom_error,
+        "lichess_error": result.lichess_error,
+        "peak_mem_usage_bytes": result.peak_mem_usage_bytes,
+        "peak_connection_count": result.peak_connection_count,
+    }
+    json_path = result.output_dir / f"{result.output_tag}-summary.json"
+    json_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(f"[{result.end_iso}] Summary written: {json_path}")
+
+
+def _print_summary(result: StressTestResult) -> None:
+    """Print a human-readable summary to stdout."""
+    peak_mb = result.peak_mem_usage_bytes / (1024**2)
+    print()
+    print("=" * 60)
+    print(f"  Stress test complete: {result.output_tag}")
+    print("=" * 60)
+    print(f"  Duration              : {result.total_duration_s / 60:.1f} min")
+    print(f"  chess.com import      : {result.chesscom_status}")
+    if result.chesscom_error:
+        print(f"    error               : {result.chesscom_error[:120]}")
+    print(f"  lichess import        : {result.lichess_status}")
+    if result.lichess_error:
+        print(f"    error               : {result.lichess_error[:120]}")
+    print(f"  Peak Postgres mem     : {peak_mb:.1f} MB ({result.peak_mem_usage_bytes:,} bytes)")
+    print(f"  Peak connection count : {result.peak_connection_count}")
+    print(f"  Output dir            : {result.output_dir}/")
+    print("=" * 60)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse and validate CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Phase 95 dual-platform import stress driver. "
+            "Runs concurrent chess.com + lichess imports for a FlawChess user, "
+            "sampling docker stats and pg_stat_activity at a fixed interval. "
+            "Writes {output_dir}/{output_tag}-docker-stats.csv, "
+            "{output_tag}-pg-activity.csv, and {output_tag}-summary.json."
+        ),
+    )
+    parser.add_argument(
+        "--user-id",
+        type=int,
+        required=True,
+        metavar="INT",
+        dest="user_id",
+        help="FlawChess internal user PK. Must exist in the dev database.",
+    )
+    parser.add_argument(
+        "--chesscom-username",
+        required=True,
+        metavar="STR",
+        dest="chesscom_username",
+        help="chess.com username to import from.",
+    )
+    parser.add_argument(
+        "--lichess-username",
+        required=True,
+        metavar="STR",
+        dest="lichess_username",
+        help="Lichess username to import from.",
+    )
+    parser.add_argument(
+        "--output-tag",
+        required=True,
+        metavar="STR",
+        dest="output_tag",
+        help=(
+            "Label for output files. Use 'pre-copy' for the baseline run "
+            "and 'post-copy' for the COPY-converted run."
+        ),
+    )
+    parser.add_argument(
+        "--sample-interval",
+        type=float,
+        default=DEFAULT_SAMPLE_INTERVAL_S,
+        metavar="SECONDS",
+        dest="sample_interval",
+        help=f"Metric sampling cadence in seconds (default: {DEFAULT_SAMPLE_INTERVAL_S}).",
+    )
+    parser.add_argument(
+        "--db-container",
+        default=DEFAULT_DB_CONTAINER,
+        metavar="STR",
+        dest="db_container",
+        help=(
+            f"Docker container name for the dev Postgres instance "
+            f"(default: {DEFAULT_DB_CONTAINER!r})."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        metavar="PATH",
+        dest="output_dir",
+        help=f"Directory for output CSVs and summary JSON (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+
+    args = parser.parse_args()
+    if args.sample_interval <= 0:
+        parser.error(f"--sample-interval must be > 0, got {args.sample_interval}")
+    return args
+
+
+async def main() -> None:
+    """Parse CLI args and run the stress test."""
+    args = parse_args()
+
+    try:
+        await run_stress_test(
+            user_id=args.user_id,
+            chesscom_username=args.chesscom_username,
+            lichess_username=args.lichess_username,
+            sample_interval_s=args.sample_interval,
+            db_container_name=args.db_container,
+            output_dir=args.output_dir,
+            output_tag=args.output_tag,
+        )
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\n[stress_test] Interrupted by user. Partial CSVs may have been flushed to disk.")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -1,0 +1,288 @@
+"""Tests for bulk_insert_positions in game_repository.
+
+Covers: column coverage, round-trip, NULL optional fields, empty-batch no-op,
+rollback atomicity, and chunking across the chunk_size boundary.
+Uses the live test Postgres DB via the db_session fixture (no DB mocks).
+"""
+
+import datetime
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.models.game import Game
+from app.models.game_position import GamePosition
+from app.repositories.game_repository import bulk_insert_games, bulk_insert_positions
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CHUNK_SIZE = 1700
+
+
+def _make_game_row(user_id: int) -> dict:
+    """Return a minimal valid games row dict."""
+    return {
+        "user_id": user_id,
+        "platform": "chess.com",
+        "platform_game_id": f"game-{uuid.uuid4().hex}",
+        "platform_url": None,
+        "pgn": "[Event 'Test']\n\n1. e4 *",
+        "result": "*",
+        "user_color": "white",
+        "time_control_str": "600+0",
+        "time_control_bucket": "blitz",
+        "time_control_seconds": 600,
+        "rated": True,
+        "white_username": "Alice",
+        "black_username": "Bob",
+        "white_rating": 1500,
+        "black_rating": 1500,
+        "opening_name": None,
+        "opening_eco": None,
+        "played_at": datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+    }
+
+
+def _make_full_position_row(game_id: int, user_id: int, ply: int) -> dict:
+    """Return a position row with every non-id column populated."""
+    base = ply * 1000
+    return {
+        "game_id": game_id,
+        "user_id": user_id,
+        "ply": ply,
+        "full_hash": base + 1,
+        "white_hash": base + 2,
+        "black_hash": base + 3,
+        "move_san": f"e{ply + 1}" if ply < 8 else None,
+        "clock_seconds": float(600 - ply * 5),
+        "material_count": 32 - ply,
+        "material_signature": f"KQRBNPkqrbnp-{ply}",
+        "material_imbalance": ply % 3,
+        "has_opposite_color_bishops": ply % 2 == 0,
+        "piece_count": max(0, 14 - ply),
+        "backrank_sparse": ply > 10,
+        "mixedness": ply * 3,
+        "phase": 0,
+        "eval_cp": 10 * ply,
+        "eval_mate": None,
+        "endgame_class": None,
+    }
+
+
+def _make_required_only_row(game_id: int, user_id: int, ply: int) -> dict:
+    """Return a position row with only the required FK+hash columns."""
+    return {
+        "game_id": game_id,
+        "user_id": user_id,
+        "ply": ply,
+        "full_hash": 0xABCD0000 + ply,
+        "white_hash": 0xBBBB0000 + ply,
+        "black_hash": 0xCCCC0000 + ply,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_column_coverage() -> None:
+    """The _POSITION_COPY_COLUMNS tuple must exactly match GamePosition non-id columns."""
+    import app.repositories.game_repository as repo_module
+
+    assert hasattr(repo_module, "_POSITION_COPY_COLUMNS"), (
+        "_POSITION_COPY_COLUMNS must be a module-level constant in game_repository"
+    )
+    columns = repo_module._POSITION_COPY_COLUMNS  # noqa: SLF001
+    model_columns = {c.name for c in GamePosition.__table__.columns if c.name != "id"}
+    assert set(columns) == model_columns, (
+        f"_POSITION_COPY_COLUMNS is missing or has extra columns.\n"
+        f"  In tuple only: {set(columns) - model_columns}\n"
+        f"  In model only: {model_columns - set(columns)}"
+    )
+    assert "id" not in columns, "id must NOT be in _POSITION_COPY_COLUMNS"
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_round_trip(db_session: AsyncSession) -> None:
+    """Insert 3 fully-populated rows, SELECT them back, assert every column round-trips."""
+    from tests.conftest import ensure_test_user
+
+    user_id = 2001
+    await ensure_test_user(db_session, user_id)
+
+    game_ids = await bulk_insert_games(db_session, [_make_game_row(user_id)])
+    game_id = game_ids[0]
+
+    rows = [_make_full_position_row(game_id, user_id, ply) for ply in range(3)]
+    await bulk_insert_positions(db_session, rows)
+    await db_session.flush()
+
+    result = await db_session.execute(
+        select(GamePosition).where(GamePosition.game_id == game_id).order_by(GamePosition.ply)
+    )
+    db_rows = result.scalars().all()
+
+    import app.repositories.game_repository as repo_module
+
+    assert len(db_rows) == 3, f"Expected 3 rows, got {len(db_rows)}"
+    for expected, actual in zip(rows, db_rows, strict=True):
+        for col in repo_module._POSITION_COPY_COLUMNS:  # noqa: SLF001
+            exp_val = expected.get(col)
+            act_val = getattr(actual, col)
+            # Float comparison: clock_seconds stored as REAL (4-byte float)
+            if col == "clock_seconds" and exp_val is not None and act_val is not None:
+                assert abs(act_val - exp_val) < 0.01, (
+                    f"col={col}: expected {exp_val!r}, got {act_val!r}"
+                )
+            else:
+                assert act_val == exp_val, f"col={col}: expected {exp_val!r}, got {act_val!r}"
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_null_optional_fields(db_session: AsyncSession) -> None:
+    """Insert 2 rows with only required keys; every optional column must read back as None."""
+    from tests.conftest import ensure_test_user
+
+    user_id = 2002
+    await ensure_test_user(db_session, user_id)
+
+    game_ids = await bulk_insert_games(db_session, [_make_game_row(user_id)])
+    game_id = game_ids[0]
+
+    rows = [_make_required_only_row(game_id, user_id, ply) for ply in range(2)]
+    await bulk_insert_positions(db_session, rows)
+    await db_session.flush()
+
+    result = await db_session.execute(
+        select(GamePosition).where(GamePosition.game_id == game_id).order_by(GamePosition.ply)
+    )
+    db_rows = result.scalars().all()
+    assert len(db_rows) == 2, f"Expected 2 rows, got {len(db_rows)}"
+
+    optional_cols = {
+        "move_san",
+        "clock_seconds",
+        "material_count",
+        "material_signature",
+        "material_imbalance",
+        "has_opposite_color_bishops",
+        "piece_count",
+        "backrank_sparse",
+        "mixedness",
+        "phase",
+        "eval_cp",
+        "eval_mate",
+        "endgame_class",
+    }
+    for row in db_rows:
+        for col in optional_cols:
+            val = getattr(row, col)
+            assert val is None, f"col={col} should be None for required-only row, got {val!r}"
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_empty_batch_noop(db_session: AsyncSession) -> None:
+    """Calling bulk_insert_positions([]) must be a no-op and not acquire a DB connection."""
+    with patch.object(type(db_session), "connection") as mock_conn:
+        await bulk_insert_positions(db_session, [])
+        mock_conn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_rollback_atomicity(test_engine) -> None:  # type: ignore[no-untyped-def]
+    """COPY must participate in the session transaction: rollback removes all rows.
+
+    Opens a fresh session (not the rollback-wrapped db_session) so that
+    session.rollback() actually abandons the transaction rather than just
+    restoring a savepoint.  After rollback a second fresh session reads back
+    zero games and zero positions for the test user.
+    """
+    from tests.conftest import ensure_test_user
+
+    session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    user_id = 2003
+    game_id: int | None = None
+
+    # Ensure user exists in a separate committed transaction.
+    async with session_maker() as setup_session:
+        await ensure_test_user(setup_session, user_id)
+        await setup_session.commit()
+
+    try:
+        async with session_maker() as session:
+            game_ids = await bulk_insert_games(session, [_make_game_row(user_id)])
+            game_id = game_ids[0]
+
+            rows = [_make_full_position_row(game_id, user_id, ply) for ply in range(5)]
+            await bulk_insert_positions(session, rows)
+
+            # Trigger a constraint violation: duplicate PK insert forces rollback.
+            # Use a raw SQL insert of a game with an explicit duplicate id.
+            await session.execute(
+                text("INSERT INTO games (id) VALUES (:gid)"),
+                {"gid": game_id},
+            )
+            # This flush should raise IntegrityError due to duplicate PK
+            await session.flush()
+
+    except Exception:
+        pass  # expected — the IntegrityError is the point
+
+    # Verify: both games and game_positions rows are gone for this user+game.
+    async with session_maker() as verify_session:
+        game_count = (
+            (await verify_session.execute(select(Game).where(Game.user_id == user_id)))
+            .scalars()
+            .all()
+        )
+        pos_count = (
+            (
+                await verify_session.execute(
+                    select(GamePosition).where(GamePosition.user_id == user_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(game_count) == 0, f"Expected 0 games after rollback, got {len(game_count)}"
+        assert len(pos_count) == 0, f"Expected 0 positions after rollback, got {len(pos_count)}"
+
+
+@pytest.mark.asyncio
+async def test_bulk_insert_positions_chunking_across_chunk_size(
+    db_session: AsyncSession,
+) -> None:
+    """Insert chunk_size + 1 (1701) rows; all 1701 must land in the table."""
+    from tests.conftest import ensure_test_user
+
+    user_id = 2004
+    await ensure_test_user(db_session, user_id)
+
+    game_ids = await bulk_insert_games(db_session, [_make_game_row(user_id)])
+    game_id = game_ids[0]
+
+    n_rows = _CHUNK_SIZE + 1  # 1701 — spans exactly two chunks
+    rows = [
+        {
+            "game_id": game_id,
+            "user_id": user_id,
+            "ply": ply,
+            "full_hash": ply | 0xFF00000000000000,  # unique per ply
+            "white_hash": ply | 0xAA00000000000000,
+            "black_hash": ply | 0xBB00000000000000,
+        }
+        for ply in range(n_rows)
+    ]
+    await bulk_insert_positions(db_session, rows)
+    await db_session.flush()
+
+    result = await db_session.execute(select(GamePosition).where(GamePosition.game_id == game_id))
+    inserted = result.scalars().all()
+    assert len(inserted) == n_rows, f"Expected {n_rows} rows after chunking, got {len(inserted)}"

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -215,44 +215,60 @@ async def test_bulk_insert_positions_rollback_atomicity(test_engine) -> None:  #
         await ensure_test_user(setup_session, user_id)
         await setup_session.commit()
 
+    # WR-04 fix: clean up the committed test user in a finally block so the
+    # session-scoped test_engine doesn't leak user_id=2003 across the rest
+    # of the pytest session. The other tests in this file use the
+    # rollback-wrapped db_session fixture and auto-clean, but this test
+    # bypasses that wrapper (per D-7) to exercise real rollback semantics.
     try:
-        async with session_maker() as session:
-            game_ids = await bulk_insert_games(session, [_make_game_row(user_id)])
-            game_id = game_ids[0]
+        try:
+            async with session_maker() as session:
+                game_ids = await bulk_insert_games(session, [_make_game_row(user_id)])
+                game_id = game_ids[0]
 
-            rows = [_make_full_position_row(game_id, user_id, ply) for ply in range(5)]
-            await bulk_insert_positions(session, rows)
+                rows = [_make_full_position_row(game_id, user_id, ply) for ply in range(5)]
+                await bulk_insert_positions(session, rows)
 
-            # Trigger a constraint violation: duplicate PK insert forces rollback.
-            # Use a raw SQL insert of a game with an explicit duplicate id.
-            await session.execute(
-                text("INSERT INTO games (id) VALUES (:gid)"),
-                {"gid": game_id},
-            )
-            # This flush should raise IntegrityError due to duplicate PK
-            await session.flush()
-
-    except Exception:
-        pass  # expected — the IntegrityError is the point
-
-    # Verify: both games and game_positions rows are gone for this user+game.
-    async with session_maker() as verify_session:
-        game_count = (
-            (await verify_session.execute(select(Game).where(Game.user_id == user_id)))
-            .scalars()
-            .all()
-        )
-        pos_count = (
-            (
-                await verify_session.execute(
-                    select(GamePosition).where(GamePosition.user_id == user_id)
+                # Trigger a constraint violation: duplicate PK insert forces rollback.
+                # Use a raw SQL insert of a game with an explicit duplicate id.
+                await session.execute(
+                    text("INSERT INTO games (id) VALUES (:gid)"),
+                    {"gid": game_id},
                 )
+                # This flush should raise IntegrityError due to duplicate PK
+                await session.flush()
+
+        except Exception:
+            pass  # expected — the IntegrityError is the point
+
+        # Verify: both games and game_positions rows are gone for this user+game.
+        async with session_maker() as verify_session:
+            game_count = (
+                (await verify_session.execute(select(Game).where(Game.user_id == user_id)))
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
-        assert len(game_count) == 0, f"Expected 0 games after rollback, got {len(game_count)}"
-        assert len(pos_count) == 0, f"Expected 0 positions after rollback, got {len(pos_count)}"
+            pos_count = (
+                (
+                    await verify_session.execute(
+                        select(GamePosition).where(GamePosition.user_id == user_id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(game_count) == 0, f"Expected 0 games after rollback, got {len(game_count)}"
+            assert len(pos_count) == 0, (
+                f"Expected 0 positions after rollback, got {len(pos_count)}"
+            )
+    finally:
+        # Clean up the committed user so it doesn't leak across the session.
+        async with session_maker() as cleanup_session:
+            await cleanup_session.execute(
+                text("DELETE FROM users WHERE id = :uid"),
+                {"uid": user_id},
+            )
+            await cleanup_session.commit()
 
 
 @pytest.mark.asyncio

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -259,9 +259,7 @@ async def test_bulk_insert_positions_rollback_atomicity(test_engine) -> None:  #
                 .all()
             )
             assert len(game_count) == 0, f"Expected 0 games after rollback, got {len(game_count)}"
-            assert len(pos_count) == 0, (
-                f"Expected 0 positions after rollback, got {len(pos_count)}"
-            )
+            assert len(pos_count) == 0, f"Expected 0 positions after rollback, got {len(pos_count)}"
     finally:
         # Clean up the committed user so it doesn't leak across the session.
         async with session_maker() as cleanup_session:

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -96,20 +96,20 @@ def _make_required_only_row(game_id: int, user_id: int, ply: int) -> dict:
 
 @pytest.mark.asyncio
 async def test_bulk_insert_positions_column_coverage() -> None:
-    """The _POSITION_COPY_COLUMNS tuple must exactly match GamePosition non-id columns."""
+    """The POSITION_COPY_COLUMNS tuple must exactly match GamePosition non-id columns."""
     import app.repositories.game_repository as repo_module
 
-    assert hasattr(repo_module, "_POSITION_COPY_COLUMNS"), (
-        "_POSITION_COPY_COLUMNS must be a module-level constant in game_repository"
+    assert hasattr(repo_module, "POSITION_COPY_COLUMNS"), (
+        "POSITION_COPY_COLUMNS must be a module-level constant in game_repository"
     )
-    columns = repo_module._POSITION_COPY_COLUMNS  # noqa: SLF001
+    columns = repo_module.POSITION_COPY_COLUMNS
     model_columns = {c.name for c in GamePosition.__table__.columns if c.name != "id"}
     assert set(columns) == model_columns, (
-        f"_POSITION_COPY_COLUMNS is missing or has extra columns.\n"
+        f"POSITION_COPY_COLUMNS is missing or has extra columns.\n"
         f"  In tuple only: {set(columns) - model_columns}\n"
         f"  In model only: {model_columns - set(columns)}"
     )
-    assert "id" not in columns, "id must NOT be in _POSITION_COPY_COLUMNS"
+    assert "id" not in columns, "id must NOT be in POSITION_COPY_COLUMNS"
 
 
 @pytest.mark.asyncio
@@ -136,7 +136,7 @@ async def test_bulk_insert_positions_round_trip(db_session: AsyncSession) -> Non
 
     assert len(db_rows) == 3, f"Expected 3 rows, got {len(db_rows)}"
     for expected, actual in zip(rows, db_rows, strict=True):
-        for col in repo_module._POSITION_COPY_COLUMNS:  # noqa: SLF001
+        for col in repo_module.POSITION_COPY_COLUMNS:
             exp_val = expected.get(col)
             act_val = getattr(actual, col)
             # Float comparison: clock_seconds stored as REAL (4-byte float)

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -16,13 +16,15 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.game import Game
 from app.models.game_position import GamePosition
-from app.repositories.game_repository import bulk_insert_games, bulk_insert_positions
+from app.repositories.game_repository import (
+    _POSITION_CHUNK_SIZE,
+    bulk_insert_games,
+    bulk_insert_positions,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_CHUNK_SIZE = 1700
 
 
 def _make_game_row(user_id: int) -> dict:
@@ -283,7 +285,7 @@ async def test_bulk_insert_positions_chunking_across_chunk_size(
     game_ids = await bulk_insert_games(db_session, [_make_game_row(user_id)])
     game_id = game_ids[0]
 
-    n_rows = _CHUNK_SIZE + 1  # 1701 — spans exactly two chunks
+    n_rows = _POSITION_CHUNK_SIZE + 1  # 1701 — spans exactly two chunks
     # Use values within signed int64 range: 0x7F00000000000000 | ply is safe.
     rows = [
         {

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -31,8 +31,8 @@ def _make_game_row(user_id: int) -> dict:
         "platform": "chess.com",
         "platform_game_id": f"game-{uuid.uuid4().hex}",
         "platform_url": None,
-        "pgn": "[Event 'Test']\n\n1. e4 *",
-        "result": "*",
+        "pgn": "[Event 'Test']\n\n1. e4 e5 *",
+        "result": "1/2-1/2",
         "user_color": "white",
         "time_control_str": "600+0",
         "time_control_bucket": "blitz",
@@ -269,14 +269,15 @@ async def test_bulk_insert_positions_chunking_across_chunk_size(
     game_id = game_ids[0]
 
     n_rows = _CHUNK_SIZE + 1  # 1701 — spans exactly two chunks
+    # Use values within signed int64 range: 0x7F00000000000000 | ply is safe.
     rows = [
         {
             "game_id": game_id,
             "user_id": user_id,
             "ply": ply,
-            "full_hash": ply | 0xFF00000000000000,  # unique per ply
-            "white_hash": ply | 0xAA00000000000000,
-            "black_hash": ply | 0xBB00000000000000,
+            "full_hash": 0x7F00000000000000 | ply,  # unique per ply, within int64
+            "white_hash": 0x5A00000000000000 | ply,
+            "black_hash": 0x3B00000000000000 | ply,
         }
         for ply in range(n_rows)
     ]

--- a/tests/test_game_repository_bulk_insert_positions.py
+++ b/tests/test_game_repository_bulk_insert_positions.py
@@ -2,7 +2,8 @@
 
 Covers: column coverage, round-trip, NULL optional fields, empty-batch no-op,
 rollback atomicity, and chunking across the chunk_size boundary.
-Uses the live test Postgres DB via the db_session fixture (no DB mocks).
+Uses the test Postgres DB (`flawchess_test`) via the `db_session` fixture,
+which auto-rolls-back each test (no DB mocks).
 """
 
 import datetime


### PR DESCRIPTION
## Summary
- **Phase 95**: Reimplements `bulk_insert_positions` on top of asyncpg's binary COPY for faster game-import position writes. Adds dual-platform import stress driver, code review fixes (WR-01..WR-05, IN-01..IN-07), and per-tick PG sampler hardening.
- **Bonus**: Frontend reload trigger — once Stockfish eval coverage reaches 100% after a pending state, the page reloads once so eval-dependent stats (Conversion/Parity/Recovery, etc.) refresh automatically.

## Test plan
- [ ] CI green (ruff, ty, pytest, frontend lint + tests, knip)
- [ ] On staging/prod, import a batch of games and confirm page auto-reloads when Stockfish completes
- [ ] Verify Conversion/Parity/Recovery values update without a manual refresh