### PR TITLE
hotfix(SEED-054): store engine best_move/pv at flaw_ply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ in `YYYY-MM-DD` (Europe/Zurich).
 
 - **Flaw stats faster and more accurate on large game libraries** — the analyzed-game gate now uses the pre-materialized `full_evals_completed_at` column instead of recomputing eval coverage across all positions on every request. This eliminates a full-partition scan that caused 135s average / 49-minute max latency under an eval drain on large accounts. Fully-analyzed short games are now correctly counted as analyzed. (260617-pu4)
 
+### Fixed
+
+- **"Better move" arrow now shows on Lichess-analyzed games** — the blue arrow that points out the move you should have played instead of a blunder was silently missing on games imported with Lichess's own analysis. The engine now also evaluates the position you moved from (not just the position after), so the better alternative is captured and the arrow renders. A one-time backfill fills this in for already-analyzed Lichess games. (SEED-054, 260618-rmk)
+
 ## [v1.27] Remote Eval Worker Fan-Out & In-App Feedback — 2026-06-16
 
 Scaled off-box eval compute beyond the idle backlog and added a low-friction feedback channel. Trusted remote workers can now claim explicit single-game "Analyze" jobs (server-busy overflow) and fan out import-time (entry-ply) evaluation on big first imports, so a brand-new user sees flaws and endgame stats sooner. A floating in-app feedback button (guests included) ties submissions to the page the user was on and pings the team via Sentry. Bundles the post-v1.26 stabilization work (guest welcome page, analyze-pill UX, import-counter/WAL ops fixes). Phases 121–123.

--- a/app/services/eval_drain.py
+++ b/app/services/eval_drain.py
@@ -318,7 +318,7 @@ async def _fetch_dedup_evals(
     identical to the self-join result: eval_cp/eval_mate are the eval OF the requested
     position and best_move is the engine's decision FROM it.
 
-    Read-side guards (ply <= DEDUP_MAX_PLY, not in flaw_adjacent_plies, not is_terminal)
+    Read-side guards (ply <= DEDUP_MAX_PLY, not in flaw_engine_plies, not is_terminal)
     remain entirely in the caller at ~line 1640 — UNCHANGED. This function only changes
     which table backs the lookup.
 
@@ -430,6 +430,46 @@ async def _batch_update_best_move_rows(
         f"UPDATE game_positions"  # noqa: S608 — no user input; params are bound
         f" SET best_move = v.best_move"
         f" FROM (VALUES {values_sql}) AS v(ply, best_move)"
+        f" WHERE game_positions.game_id = :game_id"
+        f" AND game_positions.ply = v.ply"
+    )
+    await session.execute(sql, params)
+
+
+async def _batch_update_pv_rows(
+    session: AsyncSession,
+    game_id: int,
+    pv_rows: list[tuple[int, str]],
+) -> None:
+    """Emit ONE batched UPDATE writing pv (principal variation) for the given plies.
+
+    Shared by the live drain (_classify_and_fill_oracle) and the SEED-054 backfill
+    (scripts/backfill_best_move_pv.py) so the (game_id, ply) keying is identical by
+    construction. pv is unbounded Text (PostgreSQL won't reject it at the column
+    level).
+
+    Does NOT catch exceptions — callers decide fault tolerance. The drain wraps the
+    call in its own try/except so a PV write failure never aborts the flaw rows +
+    oracle counts already written in the same transaction (T-108-04 / WR-01).
+
+    Uses CAST() rather than :: cast syntax for asyncpg compatibility (same reason
+    as _batch_update_best_move_rows). Guard: empty input is a no-op (no zero-row
+    VALUES UPDATE). Sequential execute on caller-owned session — no asyncio.gather
+    (CLAUDE.md).
+    """
+    if not pv_rows:
+        return
+    params: dict[str, int | str] = {"game_id": game_id}
+    values_parts: list[str] = []
+    for i, (ply, pv) in enumerate(pv_rows):
+        params[f"ply_{i}"] = ply
+        params[f"pv_{i}"] = pv
+        values_parts.append(f"(CAST(:ply_{i} AS smallint), CAST(:pv_{i} AS text))")
+    values_sql = ", ".join(values_parts)
+    sql = sa.text(
+        f"UPDATE game_positions"  # noqa: S608 — no user input; params are bound
+        f" SET pv = v.pv"
+        f" FROM (VALUES {values_sql}) AS v(ply, pv)"
         f" WHERE game_positions.game_id = :game_id"
         f" AND game_positions.ply = v.ply"
     )
@@ -719,54 +759,46 @@ async def _classify_and_fill_oracle(
         )
     )
 
-    # Flaw PV write: for each FlawRecord at ply N, write pv at ply N+1.
-    # The pv_string for ply N+1 comes from the engine_result_map entry at ply N+1
-    # (the board AFTER the flawed move — D-117-02 / Pitfall 4).
+    # Flaw PV write (D-117-02 / SEED-054): for each FlawRecord at ply N, write pv at
+    # BOTH ply N and ply N+1:
+    #   - ply N    = the ideal-continuation line from the pre-blunder decision board
+    #                (latent until a frontend surface renders it — SEED-054 Part 2).
+    #   - ply N+1  = the refutation line from the post-blunder board (D-117-02, the
+    #                SEED-039 tactic-motif input).
+    # Each pv_string comes from engine_result_map at its OWN ply. For lichess games
+    # ply N is engine-evaluated thanks to _flaw_engine_plies (SEED-054 Part 1); for
+    # chess.com every ply already ran. Opening dedup-transplanted plies are absent
+    # from engine_result_map → pv stays NULL there (acceptable per SEED-054). Deduped
+    # by ply: consecutive flaws can make one flaw's ply N collide with another's N+1.
     #
-    # FLAWCHESS-6B (Fixes FLAWCHESS-6B): replace the per-flaw UPDATE loop with a
-    # pre-filter-then-single-batched-UPDATE pattern.
+    # FLAWCHESS-6B: collect surviving (ply, pv_string) pairs, then ONE batched UPDATE
+    # via _batch_update_pv_rows.
     #
-    # Fault tolerance rationale: the pre-filter below collects surviving (pv_ply,
-    # pv_string) pairs up front; any skipped row is Sentry-captured but does not
-    # abort the rest. Batching trades per-row isolation for one round-trip — this
-    # is acceptable because pv is unbounded Text (PostgreSQL won't reject it at
-    # the column level), so the realistic failure mode in the old per-row code was
-    # a DB connection error that would have invalidated the whole session anyway,
-    # not a single bad row. The surviving rows still commit atomically with the
-    # flaw rows and oracle counts above (T-117-11). If the single batched execute
-    # fails, flaw rows + oracle counts are NOT rolled back — that propagation path
-    # is unchanged (both the old try/except and this new block are intentionally
-    # inside the write_session transaction; asyncpg-level errors invalidate the
-    # whole session regardless).
-    pv_pairs: list[tuple[int, str]] = []
+    # Fault tolerance rationale: batching trades per-row isolation for one round-trip —
+    # acceptable because pv is unbounded Text (PostgreSQL won't reject it at the column
+    # level), so the realistic failure mode is a DB connection error that would have
+    # invalidated the whole session anyway, not a single bad row. The surviving rows
+    # commit atomically with the flaw rows and oracle counts above (T-117-11). If the
+    # batched execute fails, flaw rows + oracle counts are NOT rolled back — both the
+    # old code and this block are inside the write_session transaction; asyncpg-level
+    # errors invalidate the whole session regardless.
+    flaw_pv_by_ply: dict[int, str] = {}
     for flaw in flaw_list:
         flaw_ply_val: int = flaw["ply"]
-        pv_ply = flaw_ply_val + 1
-        engine_entry = engine_result_map.get(pv_ply)
-        if engine_entry is None:
-            continue
-        _cp, _mt, _bm, pv_string = engine_entry
-        if pv_string is None:
-            continue
-        pv_pairs.append((pv_ply, pv_string))
+        for cand_ply in (flaw_ply_val, flaw_ply_val + 1):
+            if cand_ply in flaw_pv_by_ply:
+                continue
+            engine_entry = engine_result_map.get(cand_ply)
+            if engine_entry is None:
+                continue
+            _cp, _mt, _bm, pv_string = engine_entry
+            if pv_string is None:
+                continue
+            flaw_pv_by_ply[cand_ply] = pv_string
 
-    if pv_pairs:
-        params_pv: dict[str, int | str] = {"game_id": game_id}
-        pv_values_parts: list[str] = []
-        for i, (pv_ply, pv_string) in enumerate(pv_pairs):
-            params_pv[f"ply_{i}"] = pv_ply
-            params_pv[f"pv_{i}"] = pv_string
-            pv_values_parts.append(f"(CAST(:ply_{i} AS smallint), CAST(:pv_{i} AS text))")
-        pv_values_sql = ", ".join(pv_values_parts)
-        pv_sql = sa.text(
-            f"UPDATE game_positions"  # noqa: S608 — no user input; params are bound
-            f" SET pv = v.pv"
-            f" FROM (VALUES {pv_values_sql}) AS v(ply, pv)"
-            f" WHERE game_positions.game_id = :game_id"
-            f" AND game_positions.ply = v.ply"
-        )
+    if flaw_pv_by_ply:
         try:
-            await session.execute(pv_sql, params_pv)
+            await _batch_update_pv_rows(session, game_id, list(flaw_pv_by_ply.items()))
         except Exception as exc:
             # T-108-04 / WR-01: PV write failure must not abort flaw rows + oracle
             # counts already written above. Capture for visibility without embedding
@@ -779,23 +811,32 @@ async def _classify_and_fill_oracle(
             sentry_sdk.capture_exception(exc)
 
 
-async def _flaw_adjacent_plies(session: AsyncSession, game_id: int) -> set[int]:
-    """Pre-classify a lichess-eval game's flaws to find plies needing engine PV capture (D-117-13).
+async def _flaw_engine_plies(session: AsyncSession, game_id: int) -> set[int]:
+    """Pre-classify a lichess-eval game's flaws to find plies needing an engine pass (D-117-13 / SEED-054).
 
     Lichess-eval games (is_lichess_eval_game=True) carry a lichess %eval on
     (nearly) every ply, so the is_lichess_eval_game target filter in
-    _full_drain_tick would otherwise drop every flaw-adjacent ply before the
-    engine gather — and lichess supplies %eval but NO principal variation. The observed result (prod sanity check ~1 h after the
-    Phase 117 deploy) was 0% flaw-PV coverage for analyzed lichess games: every
-    flaw's refutation line (the SEED-039 input) was missing.
+    _full_drain_tick would otherwise drop every flaw ply before the engine
+    gather — and lichess supplies %eval but NO principal variation and NO
+    best_move. The observed result (prod sanity check ~1 h after the Phase 117
+    deploy) was 0% flaw-PV coverage for analyzed lichess games: every flaw's
+    refutation line (the SEED-039 input) was missing.
 
     Fix: classify flaws up front from the already-stored %evals — the SAME inputs
     the write-time classify in _classify_and_fill_oracle uses — and return the set
-    of {flaw_ply + 1} plies. The caller exempts these from the eval-preservation
-    filter and from the opening dedup so the engine evaluates exactly those
-    positions for PV capture, while the write path still preserves the lichess
+    of {flaw_ply, flaw_ply + 1} plies. The caller exempts these from the
+    eval-preservation filter and from the opening dedup so the engine evaluates
+    exactly those positions, while the write path still preserves the lichess
     %eval (D-116-04). Covers BOTH players' flaws (classify_game_flaws is two-sided
     per D-06), matching the write-time PV loop.
+
+    Two plies per flaw (SEED-054):
+    - flaw_ply: the pre-blunder decision board → best_move (the better alternative
+      the Flaw/Library arrow renders, read at game_positions[flaw_ply].best_move) +
+      the ideal-continuation pv at the decision ply. This was NULL for lichess
+      games before SEED-054 because the engine only ran at flaw_ply + 1.
+    - flaw_ply + 1: the post-blunder board → the refutation pv (D-117-02, the
+      SEED-039 tactic-motif input).
 
     Returns an empty set when the game is missing or classification reports
     insufficient coverage (GameNotAnalyzed) — the caller then falls back to the
@@ -816,7 +857,11 @@ async def _flaw_adjacent_plies(session: AsyncSession, game_id: int) -> set[int]:
     if "reason" in flaw_result:
         # GameNotAnalyzed: insufficient eval coverage — fall back to prior filter.
         return set()
-    return {flaw["ply"] + 1 for flaw in flaw_result}
+    plies: set[int] = set()
+    for flaw in flaw_result:
+        plies.add(flaw["ply"])
+        plies.add(flaw["ply"] + 1)
+    return plies
 
 
 # Minimal duck-typed view so count_game_severities can be called with a
@@ -1682,27 +1727,29 @@ async def _full_drain_tick() -> bool:
         # T-78-17). Filtering here avoids burning 1M-node calls whose results are
         # discarded.
         #
-        # D-117-13 EXCEPTION: flaw-adjacent plies (flaw_ply + 1) must still be
-        # engine-evaluated to capture the refutation PV. Lichess supplies %eval but
-        # NO PV, so without this exemption every flaw in an analyzed lichess game
-        # got 0 PV (verified in prod post-Phase-117). Pre-classify from the stored
-        # %evals to find {flaw_ply + 1}, then exempt those plies from the filter.
-        flaw_adjacent_plies: set[int] = set()
+        # D-117-13 / SEED-054 EXCEPTION: flaw plies (flaw_ply AND flaw_ply + 1) must
+        # still be engine-evaluated. flaw_ply + 1 captures the refutation PV; flaw_ply
+        # captures the better-alternative best_move + ideal-continuation PV. Lichess
+        # supplies %eval but NO PV and NO best_move, so without this exemption every
+        # flaw in an analyzed lichess game got 0 PV (verified in prod post-Phase-117)
+        # and a NULL best_move arrow (SEED-054). Pre-classify from the stored %evals
+        # to find {flaw_ply, flaw_ply + 1}, then exempt those plies from the filter.
+        flaw_engine_plies: set[int] = set()
         if is_lichess_eval_game:
-            flaw_adjacent_plies = await _flaw_adjacent_plies(load_session, game_id)
+            flaw_engine_plies = await _flaw_engine_plies(load_session, game_id)
             targets = [
                 t
                 for t in targets
-                if (t.eval_cp is None and t.eval_mate is None) or t.ply in flaw_adjacent_plies
+                if (t.eval_cp is None and t.eval_mate is None) or t.ply in flaw_engine_plies
             ]
 
-        # Partition opening-region hashes for dedup (EVAL-03). Flaw-adjacent plies
-        # are excluded so they always get a real engine eval + PV instead of an
-        # eval-only dedup transplant (which carries no pv_string — D-117-13).
+        # Partition opening-region hashes for dedup (EVAL-03). Flaw plies are
+        # excluded so they always get a real engine eval + best_move + PV instead of
+        # an eval-only dedup transplant (which carries no pv_string — D-117-13).
         dedup_hashes = [
             t.full_hash
             for t in targets
-            if t.ply <= _DEDUP_MAX_PLY and t.ply not in flaw_adjacent_plies and not t.is_terminal
+            if t.ply <= _DEDUP_MAX_PLY and t.ply not in flaw_engine_plies and not t.is_terminal
         ]
         dedup_map = await _fetch_dedup_evals(load_session, dedup_hashes)
     # load_session is now closed.
@@ -1713,15 +1760,16 @@ async def _full_drain_tick() -> bool:
     # Phase 117 EVAL-04: use evaluate_nodes_with_pv to capture best_move + PV string.
     # Tier-1 (QUEUE-03): fan ALL of one game's plies across the pool simultaneously.
     # Tiers 2/3: same gather — the distinction is how the game was claimed, not how it's analyzed.
-    # D-117-13: flaw-adjacent plies always go to the engine (PV capture), even if a
-    # sibling target with the same full_hash seeded the dedup map.
+    # D-117-13 / SEED-054: flaw plies (flaw_ply and flaw_ply + 1) always go to the
+    # engine (best_move + PV capture), even if a sibling target with the same
+    # full_hash seeded the dedup map.
     # The terminal eval-donor (SEED-044) is always engine-evaluated: it has no
     # full_hash in the dedup map and supplies the last move's after-eval.
     engine_targets = [
         t
         for t in targets
         if t.is_terminal
-        or t.ply in flaw_adjacent_plies
+        or t.ply in flaw_engine_plies
         or t.ply > _DEDUP_MAX_PLY
         or t.full_hash not in dedup_map
     ]

--- a/scripts/backfill_best_move_pv.py
+++ b/scripts/backfill_best_move_pv.py
@@ -1,40 +1,56 @@
-"""Backfill engine best_move + pv at flaw plies for stored lichess games (SEED-054).
+"""Backfill engine best_move + pv at flaw plies for stored games (SEED-054).
 
 Why this script exists
 ----------------------
 The Flaw card / Library Game card render a blue "better alternative" arrow from
 `game_positions[flaw_ply].best_move` — the engine's best move FROM the pre-blunder
-decision board. For lichess-eval games (`lichess_evals_at IS NOT NULL`) that column
-was NULL on essentially every flaw, because the live drain only ever engine-evaluated
-`flaw_ply + 1` (the opponent's reply). SEED-054 fixes the drain to also evaluate
-`flaw_ply` going forward; this script backfills the columns for games already stored.
+decision board. The live drain (pre-SEED-054) only ever engine-evaluated
+`flaw_ply + 1` (the opponent's reply), which left two holes in already-stored games:
 
-It runs from a local machine targeting prod over the SSH tunnel and writes the
-columns IN PLACE — it never touches the completion markers
-(`full_evals_completed_at` / `full_pv_completed_at`), so games never drop out of the
-Library / stats analyzed-gate mid-run (the decisive reason for a dedicated script
-over a worker re-enqueue — see SEED-054).
+- **lichess-eval games** (`lichess_evals_at IS NOT NULL`): `best_move` AND `pv` are
+  NULL at `flaw_ply` (lichess supplies %eval but no best_move/no PV) — the arrow
+  silently doesn't render.
+- **engine-analyzed games** (chess.com etc., `lichess_evals_at IS NULL`): `best_move`
+  is already set at every ply (the engine ran on all of them), but `pv` is NULL at
+  `flaw_ply` — only `flaw_ply + 1`'s refutation pv was written (D-117-02). The arrow
+  works there; the missing piece is the ideal-continuation `pv[flaw_ply]`.
+
+SEED-054 fixes the drain to also evaluate `flaw_ply` going forward; this script
+backfills BOTH holes for games already stored. It runs from a local machine targeting
+prod over the SSH tunnel and writes the columns IN PLACE — it never touches the
+completion markers (`full_evals_completed_at` / `full_pv_completed_at`), so games
+never drop out of the Library / stats analyzed-gate mid-run (the decisive reason for a
+dedicated script over a worker re-enqueue — see SEED-054).
+
+Scope is "already-analyzed games" by construction: it only touches positions that have
+`game_flaws` rows, which exist only after a full drain tick. So the engine compute was
+already spent; this run merely completes the best_move/pv columns on those games. No
+guest-account filter — a guest who ran on-demand "Analyze" on a lichess game hit the
+same broken arrow, so they should get the fix too.
 
 What it writes
 --------------
-For each lichess-game position at a flaw ply or flaw+1 with `best_move IS NULL`:
-- best_move (the better alternative / refutation move) — always when the engine
-  returns one.
-- pv (the principal-variation line) — when present.
-- NEVER eval_cp / eval_mate: the lichess %eval is authoritative and preserved
-  (same is_lichess_eval_game discipline as eval_drain._apply_full_eval_results).
+For each game position at a flaw ply or flaw+1, the engine runs a 1M-node search and
+the script writes, per row, ONLY the column(s) that were actually NULL:
+- best_move (the better alternative / refutation move) — when it was NULL and the
+  engine returns one.
+- pv (the principal-variation line) — when it was NULL and the engine returns one.
+- NEVER eval_cp / eval_mate: a lichess %eval or a prior engine eval at this ply is
+  authoritative and preserved (same is_lichess_eval_game discipline as
+  eval_drain._apply_full_eval_results). Writing only the originally-NULL column means
+  an engine game's existing best_move is never clobbered by a (non-deterministic) fresh
+  search — only its missing pv is filled.
 
 The write keying is identical to the live drain by construction: this script reuses
 `eval_drain._batch_update_best_move_rows` and `eval_drain._batch_update_pv_rows`.
 
 Idempotent / resumable
 ----------------------
-Selection is gated on `best_move IS NULL`, so a dropped SSH tunnel or Ctrl-C → just
-re-run; already-written positions are skipped. This naturally subsumes BOTH the
-SEED-043 cohort (never-reprocessed lichess games, NULL at both flaw plies) AND the
-SEED-054 keying gap (already-reprocessed games, NULL at flaw_ply only) in one pass.
-On lichess, best_move and pv are always written together, so `best_move IS NULL` is a
-sufficient resume predicate.
+Selection is gated on `best_move IS NULL OR pv IS NULL`, so a dropped SSH tunnel or
+Ctrl-C → just re-run; filled positions drop out of the predicate. This subsumes the
+SEED-043 cohort (never-reprocessed lichess games, NULL at both flaw plies), the
+SEED-054 lichess keying gap (best_move NULL at flaw_ply), AND the engine-game pv gap
+(best_move set, pv NULL at flaw_ply) in one pass.
 
 DB target host:port mapping (CLAUDE.md):
     dev:       localhost:5432  (Docker compose flawchess-dev)
@@ -164,14 +180,24 @@ def _boards_at_plies(pgn_text: str, plies: Sequence[int]) -> dict[int, chess.Boa
     return captured
 
 
-def _build_target_stmt(user_id: int | None, limit: int | None) -> Select[tuple[int, int, str]]:
-    """Build the SELECT for lichess flaw positions needing best_move (SEED-054).
+def _build_target_stmt(
+    user_id: int | None, limit: int | None
+) -> Select[tuple[int, int, str, bool, bool]]:
+    """Build the SELECT for flaw positions needing best_move and/or pv (SEED-054).
 
-    Selects (game_id, ply, pgn) for GamePosition rows where:
-    1. games.lichess_evals_at IS NOT NULL  (lichess-eval cohort only)
-    2. best_move IS NULL                   (idempotent / resumable — see module docstring)
-    3. the ply is a flaw ply OR a flaw+1 ply: EXISTS a game_flaws row at gp.ply
+    Selects (game_id, ply, pgn, need_bm, need_pv) for GamePosition rows where:
+    1. best_move IS NULL OR pv IS NULL  (idempotent / resumable — see module docstring;
+       covers the lichess best_move hole AND the engine-game pv hole in one pass)
+    2. the ply is a flaw ply OR a flaw+1 ply: EXISTS a game_flaws row at gp.ply
        (flaw_ply itself) or at gp.ply - 1 (gp.ply is flaw_ply + 1).
+
+    The flaw-row EXISTS also bounds scope to already-analyzed games (flaw rows are only
+    written by a full drain tick), so no analyzed-gate / guest filter is needed.
+
+    need_bm / need_pv are per-row "this column was NULL" flags so the writer fills only
+    the missing column and never clobbers an engine game's existing best_move with a
+    fresh (non-deterministic) search. Selecting the booleans (not pv itself) avoids
+    streaming the large pv text for rows that already have it.
 
     Ordered by (game_id, ply) so rows for one game are contiguous → the streaming
     reader can batch by game and replay each PGN exactly once.
@@ -184,11 +210,16 @@ def _build_target_stmt(user_id: int | None, limit: int | None) -> Select[tuple[i
     )
 
     stmt = (
-        select(GamePosition.game_id, GamePosition.ply, Game.pgn)
+        select(
+            GamePosition.game_id,
+            GamePosition.ply,
+            Game.pgn,
+            GamePosition.best_move.is_(None).label("need_bm"),
+            GamePosition.pv.is_(None).label("need_pv"),
+        )
         .join(Game, Game.id == GamePosition.game_id)
         .where(
-            Game.lichess_evals_at.isnot(None),
-            GamePosition.best_move.is_(None),
+            (GamePosition.best_move.is_(None)) | (GamePosition.pv.is_(None)),
             flaw_match,
         )
     )
@@ -232,17 +263,18 @@ async def _stream_game_batches(
             yield batch
 
 
-def _resolve_boards(rows: Sequence[Any]) -> list[tuple[int, int, chess.Board]]:
-    """Replay each game's PGN once → list of (game_id, ply, board) targets.
+def _resolve_boards(rows: Sequence[Any]) -> list[tuple[int, int, chess.Board, bool, bool]]:
+    """Replay each game's PGN once → list of (game_id, ply, board, need_bm, need_pv) targets.
 
     Rows arrive ordered by (game_id, ply); itertools.groupby gives one contiguous
     block per game so each PGN is parsed a single time. Plies whose board cannot be
     materialized (PGN parse failure) are dropped (counted by the caller as
-    skipped_no_board).
+    skipped_no_board). need_bm / need_pv are carried through from the query so the
+    writer fills only the originally-NULL column.
     """
     from itertools import groupby
 
-    out: list[tuple[int, int, chess.Board]] = []
+    out: list[tuple[int, int, chess.Board, bool, bool]] = []
     for _gid, group_iter in groupby(rows, key=lambda r: r.game_id):
         group = list(group_iter)
         plies = [r.ply for r in group]
@@ -250,7 +282,7 @@ def _resolve_boards(rows: Sequence[Any]) -> list[tuple[int, int, chess.Board]]:
         for r in group:
             board = boards.get(r.ply)
             if board is not None:
-                out.append((r.game_id, r.ply, board))
+                out.append((r.game_id, r.ply, board, r.need_bm, r.need_pv))
     return out
 
 
@@ -260,13 +292,16 @@ async def _process_batch(
     *,
     db: str,
     pool: EnginePool,
-) -> tuple[int, int, int]:
-    """Evaluate + write best_move/pv for one game-batch. Returns (written, no_board, engine_err).
+) -> tuple[int, int, int, int]:
+    """Evaluate + write best_move/pv for one game-batch.
 
-    For each target ply: run a 1M-node search, write best_move (when present) and pv
-    (when present) via the shared drain helpers. eval_cp / eval_mate are NEVER
-    written (lichess %eval preserved). Writes are grouped per game (the helpers are
-    game-scoped) and the whole batch commits once.
+    Returns (written_bm, written_pv, no_board, engine_err).
+
+    For each target ply: run a 1M-node search, then write ONLY the originally-NULL
+    column(s) — best_move when need_bm, pv when need_pv — via the shared drain
+    helpers. This never clobbers an engine game's existing best_move. eval_cp /
+    eval_mate are NEVER written (lichess %eval / prior engine eval preserved). Writes
+    are grouped per game (the helpers are game-scoped) and the whole batch commits once.
     """
     targets = _resolve_boards(rows)
     no_board = len(rows) - len(targets)
@@ -276,34 +311,39 @@ async def _process_batch(
     # Per-game accumulators: {game_id: [(ply, best_move)]} and {game_id: [(ply, pv)]}.
     bm_by_game: dict[int, list[tuple[int, str]]] = {}
     pv_by_game: dict[int, list[tuple[int, str]]] = {}
-    written = 0
+    written_bm = 0
+    written_pv = 0
     engine_err = 0
 
     for chunk_start in range(0, len(targets), EVAL_CHUNK_SIZE):
         chunk = targets[chunk_start : chunk_start + EVAL_CHUNK_SIZE]
         results = await asyncio.gather(
-            *(pool.evaluate_nodes_with_pv(board) for _gid, _ply, board in chunk)
+            *(pool.evaluate_nodes_with_pv(board) for _gid, _ply, board, _nb, _np in chunk)
         )
-        for (game_id, ply, _board), (_cp, _mt, best_move, pv) in zip(chunk, results, strict=True):
-            if best_move is None and pv is None:
-                # Engine failure (None, None, None, None) or a position with no PV —
-                # nothing to write. A genuine engine outage is the (None,)*4 case.
-                if best_move is None:
-                    engine_err += 1
-                    sentry_sdk.set_context(
-                        "backfill_best_move_pv",
-                        {"game_id": game_id, "ply": ply, "db_target": db},
-                    )
-                    sentry_sdk.set_tag("source", "backfill")
-                    sentry_sdk.capture_message(
-                        "backfill_best_move_pv: engine returned no best_move", level="warning"
-                    )
+        for (game_id, ply, _board, need_bm, need_pv), (_cp, _mt, best_move, pv) in zip(
+            chunk, results, strict=True
+        ):
+            if best_move is None:
+                # (None, None, None, None) — genuine engine failure (a legal position
+                # always yields a best move). pv is None too; nothing to write.
+                engine_err += 1
+                sentry_sdk.set_context(
+                    "backfill_best_move_pv",
+                    {"game_id": game_id, "ply": ply, "db_target": db},
+                )
+                sentry_sdk.set_tag("source", "backfill")
+                sentry_sdk.capture_message(
+                    "backfill_best_move_pv: engine returned no best_move", level="warning"
+                )
                 continue
-            if best_move is not None:
+            # Fill only the column that was originally NULL (never clobber an existing
+            # best_move / pv). best_move is present here; pv may still be None.
+            if need_bm:
                 bm_by_game.setdefault(game_id, []).append((ply, best_move))
-                written += 1
-            if pv is not None:
+                written_bm += 1
+            if need_pv and pv is not None:
                 pv_by_game.setdefault(game_id, []).append((ply, pv))
+                written_pv += 1
 
     # One pair of batched UPDATEs per game (keying identical to the drain), then a
     # single commit for the whole batch.
@@ -313,7 +353,7 @@ async def _process_batch(
         await _batch_update_pv_rows(session, game_id, pv_rows)
     await session.commit()
 
-    return written, no_board, engine_err
+    return written_bm, written_pv, no_board, engine_err
 
 
 async def run_backfill(
@@ -329,8 +369,8 @@ async def run_backfill(
 ) -> None:
     """SEED-054 backfill driver. Public callable for testability.
 
-    Idempotency / resume: selection is gated on best_move IS NULL, so a re-run after
-    a mid-run kill naturally continues (per-batch commit bounds the loss).
+    Idempotency / resume: selection is gated on (best_move IS NULL OR pv IS NULL), so a
+    re-run after a mid-run kill naturally continues (per-batch commit bounds the loss).
 
     _session_maker / _pool are internal test hooks; production callers omit both.
     """
@@ -353,7 +393,10 @@ async def run_backfill(
             count = (
                 await count_session.execute(select(func.count()).select_from(stmt.subquery()))
             ).scalar_one()
-        _log(f"--dry-run: {count} lichess flaw position(s) need best_move (best_move IS NULL).")
+        _log(
+            f"--dry-run: {count} flaw position(s) need best_move and/or pv "
+            "(best_move IS NULL OR pv IS NULL)."
+        )
         _log("--dry-run: exiting without starting engine or writing.")
         if dispose_engine and async_engine is not None:
             await async_engine.dispose()
@@ -370,7 +413,8 @@ async def run_backfill(
         pool = _pool
 
     rows_seen = 0
-    written_total = 0
+    written_bm_total = 0
+    written_pv_total = 0
     no_board_total = 0
     engine_err_total = 0
     batch_idx = 0
@@ -378,15 +422,17 @@ async def run_backfill(
         async with session_maker() as write_session:
             async for batch in _stream_game_batches(session_maker, stmt, GAMES_PER_BATCH):
                 batch_idx += 1
-                w, nb, ee = await _process_batch(batch, write_session, db=db, pool=pool)
+                wbm, wpv, nb, ee = await _process_batch(batch, write_session, db=db, pool=pool)
                 rows_seen += len(batch)
-                written_total += w
+                written_bm_total += wbm
+                written_pv_total += wpv
                 no_board_total += nb
                 engine_err_total += ee
                 _log(
                     f"  batch {batch_idx} done ({len(batch)} rows; cumulative "
-                    f"seen={rows_seen}, written_best_move={written_total}, "
-                    f"skipped_no_board={no_board_total}, engine_err={engine_err_total})"
+                    f"seen={rows_seen}, written_best_move={written_bm_total}, "
+                    f"written_pv={written_pv_total}, skipped_no_board={no_board_total}, "
+                    f"engine_err={engine_err_total})"
                 )
     finally:
         if dispose_pool:
@@ -394,11 +440,12 @@ async def run_backfill(
 
     if rows_seen:
         _log(
-            f"Backfill complete: rows={rows_seen}, written_best_move={written_total}, "
-            f"skipped_no_board={no_board_total}, engine_err={engine_err_total}"
+            f"Backfill complete: rows={rows_seen}, written_best_move={written_bm_total}, "
+            f"written_pv={written_pv_total}, skipped_no_board={no_board_total}, "
+            f"engine_err={engine_err_total}"
         )
     else:
-        _log("No lichess flaw positions needed best_move (no-op).")
+        _log("No flaw positions needed best_move or pv (no-op).")
 
     if dispose_engine and async_engine is not None:
         await async_engine.dispose()
@@ -407,7 +454,7 @@ async def run_backfill(
 def parse_args() -> argparse.Namespace:
     """Parse and validate CLI arguments."""
     parser = argparse.ArgumentParser(
-        description="Backfill engine best_move + pv at flaw plies for stored lichess games (SEED-054)."
+        description="Backfill engine best_move + pv at flaw plies for stored games (SEED-054)."
     )
     parser.add_argument(
         "--db",

--- a/scripts/backfill_best_move_pv.py
+++ b/scripts/backfill_best_move_pv.py
@@ -51,6 +51,11 @@ Usage:
     # Smoke on dev:
     uv run python scripts/backfill_best_move_pv.py --db dev --limit 50 --workers 4
 
+    # Scope to a single user (--user-id) — handy to size/verify one account before
+    # the full prod pass (e.g. user 13):
+    uv run python scripts/backfill_best_move_pv.py --db prod --user-id 13 --dry-run
+    uv run python scripts/backfill_best_move_pv.py --db prod --user-id 13 --workers 10
+
     # Full prod backfill from the local machine (zero prod compute):
     bin/prod_db_tunnel.sh
     uv run python scripts/backfill_best_move_pv.py --db prod --workers 10
@@ -419,7 +424,10 @@ def parse_args() -> argparse.Namespace:
         default=None,
         dest="user_id",
         metavar="N",
-        help="Limit backfill to a single user ID. Default: all users.",
+        help=(
+            "Limit backfill to a single user ID (e.g. --user-id 13). Default: all "
+            "users. Useful to size/verify one account before the full prod pass."
+        ),
     )
     parser.add_argument(
         "--dry-run",

--- a/scripts/backfill_best_move_pv.py
+++ b/scripts/backfill_best_move_pv.py
@@ -1,0 +1,492 @@
+"""Backfill engine best_move + pv at flaw plies for stored lichess games (SEED-054).
+
+Why this script exists
+----------------------
+The Flaw card / Library Game card render a blue "better alternative" arrow from
+`game_positions[flaw_ply].best_move` — the engine's best move FROM the pre-blunder
+decision board. For lichess-eval games (`lichess_evals_at IS NOT NULL`) that column
+was NULL on essentially every flaw, because the live drain only ever engine-evaluated
+`flaw_ply + 1` (the opponent's reply). SEED-054 fixes the drain to also evaluate
+`flaw_ply` going forward; this script backfills the columns for games already stored.
+
+It runs from a local machine targeting prod over the SSH tunnel and writes the
+columns IN PLACE — it never touches the completion markers
+(`full_evals_completed_at` / `full_pv_completed_at`), so games never drop out of the
+Library / stats analyzed-gate mid-run (the decisive reason for a dedicated script
+over a worker re-enqueue — see SEED-054).
+
+What it writes
+--------------
+For each lichess-game position at a flaw ply or flaw+1 with `best_move IS NULL`:
+- best_move (the better alternative / refutation move) — always when the engine
+  returns one.
+- pv (the principal-variation line) — when present.
+- NEVER eval_cp / eval_mate: the lichess %eval is authoritative and preserved
+  (same is_lichess_eval_game discipline as eval_drain._apply_full_eval_results).
+
+The write keying is identical to the live drain by construction: this script reuses
+`eval_drain._batch_update_best_move_rows` and `eval_drain._batch_update_pv_rows`.
+
+Idempotent / resumable
+----------------------
+Selection is gated on `best_move IS NULL`, so a dropped SSH tunnel or Ctrl-C → just
+re-run; already-written positions are skipped. This naturally subsumes BOTH the
+SEED-043 cohort (never-reprocessed lichess games, NULL at both flaw plies) AND the
+SEED-054 keying gap (already-reprocessed games, NULL at flaw_ply only) in one pass.
+On lichess, best_move and pv are always written together, so `best_move IS NULL` is a
+sufficient resume predicate.
+
+DB target host:port mapping (CLAUDE.md):
+    dev:       localhost:5432  (Docker compose flawchess-dev)
+    benchmark: localhost:5433  (Docker compose flawchess-benchmark)
+    prod:      localhost:15432 (via bin/prod_db_tunnel.sh)
+
+Stockfish binary: auto-discovered by app.services.engine (STOCKFISH_PATH, else
+/usr/local/bin/stockfish, else ~/.local/stockfish/sf, else `stockfish` on PATH).
+
+Usage:
+    # Size it first (tunnel up):
+    uv run python scripts/backfill_best_move_pv.py --db prod --dry-run
+
+    # Smoke on dev:
+    uv run python scripts/backfill_best_move_pv.py --db dev --limit 50 --workers 4
+
+    # Full prod backfill from the local machine (zero prod compute):
+    bin/prod_db_tunnel.sh
+    uv run python scripts/backfill_best_move_pv.py --db prod --workers 10
+
+Parallelism (--workers, default 1):
+    Runs N independent Stockfish processes (Threads=1 each) via EnginePool. On a
+    16 vCPU workstation, 10-12 is a good upper bound (leave headroom for the SSH
+    tunnel + OS). The engine runs on the LOCAL machine → zero prod compute impact,
+    so there is no prod 4g-container constraint to respect here. Do NOT run this
+    script ON the prod server with a high --workers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import sys
+from collections.abc import AsyncIterator, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import chess
+import chess.pgn
+import sentry_sdk
+from sqlalchemy import exists, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.sql import Select
+
+# Bootstrap project root so `app.*` imports resolve when running as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.config import db_url_for_target, settings  # noqa: E402
+from app.models.game import Game  # noqa: E402
+from app.models.game_flaw import GameFlaw  # noqa: E402
+from app.models.game_position import GamePosition  # noqa: E402
+
+# Joining Game forces SQLAlchemy to configure the mapper chain, and User in turn
+# declares a relationship to OAuthAccount, so OAuthAccount must be imported/registered
+# or mapper configuration fails at query time (pattern from scripts/backfill_flaws.py).
+from app.models.oauth_account import OAuthAccount  # noqa: E402, F401
+from app.services import engine as _engine_module  # noqa: E402
+from app.services.engine import EnginePool  # noqa: E402
+
+# Reuse the live drain's batched write helpers so the (game_id, ply) keying for
+# best_move / pv is identical to the in-process drain by construction (SEED-054).
+from app.services.eval_drain import (  # noqa: E402
+    _batch_update_best_move_rows,
+    _batch_update_pv_rows,
+)
+
+# Commit cadence in game-units. Each game's writes collapse to two batched UPDATEs
+# (best_move + pv); committing every 100 games keeps the SSH tunnel responsive and
+# bounds the work lost to a mid-run disconnect to one batch (SEED-054).
+GAMES_PER_BATCH = 100
+
+# Default single-worker mode. CLI --workers overrides; a 16 vCPU workstation can
+# comfortably run 10-12 (the engine runs locally — no prod constraint applies).
+DEFAULT_WORKERS = 1
+
+# Eval fan-out chunk: number of evaluate_nodes_with_pv() calls gathered at once.
+# The EnginePool queue caps in-flight analyses at pool.size, so a 1-worker pool
+# serializes while an N-worker pool gets ~Nx throughput.
+EVAL_CHUNK_SIZE = 200
+
+
+def _log(msg: str = "") -> None:
+    """Print a message prefixed with a UTC timestamp (second precision)."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}")
+
+
+def _db_url(target: str) -> str:
+    """Resolve the asyncpg URL for the chosen --db target (via .env)."""
+    return db_url_for_target(target)
+
+
+def _boards_at_plies(pgn_text: str, plies: Sequence[int]) -> dict[int, chess.Board]:
+    """Replay PGN once, return {ply: board} (pre-push board) for all requested plies.
+
+    Board state BEFORE the move at that ply — the decision position whose best_move
+    we want. ply >= mainline length → final position. Returns an empty dict if the
+    PGN cannot be parsed; callers treat missing keys as a skip. Mirrors the
+    same-named helper in scripts/backfill_eval.py.
+    """
+    if not plies:
+        return {}
+    try:
+        game = chess.pgn.read_game(io.StringIO(pgn_text))
+    except Exception:
+        return {}
+    if game is None:
+        return {}
+
+    plies_set = set(plies)
+    captured: dict[int, chess.Board] = {}
+    board = game.board()
+    for i, node in enumerate(game.mainline()):
+        if i in plies_set:
+            captured[i] = board.copy()
+        board.push(node.move)
+    # Any requested ply >= mainline length → final position (after the last push).
+    for ply in plies_set:
+        captured.setdefault(ply, board)
+    return captured
+
+
+def _build_target_stmt(user_id: int | None, limit: int | None) -> Select[tuple[int, int, str]]:
+    """Build the SELECT for lichess flaw positions needing best_move (SEED-054).
+
+    Selects (game_id, ply, pgn) for GamePosition rows where:
+    1. games.lichess_evals_at IS NOT NULL  (lichess-eval cohort only)
+    2. best_move IS NULL                   (idempotent / resumable — see module docstring)
+    3. the ply is a flaw ply OR a flaw+1 ply: EXISTS a game_flaws row at gp.ply
+       (flaw_ply itself) or at gp.ply - 1 (gp.ply is flaw_ply + 1).
+
+    Ordered by (game_id, ply) so rows for one game are contiguous → the streaming
+    reader can batch by game and replay each PGN exactly once.
+    """
+    flaw_match = exists(
+        select(GameFlaw.ply).where(
+            GameFlaw.game_id == GamePosition.game_id,
+            ((GameFlaw.ply == GamePosition.ply) | (GameFlaw.ply == GamePosition.ply - 1)),
+        )
+    )
+
+    stmt = (
+        select(GamePosition.game_id, GamePosition.ply, Game.pgn)
+        .join(Game, Game.id == GamePosition.game_id)
+        .where(
+            Game.lichess_evals_at.isnot(None),
+            GamePosition.best_move.is_(None),
+            flaw_match,
+        )
+    )
+
+    if user_id is not None:
+        stmt = stmt.where(GamePosition.user_id == user_id)
+
+    stmt = stmt.order_by(GamePosition.game_id, GamePosition.ply)
+
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    return stmt
+
+
+async def _stream_game_batches(
+    session_maker: async_sessionmaker[AsyncSession],
+    stmt: Select[Any],
+    games_per_batch: int,
+) -> AsyncIterator[list[Any]]:
+    """Stream rows from a server-side cursor, yielding game-batched lists.
+
+    ORDER BY (game_id, ply) keeps each game's rows contiguous, so we flush a batch
+    as soon as we cross `games_per_batch` distinct game_ids. Postgres holds the
+    cursor; only one batch is alive in Python at a time (mirrors backfill_eval).
+    """
+    async with session_maker() as read_session:
+        result = await read_session.stream(stmt)
+        batch: list[Any] = []
+        seen_games: set[int] = set()
+        async for row in result:
+            gid = row.game_id
+            if gid not in seen_games:
+                if len(seen_games) >= games_per_batch:
+                    yield batch
+                    batch = []
+                    seen_games = set()
+                seen_games.add(gid)
+            batch.append(row)
+        if batch:
+            yield batch
+
+
+def _resolve_boards(rows: Sequence[Any]) -> list[tuple[int, int, chess.Board]]:
+    """Replay each game's PGN once → list of (game_id, ply, board) targets.
+
+    Rows arrive ordered by (game_id, ply); itertools.groupby gives one contiguous
+    block per game so each PGN is parsed a single time. Plies whose board cannot be
+    materialized (PGN parse failure) are dropped (counted by the caller as
+    skipped_no_board).
+    """
+    from itertools import groupby
+
+    out: list[tuple[int, int, chess.Board]] = []
+    for _gid, group_iter in groupby(rows, key=lambda r: r.game_id):
+        group = list(group_iter)
+        plies = [r.ply for r in group]
+        boards = _boards_at_plies(group[0].pgn, plies)
+        for r in group:
+            board = boards.get(r.ply)
+            if board is not None:
+                out.append((r.game_id, r.ply, board))
+    return out
+
+
+async def _process_batch(
+    rows: Sequence[Any],
+    session: AsyncSession,
+    *,
+    db: str,
+    pool: EnginePool,
+) -> tuple[int, int, int]:
+    """Evaluate + write best_move/pv for one game-batch. Returns (written, no_board, engine_err).
+
+    For each target ply: run a 1M-node search, write best_move (when present) and pv
+    (when present) via the shared drain helpers. eval_cp / eval_mate are NEVER
+    written (lichess %eval preserved). Writes are grouped per game (the helpers are
+    game-scoped) and the whole batch commits once.
+    """
+    targets = _resolve_boards(rows)
+    no_board = len(rows) - len(targets)
+    if no_board:
+        _log(f"  WARNING: {no_board} position(s) had an unparseable PGN — skipped")
+
+    # Per-game accumulators: {game_id: [(ply, best_move)]} and {game_id: [(ply, pv)]}.
+    bm_by_game: dict[int, list[tuple[int, str]]] = {}
+    pv_by_game: dict[int, list[tuple[int, str]]] = {}
+    written = 0
+    engine_err = 0
+
+    for chunk_start in range(0, len(targets), EVAL_CHUNK_SIZE):
+        chunk = targets[chunk_start : chunk_start + EVAL_CHUNK_SIZE]
+        results = await asyncio.gather(
+            *(pool.evaluate_nodes_with_pv(board) for _gid, _ply, board in chunk)
+        )
+        for (game_id, ply, _board), (_cp, _mt, best_move, pv) in zip(chunk, results, strict=True):
+            if best_move is None and pv is None:
+                # Engine failure (None, None, None, None) or a position with no PV —
+                # nothing to write. A genuine engine outage is the (None,)*4 case.
+                if best_move is None:
+                    engine_err += 1
+                    sentry_sdk.set_context(
+                        "backfill_best_move_pv",
+                        {"game_id": game_id, "ply": ply, "db_target": db},
+                    )
+                    sentry_sdk.set_tag("source", "backfill")
+                    sentry_sdk.capture_message(
+                        "backfill_best_move_pv: engine returned no best_move", level="warning"
+                    )
+                continue
+            if best_move is not None:
+                bm_by_game.setdefault(game_id, []).append((ply, best_move))
+                written += 1
+            if pv is not None:
+                pv_by_game.setdefault(game_id, []).append((ply, pv))
+
+    # One pair of batched UPDATEs per game (keying identical to the drain), then a
+    # single commit for the whole batch.
+    for game_id, bm_rows in bm_by_game.items():
+        await _batch_update_best_move_rows(session, game_id, bm_rows)
+    for game_id, pv_rows in pv_by_game.items():
+        await _batch_update_pv_rows(session, game_id, pv_rows)
+    await session.commit()
+
+    return written, no_board, engine_err
+
+
+async def run_backfill(
+    *,
+    db: str,
+    user_id: int | None,
+    dry_run: bool,
+    limit: int | None,
+    workers: int = DEFAULT_WORKERS,
+    timeout: float | None = None,
+    _session_maker: async_sessionmaker[AsyncSession] | None = None,
+    _pool: EnginePool | None = None,
+) -> None:
+    """SEED-054 backfill driver. Public callable for testability.
+
+    Idempotency / resume: selection is gated on best_move IS NULL, so a re-run after
+    a mid-run kill naturally continues (per-batch commit bounds the loss).
+
+    _session_maker / _pool are internal test hooks; production callers omit both.
+    """
+    if timeout is not None:
+        _engine_module._TIMEOUT_S = timeout
+        _log(f"Engine per-eval timeout overridden: {timeout}s (default 2.0s)")
+
+    dispose_engine = _session_maker is None
+    if _session_maker is None:
+        async_engine = create_async_engine(_db_url(db), pool_pre_ping=True)
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+    else:
+        async_engine = None  # type: ignore[assignment]  # not created here; nothing to dispose
+        session_maker = _session_maker
+
+    stmt = _build_target_stmt(user_id, limit)
+
+    if dry_run:
+        async with session_maker() as count_session:
+            count = (
+                await count_session.execute(select(func.count()).select_from(stmt.subquery()))
+            ).scalar_one()
+        _log(f"--dry-run: {count} lichess flaw position(s) need best_move (best_move IS NULL).")
+        _log("--dry-run: exiting without starting engine or writing.")
+        if dispose_engine and async_engine is not None:
+            await async_engine.dispose()
+        return
+
+    _log(f"Streaming target rows in batches of {GAMES_PER_BATCH} games.")
+
+    dispose_pool = _pool is None
+    if _pool is None:
+        pool = EnginePool(workers)
+        await pool.start()
+        _log(f"EnginePool started with {workers} worker(s).")
+    else:
+        pool = _pool
+
+    rows_seen = 0
+    written_total = 0
+    no_board_total = 0
+    engine_err_total = 0
+    batch_idx = 0
+    try:
+        async with session_maker() as write_session:
+            async for batch in _stream_game_batches(session_maker, stmt, GAMES_PER_BATCH):
+                batch_idx += 1
+                w, nb, ee = await _process_batch(batch, write_session, db=db, pool=pool)
+                rows_seen += len(batch)
+                written_total += w
+                no_board_total += nb
+                engine_err_total += ee
+                _log(
+                    f"  batch {batch_idx} done ({len(batch)} rows; cumulative "
+                    f"seen={rows_seen}, written_best_move={written_total}, "
+                    f"skipped_no_board={no_board_total}, engine_err={engine_err_total})"
+                )
+    finally:
+        if dispose_pool:
+            await pool.stop()
+
+    if rows_seen:
+        _log(
+            f"Backfill complete: rows={rows_seen}, written_best_move={written_total}, "
+            f"skipped_no_board={no_board_total}, engine_err={engine_err_total}"
+        )
+    else:
+        _log("No lichess flaw positions needed best_move (no-op).")
+
+    if dispose_engine and async_engine is not None:
+        await async_engine.dispose()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse and validate CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Backfill engine best_move + pv at flaw plies for stored lichess games (SEED-054)."
+    )
+    parser.add_argument(
+        "--db",
+        choices=["dev", "benchmark", "prod"],
+        required=True,
+        help=(
+            "Database target. dev=localhost:5432, benchmark=localhost:5433, "
+            "prod=localhost:15432 (via bin/prod_db_tunnel.sh). REQUIRED."
+        ),
+    )
+    parser.add_argument(
+        "--user-id",
+        type=int,
+        default=None,
+        dest="user_id",
+        metavar="N",
+        help="Limit backfill to a single user ID. Default: all users.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Count target positions and print; do not start engine or write anything.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Cap at N target positions. Useful for smoke checks.",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=DEFAULT_WORKERS,
+        metavar="N",
+        help=(
+            f"Number of parallel local Stockfish workers (default {DEFAULT_WORKERS}). "
+            "Each is its own UCI process configured Threads=1. On a 16 vCPU "
+            "workstation, 10-12 is a good upper bound. The engine runs locally, so "
+            "no prod memory constraint applies. Do NOT raise this when running ON "
+            "the prod server."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Override the engine's per-eval timeout (default 2.0s in "
+            "app/services/engine.py:_TIMEOUT_S). Applies to every pool worker."
+        ),
+    )
+    args = parser.parse_args()
+    if args.workers < 1:
+        parser.error(f"--workers must be >= 1, got {args.workers}")
+    if args.timeout is not None and args.timeout <= 0:
+        parser.error(f"--timeout must be > 0, got {args.timeout}")
+    return args
+
+
+async def main() -> None:
+    """Entry point: parse CLI args, init Sentry, run backfill."""
+    args = parse_args()
+
+    if settings.SENTRY_DSN:
+        sentry_sdk.init(dsn=settings.SENTRY_DSN, environment=settings.ENVIRONMENT)
+
+    _log(
+        f"Starting best_move/pv backfill: db={args.db} user_id={args.user_id} "
+        f"dry_run={args.dry_run} limit={args.limit} workers={args.workers} "
+        f"timeout={args.timeout}"
+    )
+    await run_backfill(
+        db=args.db,
+        user_id=args.user_id,
+        dry_run=args.dry_run,
+        limit=args.limit,
+        workers=args.workers,
+        timeout=args.timeout,
+    )
+    _log("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/services/test_full_eval_drain.py
+++ b/tests/services/test_full_eval_drain.py
@@ -1299,24 +1299,27 @@ def _blunder_eval_sequence() -> list[tuple[int, None, str, str]]:
 
 
 class TestFlawPv:
-    """EVAL-04 / D-117-02: game_positions.pv is written ONLY at ply N+1 for a flaw at ply N.
+    """EVAL-04 / D-117-02 / SEED-054: game_positions.pv is written at BOTH ply N and ply N+1
+    for a flaw at ply N.
 
-    Pitfall 4: the PV belongs to the position AFTER the flawed move (the refutation
-    line starts from the resulting position), NOT to the flaw position itself.
+    - ply N+1: the refutation line from the position AFTER the flawed move (Pitfall 4,
+      the SEED-039 tactic-motif input).
+    - ply N: the ideal-continuation line from the pre-blunder decision board (SEED-054).
     """
 
-    async def test_flaw_pv_written_at_ply_n_plus_one(
+    async def test_flaw_pv_written_at_flaw_ply_and_ply_n_plus_one(
         self,
         full_drain_test_user_117: int,
         full_drain_session_maker: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """After a drain tick on a game with a clear blunder at ply 2 (white's move),
-        game_positions.pv is set at ply 3 (ply N+1) and NULL at all other plies.
+        game_positions.pv is set at BOTH ply 2 (flaw_ply) and ply 3 (ply N+1), NULL elsewhere.
 
         classify_game_flaws emits a FlawRecord for ply 2 (n=2, mover=white).
-        The PV for ply 3 (the refutation board) comes from engine_result_map[3].
-        Plies 0,1,2,4,5 must have pv=NULL (pv only written at the flaw-adjacent ply).
+        The PV for ply 2 (the decision board) comes from engine_result_map[2]; the PV
+        for ply 3 (the refutation board) comes from engine_result_map[3] (SEED-054).
+        Plies 0,1,4,5 must have pv=NULL (pv only written at flaw plies).
         """
         from app.models.game_position import GamePosition
 
@@ -1361,11 +1364,17 @@ class TestFlawPv:
                 "game_positions.pv at ply 3 (N+1 for blunder at ply 2) must be set "
                 "— D-117-02 flaw PV write."
             )
-            # All other plies must NOT have a PV set (pv is only written at flaw N+1).
-            for ply in [0, 1, 2, 4, 5]:
+            # ply 2 (flaw_ply) must have the ideal-continuation PV from
+            # engine_result_map[2] (SEED-054 Part 2).
+            assert pv_by_ply.get(2) is not None, (
+                "game_positions.pv at ply 2 (flaw_ply) must be set — SEED-054 "
+                "ideal-continuation PV write."
+            )
+            # All other plies must NOT have a PV set (pv is only written at flaw plies).
+            for ply in [0, 1, 4, 5]:
                 assert pv_by_ply.get(ply) is None, (
                     f"game_positions.pv at ply {ply} must be NULL — pv is only written "
-                    "at the ply AFTER a flaw (D-117-02 / Pitfall 4)."
+                    "at flaw plies (ply N and ply N+1; D-117-02 / SEED-054)."
                 )
         finally:
             await _delete_games(full_drain_session_maker, [game_id])
@@ -1376,19 +1385,21 @@ class TestFlawPv:
         full_drain_session_maker: async_sessionmaker[AsyncSession],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """D-117-13: analyzed lichess games still get a flaw PV even though every ply
-        already carries a lichess %eval.
+        """D-117-13 / SEED-054: analyzed lichess games get a flaw PV + best_move at BOTH
+        flaw plies even though every ply already carries a lichess %eval.
 
         Regression guard for the prod-observed 0% flaw-PV coverage on analyzed
         lichess games: the is_lichess_eval_game eval-preservation filter dropped every
-        flaw-adjacent ply before the engine gather, so the refutation PV was never
-        captured (lichess supplies %eval but no PV). The D-117-13 fix pre-classifies
-        flaws and exempts {flaw_ply + 1} from the filter.
+        flaw ply before the engine gather, so neither the refutation PV nor the
+        better-alternative best_move was captured (lichess supplies %eval but no PV and
+        no best_move). The D-117-13 / SEED-054 fix pre-classifies flaws and exempts
+        {flaw_ply, flaw_ply + 1} from the filter.
 
         Setup: all 6 plies carry a pre-existing %eval encoding a white blunder at
-        ply 2. Only ply 3 (flaw_ply + 1) should be engine-evaluated (for the PV);
-        the other five plies are preserved without an engine call. Before the fix,
-        the engine was called 0 times and pv at ply 3 stayed NULL.
+        ply 2. Both ply 2 (flaw_ply) and ply 3 (flaw_ply + 1) should be
+        engine-evaluated (for best_move + PV); the other four plies are preserved
+        without an engine call. Before the fix, the engine was called 0 times (D-117)
+        or only at ply 3 (post-D-117-13, pre-SEED-054) and pv at ply 2 stayed NULL.
         """
         from app.models.game_position import GamePosition
 
@@ -1411,7 +1422,8 @@ class TestFlawPv:
             is_lichess_eval_game=True,
         )
 
-        # Only ply 3 (flaw_ply + 1) should reach the engine — one PV result.
+        # Both ply 2 (flaw_ply) and ply 3 (flaw_ply + 1) should reach the engine
+        # (SEED-054). Same mock result for each — only the keying matters here.
         mock_evaluate = AsyncMock(return_value=(-480, None, "g8f6", "g8f6 f1c4 d7d5"))
         monkeypatch.setattr(drain_module.engine_service, "evaluate_nodes_with_pv", mock_evaluate)
 
@@ -1435,34 +1447,52 @@ class TestFlawPv:
             processed = await drain_module._full_drain_tick()
             assert processed is True, "Tick must report a processed game"
 
-            # Exactly one engine call: the flaw-adjacent ply 3 (D-117-13). The other
-            # five plies are preserved without burning a 1M-node eval.
-            assert mock_evaluate.await_count == 1, (
-                "Only the flaw-adjacent ply (flaw_ply + 1) should be engine-evaluated "
+            # Exactly two engine calls: flaw plies 2 and 3 (D-117-13 / SEED-054). The
+            # other four plies are preserved without burning a 1M-node eval.
+            assert mock_evaluate.await_count == 2, (
+                "Both flaw plies (flaw_ply and flaw_ply + 1) should be engine-evaluated "
                 f"for an analyzed game — got {mock_evaluate.await_count} engine calls."
             )
 
             async with full_drain_session_maker() as verify:
                 rows = await verify.execute(
-                    select(GamePosition.ply, GamePosition.pv, GamePosition.eval_cp)
+                    select(
+                        GamePosition.ply,
+                        GamePosition.pv,
+                        GamePosition.eval_cp,
+                        GamePosition.best_move,
+                    )
                     .where(GamePosition.game_id == game_id)
                     .order_by(GamePosition.ply)
                 )
-                by_ply = {r[0]: (r[1], r[2]) for r in rows.all()}
+                by_ply = {r[0]: (r[1], r[2], r[3]) for r in rows.all()}
 
-            assert by_ply.get(3, (None, None))[0] is not None, (
+            assert by_ply.get(3, (None, None, None))[0] is not None, (
                 "game_positions.pv at ply 3 must be set for an analyzed lichess game "
                 "— D-117-13 flaw-PV fix (lichess provides %eval but no PV)."
             )
-            # Preserved lichess %evals are untouched (D-116-04 still holds).
-            assert by_ply.get(3, (None, None))[1] == -480, (
-                "The lichess %eval at the flaw-adjacent ply must be preserved, not "
+            # SEED-054: pv + best_move at flaw_ply (ply 2) — the better-alternative arrow.
+            assert by_ply.get(2, (None, None, None))[0] is not None, (
+                "game_positions.pv at ply 2 (flaw_ply) must be set for an analyzed "
+                "lichess game — SEED-054 ideal-continuation PV."
+            )
+            assert by_ply.get(2, (None, None, None))[2] == "g8f6", (
+                "game_positions.best_move at ply 2 (flaw_ply) must be set for an "
+                "analyzed lichess game — SEED-054 better-alternative arrow."
+            )
+            # Preserved lichess %evals are untouched at both flaw plies (D-116-04).
+            assert by_ply.get(3, (None, None, None))[1] == -480, (
+                "The lichess %eval at flaw_ply + 1 must be preserved, not "
                 "overwritten by the engine eval (D-116-04)."
             )
-            for ply in [0, 1, 2, 4, 5]:
-                assert by_ply.get(ply, (None, None))[0] is None, (
+            assert by_ply.get(2, (None, None, None))[1] == -500, (
+                "The lichess %eval at flaw_ply must be preserved, not overwritten "
+                "by the engine eval (D-116-04 / SEED-054)."
+            )
+            for ply in [0, 1, 4, 5]:
+                assert by_ply.get(ply, (None, None, None))[0] is None, (
                     f"game_positions.pv at ply {ply} must be NULL — pv is only written "
-                    "at the ply AFTER a flaw (D-117-02 / Pitfall 4)."
+                    "at flaw plies (ply N and ply N+1; D-117-02 / SEED-054)."
                 )
         finally:
             await _delete_games(full_drain_session_maker, [game_id])
@@ -2716,16 +2746,16 @@ class TestBatchedWriteRegression:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """After a drain tick on a game with TWO blunders (one white, one black),
-        game_positions.pv is set at BOTH N+1 plies (ply 3 and ply 4) and NULL at
-        all other plies.
+        game_positions.pv is set at flaw plies 2, 3 AND 4 (SEED-054) and NULL elsewhere.
 
         This exercises the multi-row VALUES clause in the batched flaw-PV UPDATE
         (FLAWCHESS-6B) — the existing single-flaw test covers one VALUES row only.
 
         _SIX_PLY_PGN = "1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 *" (plies 0..5).
         Two blunders from _two_blunder_eval_sequence:
-          - White blunder at ply 2 → PV at ply 3
-          - Black blunder at ply 3 → PV at ply 4
+          - White blunder at ply 2 → PV at ply 2 (decision, SEED-054) and ply 3 (refutation)
+          - Black blunder at ply 3 → PV at ply 3 (decision, SEED-054) and ply 4 (refutation)
+        Union of written plies = {2, 3, 4}; plies 0, 1, 5 stay NULL.
         """
         from app.models.game_position import GamePosition
 
@@ -2765,19 +2795,24 @@ class TestBatchedWriteRegression:
                 )
                 by_ply = {r[0]: (r[1], r[2]) for r in rows.all()}
 
-            # Both flaw-adjacent plies must carry a PV (batched VALUES with 2 rows).
+            # Flaw plies 2, 3, 4 must carry a PV (batched VALUES with multiple rows).
+            assert by_ply.get(2, (None, None))[0] is not None, (
+                "ply 2 (decision board for white blunder at ply 2) must have pv set — "
+                "SEED-054 ideal-continuation PV"
+            )
             assert by_ply.get(3, (None, None))[0] is not None, (
-                "ply 3 (N+1 for white blunder at ply 2) must have pv set — "
-                "multi-row batched PV VALUES clause (FLAWCHESS-6B regression)"
+                "ply 3 (N+1 for white blunder at ply 2; decision for black blunder at "
+                "ply 3) must have pv set — multi-row batched PV VALUES (FLAWCHESS-6B)"
             )
             assert by_ply.get(4, (None, None))[0] is not None, (
                 "ply 4 (N+1 for black blunder at ply 3) must have pv set — "
                 "multi-row batched PV VALUES clause (FLAWCHESS-6B regression)"
             )
             # Non-flaw plies must NOT have a PV.
-            for ply in [0, 1, 2, 5]:
+            for ply in [0, 1, 5]:
                 assert by_ply.get(ply, (None, None))[0] is None, (
-                    f"ply {ply} must have pv=NULL — pv only written at flaw N+1 (D-117-02)"
+                    f"ply {ply} must have pv=NULL — pv only written at flaw plies "
+                    "(ply N and ply N+1; D-117-02 / SEED-054)"
                 )
             # Sanity: eval_cp rows populated by the batched eval write (Task 1 batch).
             # Row 2 = -500 (white blunder), row 3 = 100 (black blunder).


### PR DESCRIPTION
## Hotfix: SEED-054 to production

Ships **SEED-054** (store engine best_move/pv at flaw_ply, not only flaw_ply+1) to production **without** unreleased phases 124/125 (tactic tagging), which remain on `main`.

### Why isolated cherry-pick is safe
- Phase 124/125 are ancestors of SEED-054 on `main`; cherry-pick does not pull them in.
- **No migration** — Alembic head unchanged (phase 124 owns the tactic-motifs migration).
- `eval_drain.py` here has **zero** references to `tactic_detector` / `_detect_tactic_for_flaw` / `tactic_motif` (that block was added by phase 125). Builds purely on the existing Phase 117 `_batch_update_best_move_rows` base already in production.
- No `.planning/` churn (planning-doc conflicts were dropped).

### Changes
- `app/services/eval_drain.py` — write best_move/pv at flaw_ply
- `scripts/backfill_best_move_pv.py` — one-off backfill for historical flaw rows (run manually vs prod)
- `tests/services/test_full_eval_drain.py`, `CHANGELOG.md`

### Gates (local, against production base)
- `ty` ✅ · `ruff` ✅ · `ruff format --check` ✅
- Full backend suite: **2717 passed, 10 skipped**
- No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)