### PR TITLE
fix: close async race that over-counted user_activity

### DIFF
--- a/app/middleware/last_activity.py
+++ b/app/middleware/last_activity.py
@@ -82,6 +82,18 @@ class LastActivityMiddleware:
             if last is not None and (now - last) < _ACTIVITY_THROTTLE:
                 return
 
+            # Claim the throttle slot BEFORE the first `await` below. The gate read
+            # and this write must be adjacent with no await between them: the DB
+            # writes are await points, so without claiming the slot first, a burst
+            # of concurrent same-user requests (the frontend fires several parallel
+            # authenticated queries per page load) would all read the stale cache,
+            # all pass the gate, and all increment activity_count — inflating it far
+            # past the intended "distinct active hours" (1-24) at each hour boundary.
+            # Trade-off: if the write below fails, this user is throttled until the
+            # next hour. Acceptable for best-effort activity tracking — losing an
+            # occasional increment beats over-counting.
+            _last_updated[user_id] = now
+
             # Single UPDATE, no SELECT — the DB does the work
             async with async_session_maker() as session:
                 await session.execute(
@@ -101,7 +113,6 @@ class LastActivityMiddleware:
                 )
                 await session.execute(activity_stmt)
                 await session.commit()
-            _last_updated[user_id] = now
             # NOTE: last_activity is the tier-3 idle-drain priority key — claim_eval_job
             # orders the backlog by users.last_activity DESC, so keeping it fresh here is
             # what nudges an active user's games to the front of the background eval queue.

--- a/tests/test_last_activity_middleware.py
+++ b/tests/test_last_activity_middleware.py
@@ -8,6 +8,7 @@ Covers:
 - Integration: impersonation tokens skip last_activity writes (D-07, phase 62)
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -480,6 +481,40 @@ class TestUserActivityRecording:
         assert len(rows) == 1, f"Expected exactly one row (unique key held), got {len(rows)}"
         assert rows[0].activity_count == 2, (
             f"Expected count 2 after ON CONFLICT, got {rows[0].activity_count}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_increment_count_once(self, test_engine):
+        """A burst of concurrent same-user requests increments activity_count by 1, not N.
+
+        Regression for the async check-then-act race: the throttle slot is claimed
+        synchronously between the gate read and the first `await`, so concurrent
+        in-flight requests (the frontend fires several parallel authenticated
+        queries per page load) can't all pass the gate and each increment. Before
+        the fix, count == CONCURRENCY; after, count == 1.
+        """
+        CONCURRENCY = 8
+        email = self._unique_email("ua_race")
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            user_id, token = await self._register_and_login(client, email)
+            # Empty cache so every request is eligible to write — the in-memory
+            # slot-claim is the only thing that must collapse them to a single bump.
+            _last_updated.pop(user_id, None)
+
+            headers = {"Authorization": f"Bearer {token}"}
+            responses = await asyncio.gather(
+                *(client.get("/api/users/me/profile", headers=headers) for _ in range(CONCURRENCY))
+            )
+            assert all(r.status_code == 200 for r in responses)
+
+        today = datetime.now(timezone.utc).date()
+        rows = await self._get_activity_rows(test_engine, user_id, today)
+
+        assert len(rows) == 1, f"Expected exactly one row, got {len(rows)}"
+        assert rows[0].activity_count == 1, (
+            f"Concurrent burst must increment once, got {rows[0].activity_count}"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`user_activity.activity_count` is documented to mean "distinct active hours that day (1-24)", gated by a once-per-hour in-memory throttle. In prod it climbs much faster: user 28 hit 17 within ~10 hours of the table's deploy, which is arithmetically impossible under a working once-per-hour throttle.

Root cause is an **async check-then-act race** in `LastActivityMiddleware`, not process restarts (backend has 0 restarts / 10h uptime, single uvicorn process). The throttle gate is read *before* the DB write and the in-memory cache is updated *after* it, with several `await`s in between. The frontend fires a burst of parallel authenticated requests per page load; at each hour boundary they all read the stale cache, all pass the gate, and all run the `activity_count + 1` upsert.

## Fix

Claim the throttle slot synchronously between the gate read and the first `await`, so concurrent in-flight requests see the fresh timestamp and bail. Trade-off: if the write then fails, that user is throttled until the next hour — acceptable for best-effort activity tracking (losing an occasional increment beats over-counting).

A future hardening (not in this hotfix) would gate the upsert on the DB's own `last_activity` so a process restart mid-hour can't add an extra write.

## Tests

Adds a regression test firing 8 concurrent same-user requests and asserting `activity_count == 1` (red on the bug, green on the fix). Full backend suite green (2916 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)