### PR TITLE
fix(sentry): stop reporting two expected frontend failures

### DIFF
--- a/frontend/src/__tests__/instrument.beforeSend.test.ts
+++ b/frontend/src/__tests__/instrument.beforeSend.test.ts
@@ -21,7 +21,7 @@ vi.mock('@sentry/react', () => ({
 interface AxiosLikeErrorInput {
   isAxiosError: true;
   code?: string;
-  response?: { status: number };
+  response?: { status: number; data?: unknown };
   config?: { url?: string; method?: string };
 }
 
@@ -226,6 +226,70 @@ describe('sentryBeforeSend (FLAWCHESS-24)', () => {
   });
 });
 
+describe('sentryBeforeSend pasted-PGN rejection (FLAWCHESS-9W)', () => {
+  /** The real prod failure: POST /imports/paste rejecting text that is not a game. */
+  function pasteRejection(detail: unknown): AxiosLikeErrorInput {
+    return {
+      isAxiosError: true,
+      response: { status: 422, data: { detail } },
+      config: { url: '/imports/paste', method: 'post' },
+    };
+  }
+
+  it('drops the 422 from POST /imports/paste when detail is the server string', async () => {
+    const { sentryBeforeSend } = await import('@/instrument');
+
+    const result = sentryBeforeSend(
+      makeEvent() as never,
+      makeHint(pasteRejection('Could not read that PGN as a complete game')) as never,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('KEEPS a Pydantic schema 422 on the same endpoint — an array detail means we built a bad request', async () => {
+    const { sentryBeforeSend } = await import('@/instrument');
+
+    const event = sentryBeforeSend(
+      makeEvent() as never,
+      makeHint(pasteRejection([{ loc: ['body', 'user_color'], msg: 'unexpected value' }])) as never,
+    );
+    expect(event).not.toBeNull();
+    expect((event as unknown as { fingerprint: string[] }).fingerprint).toEqual(['api-http-422']);
+  });
+
+  it('KEEPS a 422 from another endpoint — from_date > to_date is a frontend bug', async () => {
+    const { sentryBeforeSend } = await import('@/instrument');
+
+    const event = sentryBeforeSend(
+      makeEvent() as never,
+      makeHint({
+        isAxiosError: true,
+        response: { status: 422, data: { detail: 'from_date must be <= to_date' } },
+        config: { url: '/library/games', method: 'get' },
+      }) as never,
+    );
+    expect(event).not.toBeNull();
+    expect((event as unknown as { fingerprint: string[] }).fingerprint).toEqual(['api-http-422']);
+  });
+
+  it('KEEPS a non-422 failure of the paste endpoint (a 500 is still a bug)', async () => {
+    const { sentryBeforeSend } = await import('@/instrument');
+
+    const event = sentryBeforeSend(
+      makeEvent() as never,
+      makeHint({
+        isAxiosError: true,
+        response: { status: 500, data: { detail: 'Internal Server Error' } },
+        config: { url: '/imports/paste', method: 'post' },
+      }) as never,
+    );
+    expect(event).not.toBeNull();
+    expect((event as unknown as { fingerprint: string[] }).fingerprint).toEqual([
+      'api-server-error',
+    ]);
+  });
+});
+
 describe('sentryBeforeSend request attachment (FLAWCHESS-64)', () => {
   it("attaches config.url and the uppercased config.method to event.request", async () => {
     const { sentryBeforeSend } = await import('@/instrument');
@@ -278,6 +342,26 @@ describe('Sentry.init config (FLAWCHESS-24 / SEED-148 items 3)', () => {
     const prodMessage =
       "Failed to update a ServiceWorker for scope ('https://flawchess.com/'), script ('https://flawchess.com/sw.js')";
     expect(ignoreErrors.some((p) => p.test(prodMessage))).toBe(true);
+  });
+
+  it("ignoreErrors matches WebKit's wording for the same failure (FLAWCHESS-8P)", async () => {
+    const Sentry = await import('@sentry/react');
+    await import('@/instrument');
+
+    const initCall = vi.mocked(Sentry.init).mock.calls[0]?.[0];
+    const ignoreErrors = (initCall?.ignoreErrors ?? []) as RegExp[];
+    const prodMessage = 'Script https://flawchess.com/sw.js load failed';
+    expect(ignoreErrors.some((p) => p.test(prodMessage))).toBe(true);
+  });
+
+  it('ignoreErrors does NOT swallow an unrelated script load failure', async () => {
+    const Sentry = await import('@sentry/react');
+    await import('@/instrument');
+
+    const initCall = vi.mocked(Sentry.init).mock.calls[0]?.[0];
+    const ignoreErrors = (initCall?.ignoreErrors ?? []) as RegExp[];
+    const unrelated = 'Script https://flawchess.com/assets/index-abc123.js load failed';
+    expect(ignoreErrors.some((p) => p.test(unrelated))).toBe(false);
   });
 
   it('denyUrls matches a Cloudflare beacon.min.js frame URL', async () => {

--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/react";
 // instrumentation file which loads before the app bundle is ready.
 interface AxiosLikeError {
   isAxiosError: true;
-  response?: { status: number };
+  response?: { status: number; data?: unknown };
   code?: string;
   config?: { url?: string; method?: string };
 }
@@ -50,6 +50,34 @@ function isSuppressibleNetworkNoise(): boolean {
   return false;
 }
 
+/** The one endpoint whose 422 is a deliberate, user-facing rejection (below). */
+const PASTE_GAME_URL = "/imports/paste";
+
+/**
+ * FLAWCHESS-9W: true for the pasted-PGN endpoint rejecting text that is not a
+ * complete game. `PasteModal` renders the server's message in its
+ * `paste-save-error` slot and the user edits and retries, so there is nothing
+ * to fix — reporting it just files a Sentry issue per typo.
+ *
+ * Scoped to this one method+path rather than to the status: every OTHER 422
+ * in the API is `from_date must be <= to_date`, which our own date-range
+ * picker is supposed to make impossible and which therefore IS a bug.
+ *
+ * The string-`detail` check keeps the remaining bug case visible. FastAPI
+ * puts a plain string in `detail` for an explicit `HTTPException` (our
+ * deliberate rejection) but an ARRAY there for a Pydantic schema failure —
+ * and a schema failure on this endpoint means the frontend built a malformed
+ * request body, which still ships to Sentry.
+ */
+function isExpectedPastedPgnRejection(error: AxiosLikeError): boolean {
+  if (error.response?.status !== 422) return false;
+  if (error.config?.method?.toLowerCase() !== "post") return false;
+  if (error.config?.url !== PASTE_GAME_URL) return false;
+  const data = error.response.data;
+  if (typeof data !== "object" || data === null) return false;
+  return typeof (data as Record<string, unknown>)["detail"] === "string";
+}
+
 function sentryBeforeSend(
   event: Sentry.ErrorEvent,
   hint: Sentry.EventHint,
@@ -59,6 +87,11 @@ function sentryBeforeSend(
     // 401 Unauthorized is never a bug — it's a normal auth failure (expired session,
     // wrong credentials). Drop it to avoid noise in Sentry.
     if (error.response?.status === 401) {
+      return null;
+    }
+    // FLAWCHESS-9W: an unparseable pasted PGN is expected user input, not a
+    // bug — see isExpectedPastedPgnRejection() above.
+    if (isExpectedPastedPgnRejection(error)) {
       return null;
     }
     // FLAWCHESS-24: drop unactionable network noise — see SUPPRESSIBLE_AXIOS_CODES
@@ -123,6 +156,11 @@ Sentry.init({
     // by construction, and the sampled events share a trace id with the
     // offline XHR failure that produced them.
     /Failed to update a ServiceWorker/,
+    // FLAWCHESS-8P: WebKit's wording for that same failed revalidation.
+    // Chrome says "Failed to update a ServiceWorker ..."; Safari/iOS throws a
+    // TypeError reading "Script <url> load failed", so the pattern above never
+    // matched it and all 6 events were Mobile Safari.
+    /Script \S+\/sw\.js load failed/,
   ],
   // These frames are entirely inside Cloudflare Web Analytics, not our code.
   denyUrls: [/beacon\.min\.js/],


### PR DESCRIPTION
Triage of the five unresolved production Sentry issues. Two are expected conditions rather than bugs and are suppressed here; three are left alone with reasons below.

## Fixed

**[FLAWCHESS-9W](https://flawchess.sentry.io/issues/FLAWCHESS-9W) — `AxiosError: 422` on `POST /imports/paste`**

The server answers 422 `"Could not read that PGN as a complete game"` when someone pastes text that is not a game. `PasteModal` already renders that message in its `paste-save-error` slot and the user edits and retries, so there is nothing to fix. Same class as `d4470539e` (unknown chess.com/lichess usernames).

Dropped in `beforeSend`, deliberately scoped to this one method+path rather than to the status:

- Every *other* 422 in the API is `from_date must be <= to_date`, which our own date-range picker is supposed to make impossible — so those still report.
- A Pydantic schema 422 on this same endpoint also still reports. FastAPI puts a plain string in `detail` for an explicit `HTTPException` (our deliberate rejection) but an **array** for a schema failure, and a schema failure here means the frontend built a malformed request body.

**[FLAWCHESS-8P](https://flawchess.sentry.io/issues/FLAWCHESS-8P) — `TypeError: Script https://flawchess.com/sw.js load failed`**

`ignoreErrors` already declares a failed sw.js revalidation unactionable ("the network is gone"), but the pattern only matched Chrome's wording, `Failed to update a ServiceWorker`. Safari throws a `TypeError` reading `Script <url> load failed` instead — which is why all 6 events were Mobile Safari. Added WebKit's wording beside it, narrowed to `sw.js` so an asset-bundle load failure still reports.

## Left alone

- **[FLAWCHESS-9G](https://flawchess.sentry.io/issues/FLAWCHESS-9G)** — grading watchdog timeout. Its suspend-aware fix (`7783c004f`) is live in production and the last event fired 2026-08-22 16:05, hours before that release. Nothing new to fix; worth resolving in Sentry and watching.
- **[FLAWCHESS-24](https://flawchess.sentry.io/issues/FLAWCHESS-24)** — `Network Error`. The unloading/offline/backgrounded populations are already dropped; what survives is the foreground+online variant, kept on purpose as the only signal of a Caddy/host outage that never reaches the backend's own Sentry.
- **[FLAWCHESS-9V](https://flawchess.sentry.io/issues/FLAWCHESS-9V)** — `Maia worker inference error (oom)`. One event, iPhone/iOS 18.7, raw `[wasm] RangeError: Out of memory`. Real device memory exhaustion, already classified into a stable bucket and degraded gracefully — not a code defect.

## Verification

Both new suppressions were proven load-bearing by disabling them and confirming the new tests fail.

```
npx vitest run src/__tests__/instrument.beforeSend.test.ts  # 24 passed
npm run lint                                               # clean
npx tsc -b --noEmit                                        # clean
npm test -- --run                                          # 3572 passed
```

`Train.guestGate.test.tsx` times out under full-suite load (5030 ms against the 5 s Vitest ceiling) and passes in isolation — the known heavy-test flake, unrelated to this change.

No changelog entry: nothing here changes user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQnpfcZ2gy8PMfxkL22W5B