### PR TITLE
chore(deps): resolve pydantic-ai 1.99.0 deprecation warnings

### DIFF
--- a/app/schemas/llm_log.py
+++ b/app/schemas/llm_log.py
@@ -8,7 +8,7 @@ All fields come from the caller:
     user_prompt, cache_hit, error — request/context
   - model — the pydantic-ai model string (e.g. `anthropic:claude-haiku-4-5-20251001`)
   - response_json — parsed EndgameInsightsReport dict, or None on error
-  - input_tokens, output_tokens — from pydantic-ai RunResult.usage()
+  - input_tokens, output_tokens — from pydantic-ai RunResult.usage
   - latency_ms — wall-clock time caller measured around Agent.run()
 
 Fields NOT on LlmLogCreate (repo/DB compute):

--- a/app/services/insights_llm.py
+++ b/app/services/insights_llm.py
@@ -317,18 +317,18 @@ def get_insights_agent() -> Agent[None, EndgameInsightsReport]:
         google_settings = GoogleModelSettings(
             google_thinking_config=_build_google_thinking_config(model_name),  # ty: ignore[invalid-argument-type]
         )
-        return Agent(  # ty: ignore[invalid-return-type, no-matching-overload]
+        return Agent(  # ty: ignore[invalid-return-type]
             google_model,
             output_type=EndgameInsightsReport,
             system_prompt=_SYSTEM_PROMPT,
-            output_retries=_OUTPUT_RETRIES,
+            retries={"output": _OUTPUT_RETRIES},
             model_settings=google_settings,
         )
-    return Agent(  # ty: ignore[invalid-return-type, no-matching-overload] — pydantic-ai Agent generic params depend on runtime model string; ty cannot infer Agent[None, EndgameInsightsReport] from a str variable
+    return Agent(  # ty: ignore[invalid-return-type] — pydantic-ai Agent generic params depend on runtime model string; ty cannot infer Agent[None, EndgameInsightsReport] from a str variable
         model_str,
         output_type=EndgameInsightsReport,
         system_prompt=_SYSTEM_PROMPT,
-        output_retries=_OUTPUT_RETRIES,
+        retries={"output": _OUTPUT_RETRIES},
     )
 
 
@@ -2065,7 +2065,7 @@ async def _run_agent(
         sentry_sdk.capture_exception(exc)
         return None, 0, 0, None, latency_ms, "provider_error"
     latency_ms = int((time.monotonic() - t0) * 1000)
-    usage = result.usage()
+    usage = result.usage
     thinking = usage.details.get(_THOUGHTS_DETAIL_KEY) or None
     return result.output, usage.input_tokens, usage.output_tokens, thinking, latency_ms, None
 

--- a/tests/services/test_insights_llm.py
+++ b/tests/services/test_insights_llm.py
@@ -3154,10 +3154,10 @@ class TestErrors:
             "model_used": "test",
             "prompt_version": "endgame_v16",
         }
-        fake = Agent(  # ty: ignore[no-matching-overload]
+        fake = Agent(
             TestModel(custom_output_args=bad_output),
             output_type=EndgameInsightsReport,
-            output_retries=0,  # no retries — fail immediately
+            retries={"output": 0},  # no retries — fail immediately
         )
         monkeypatch.setattr("app.services.insights_llm.get_insights_agent", lambda: fake)
         monkeypatch.setattr(

--- a/tests/test_insights_llm_thinking.py
+++ b/tests/test_insights_llm_thinking.py
@@ -133,6 +133,7 @@ class _FakeResult:
     output: EndgameInsightsReport
     _usage: _FakeUsage
 
+    @property
     def usage(self) -> _FakeUsage:  # pragma: no cover - trivial
         return self._usage
 


### PR DESCRIPTION
Follow-up to the pydantic-ai-slim 1.85.0 → 1.99.0 bump (#136). Clears the two deprecation warnings 1.99.0 emits against the insights service.

## Changes
- **`RunResult.usage()` → `RunResult.usage`** — now a property (`insights_llm.py`, plus a docstring reference in `llm_log.py`).
- **`Agent(output_retries=N)` → `retries={"output": N}`** — `output_retries` is deprecated for removal in pydantic-ai v2.0. Applied at both `Agent(...)` call sites and the test fake.
- **Removed now-unused `no-matching-overload` ty suppressions** — switching to the current `retries=` kwarg makes the constructor match ty's overloads, so the suppressions added during the #136 bump are no longer needed. The `invalid-return-type` ignores remain (ty can't infer the runtime-model generic).

## Verification
- `ruff format` / `ruff check` / `ty check` clean.
- `pytest tests/services/test_insights_llm.py` — 90 passed, including with `-W error::DeprecationWarning` to prove the warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)