### PR TITLE
Hotfix: gate Maia off on iOS/iPadOS (analysis tab crash, SEED-158)

### DIFF
--- a/.planning/seeds/SEED-158-maia-webgpu-fails-on-capable-devices.md
+++ b/.planning/seeds/SEED-158-maia-webgpu-fails-on-capable-devices.md
@@ -2,7 +2,7 @@
 id: SEED-158
 status: active
 planted: 2026-08-29
-updated: 2026-09-06 (evening: wasm path kills the iOS page, see the iOS section)
+updated: 2026-09-06 (night: iOS gate hotfixed, see the iOS section)
 planted_during: Sentry triage of the 2026-08-29 18:54 UTC iPad OOM cascade
   (FLAWCHESS-9V regression + new FLAWCHESS-A2/A3), same session as quick task
   260829-tku (oom terminal variant in EngineReadyGate)
@@ -112,11 +112,19 @@ functions in the background with a footprint far above the heap; the ~10 s delay
 controllable from the page.
 
 Consequence for the release carrying quick task 260906-p54: before the cap, iOS users got a
-graceful `oom` terminal state; after it they get a dead analysis tab. Until either WebGPU
-works on iOS 26 or the wasm kill is understood, the wasm Maia path should be gated off on iOS
-Safari (a `unsupported`-style terminal state with honest copy), which is the only lever that
-keeps `/analysis` usable there. Collecting the WebGPU failure reason on the phone is the first
-step of the plan above and would remove the need for the gate.
+graceful `oom` terminal state; after it they get a dead analysis tab.
+
+**Hotfix shipped 2026-09-06 (`hotfix/ios-maia-gate`):** Maia is gated off ENTIRELY on
+iOS/iPadOS WebKit at the D-13 choke point (`maiaWorkerHost.ts` `ensureSpawned()`, predicate in
+`frontend/src/lib/engine/iosWebKit.ts`, iPadOS desktop-mode UA detected via `MacIntel` +
+`maxTouchPoints > 1`). The store carries `unsupportedReason: 'ios-webkit'`, the bots gate shows
+iOS-specific copy (`engine-gate-unsupported-ios`), Sentry's unsupported capture is tagged
+`unsupported_reason`. Not a wasm-only ban: WebGPU also fails on the reference device, so trying
+it first would only cost the 25.7 MB asyncify download before landing in the same state. When
+WebGPU is made to work on iOS, NARROW the gate (allow the `'auto'` spawn when the probe picks
+`webgpu`, and turn both `respawnPinnedToWasm` call sites into the `unsupported` terminal on
+iOS instead of the fatal wasm respawn). Collecting the WebGPU failure reason on the phone is the
+first step of the plan above.
 
 Prior art from the ORT tracker: microsoft/onnxruntime#22776 ("Support iOS devices") and
 #22086 (wasm load failures on iOS 17) are open with no maintainer guidance; WebGPU on iOS was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ in `YYYY-MM-DD` (Europe/Zurich).
 - Generate Insights on the Endgames tab works again. The rated-games default introduced with the new analytics population was rejected by the insights endpoint itself, so the button was enabled but every click failed with "Couldn't generate insights." Reports now cover your rated games against human opponents, matching the numbers on the rest of the tab, and cached reports written under the old population are regenerated once.
 - The "Try again" button on a failed insights report is now disabled while a filter blocks generation, like the Generate Insights button already was.
 - Maia analysis no longer fails with an out-of-memory error on iPhones. The browser inference runtime was reserving four times more memory address space than iOS Safari allows a page to hold alongside the Stockfish engine workers.
+- Hotfix: the analysis board no longer crashes the whole tab on iPhone and iPad. The previous fix let the Maia engine start on iOS for the first time, and Safari then killed the page within seconds of stepping through moves. Maia (the Human Move Probability chart, FlawChess Engine and the practice bots) is now switched off on iOS with a clear message on the bots page; the analysis board, Stockfish evaluation and game imports keep working there.
 
 ### Changed
 

--- a/frontend/src/components/bots/EngineReadyGate.tsx
+++ b/frontend/src/components/bots/EngineReadyGate.tsx
@@ -17,6 +17,7 @@ import { readDeviceContext } from '@/lib/maiaWorkerErrors';
 import { useEngineAssets } from '@/hooks/useEngineAssets';
 import { trackEvent } from '@/lib/analytics';
 import type { MaiaFailureKind } from '@/lib/maiaWorkerErrors';
+import type { EngineUnsupportedReason } from '@/lib/engine/engineAssetProgress';
 
 // ─── Named constants (CLAUDE.md no-magic-numbers) ──────────────────────────
 
@@ -125,7 +126,10 @@ const ENGINE_FAILURE_TAG_DOWNLOAD = 'download';
  * below). `unsupported` renders NO button of any kind; `failed` and `oom`
  * (quick 260829-tku) each render exactly one, Retry.
  */
-type TerminalVariant = 'unsupported' | 'failed' | 'oom';
+type TerminalVariant = 'unsupported' | 'unsupported-ios' | 'failed' | 'oom';
+
+/** The two dead-end variants: no button of any kind, since neither a retry nor a reload can change the outcome. */
+const NO_RETRY_VARIANTS: ReadonlySet<TerminalVariant> = new Set(['unsupported', 'unsupported-ios']);
 
 const TERMINAL_COPY: Record<TerminalVariant, { title: string; body: string; testId: string }> = {
   // G-213-34: reachable ONLY from the bots surface — the analysis mount
@@ -142,6 +146,20 @@ const TERMINAL_COPY: Record<TerminalVariant, { title: string; body: string; test
       "that isn't something a retry can fix. You can still use the free analysis board " +
       'and import your games from chess.com or lichess.',
     testId: 'engine-gate-unsupported',
+  },
+  // Hotfix 2026-09-06 (SEED-158): iOS/iPadOS WebKit CAN run the model but
+  // Safari kills the page while it does (see `iosWebKit.ts`), so the generic
+  // `unsupported` copy above ("doesn't support the technology") would be
+  // untrue here. Same dead-end shape (no button): a retry or reload runs
+  // straight into the same kill. Only the bots surface ever shows this
+  // (Analysis.tsx suppresses every `unsupported` mount, see the note above).
+  'unsupported-ios': {
+    title: "The bot engine is switched off on iPhone and iPad",
+    body:
+      'Safari on iOS shuts the page down while the bot engine is thinking, so FlawChess ' +
+      "doesn't start it there for now. You can still use the analysis board and import " +
+      'your games from chess.com or lichess, or play the bots on a desktop or Android browser.',
+    testId: 'engine-gate-unsupported-ios',
   },
   failed: {
     // Surface-neutral (G-213-34): both bots and analysis mount this state,
@@ -188,8 +206,12 @@ export interface EngineReadyGateProps {
  * `'failed'` status splits into `'oom'` for a classified memory exhaustion
  * and `'failed'` for every other case (`'load'`, `'inference'`, or `null`).
  */
-function pickTerminalVariant(status: 'unsupported' | 'failed', failureKind: MaiaFailureKind | null): TerminalVariant {
-  if (status === 'unsupported') return 'unsupported';
+function pickTerminalVariant(
+  status: 'unsupported' | 'failed',
+  failureKind: MaiaFailureKind | null,
+  unsupportedReason: EngineUnsupportedReason | null,
+): TerminalVariant {
+  if (status === 'unsupported') return unsupportedReason === 'ios-webkit' ? 'unsupported-ios' : 'unsupported';
   return failureKind === 'oom' ? 'oom' : 'failed';
 }
 
@@ -254,8 +276,15 @@ export function EngineReadyGate({ surface, onStart, onRetry }: EngineReadyGatePr
   useEffect(() => {
     if (assets.status === 'unsupported' && !unsupportedCapturedRef.current) {
       unsupportedCapturedRef.current = true;
+      // Hotfix 2026-09-06 (SEED-158): `unsupported_reason` splits the D-13
+      // no-SIMD population from the iOS gate in the dashboard without
+      // changing the (grouping-relevant) message.
       Sentry.captureException(new Error(SENTRY_MESSAGE_UNSUPPORTED), {
-        tags: { source: 'engine-ready-gate', engine_failure: 'unsupported' },
+        tags: {
+          source: 'engine-ready-gate',
+          engine_failure: 'unsupported',
+          unsupported_reason: assets.unsupportedReason ?? 'unknown',
+        },
         contexts: { engine_device: readDeviceContext() },
       });
     }
@@ -274,7 +303,7 @@ export function EngineReadyGate({ surface, onStart, onRetry }: EngineReadyGatePr
         contexts: { engine_device: readDeviceContext() },
       });
     }
-  }, [assets.status, assets.failureKind]);
+  }, [assets.status, assets.failureKind, assets.unsupportedReason]);
 
   // D-18: the single start path for BOTH surfaces — a bots-surface click and
   // an analysis-surface auto-close both funnel through this one function, so
@@ -318,7 +347,7 @@ export function EngineReadyGate({ surface, onStart, onRetry }: EngineReadyGatePr
   }, [surface, assets.ready, handleStart]);
 
   if (assets.status === 'unsupported' || assets.status === 'failed') {
-    const variant = pickTerminalVariant(assets.status, assets.failureKind);
+    const variant = pickTerminalVariant(assets.status, assets.failureKind, assets.unsupportedReason);
     const copy = TERMINAL_COPY[variant];
     return (
       <Dialog open onOpenChange={() => {}}>
@@ -332,7 +361,7 @@ export function EngineReadyGate({ surface, onStart, onRetry }: EngineReadyGatePr
               <DialogDescription className="text-sm">{copy.body}</DialogDescription>
             </DialogHeader>
           </div>
-          {variant !== 'unsupported' && (
+          {!NO_RETRY_VARIANTS.has(variant) && (
             <DialogFooter>
               <Button
                 variant="default"

--- a/frontend/src/components/bots/__tests__/EngineReadyGate.test.tsx
+++ b/frontend/src/components/bots/__tests__/EngineReadyGate.test.tsx
@@ -312,7 +312,7 @@ describe('EngineReadyGate', () => {
 
   it('the unsupported terminal state renders no button of any kind, and never the LoadError trailer copy', () => {
     act(() => {
-      markEngineAssetsUnsupported();
+      markEngineAssetsUnsupported('no-wasm-simd');
     });
     render(<EngineReadyGate surface="bots" onStart={vi.fn()} onRetry={vi.fn()} />);
 
@@ -320,6 +320,21 @@ describe('EngineReadyGate', () => {
     expect(within(gate).queryAllByRole('button')).toHaveLength(0);
     expect(screen.getByTestId('engine-gate-unsupported')).toBeTruthy();
     expect(gate.textContent).not.toContain('Please try again in a moment');
+  });
+
+  it('the iOS-gated terminal state (hotfix 2026-09-06, SEED-158) renders its own copy and, like unsupported, no button of any kind', () => {
+    act(() => {
+      markEngineAssetsUnsupported('ios-webkit');
+    });
+    render(<EngineReadyGate surface="bots" onStart={vi.fn()} onRetry={vi.fn()} />);
+
+    const gate = screen.getByTestId('engine-ready-gate');
+    expect(within(gate).queryAllByRole('button')).toHaveLength(0);
+    expect(screen.getByTestId('engine-gate-unsupported-ios')).toBeTruthy();
+    expect(screen.queryByTestId('engine-gate-unsupported')).toBeNull();
+    expect(gate.textContent).toContain('switched off on iPhone and iPad');
+    // Must not claim the device lacks a capability it actually has.
+    expect(gate.textContent).not.toContain("doesn't support the technology");
   });
 
   it('the failed terminal state renders a Retry button that clears the failed status and calls onRetry exactly once', () => {
@@ -505,7 +520,7 @@ describe('EngineReadyGate', () => {
 
     it('captures exactly one Sentry exception for the unsupported terminal state, with device context and no interpolated message', () => {
       act(() => {
-        markEngineAssetsUnsupported();
+        markEngineAssetsUnsupported('no-wasm-simd');
       });
       render(<EngineReadyGate surface="bots" onStart={vi.fn()} onRetry={vi.fn()} />);
 
@@ -515,6 +530,21 @@ describe('EngineReadyGate', () => {
         expect.objectContaining({
           tags: expect.objectContaining({ source: 'engine-ready-gate', engine_failure: 'unsupported' }),
           contexts: expect.objectContaining({ engine_device: expect.any(Object) }),
+        }),
+      );
+    });
+
+    it('tags the unsupported capture with the gate reason so the iOS population is separable from no-SIMD (same grouping message)', () => {
+      act(() => {
+        markEngineAssetsUnsupported('ios-webkit');
+      });
+      render(<EngineReadyGate surface="bots" onStart={vi.fn()} onRetry={vi.fn()} />);
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Engine cold start: device cannot run the Maia model' }),
+        expect.objectContaining({
+          tags: expect.objectContaining({ engine_failure: 'unsupported', unsupported_reason: 'ios-webkit' }),
         }),
       );
     });
@@ -678,7 +708,7 @@ describe('EngineReadyGate', () => {
 
     it('analysis: the unsupported terminal state does NOT auto-close — onStart is never called (defensive; Analysis.tsx additionally suppresses mounting the gate at all in this state)', () => {
       act(() => {
-        markEngineAssetsUnsupported();
+        markEngineAssetsUnsupported('no-wasm-simd');
       });
       const onStart = vi.fn();
       render(<EngineReadyGate surface="analysis" onStart={onStart} onRetry={vi.fn()} />);
@@ -696,7 +726,7 @@ describe('EngineReadyGate', () => {
 
       resetEngineAssetsForTests();
       act(() => {
-        markEngineAssetsUnsupported();
+        markEngineAssetsUnsupported('no-wasm-simd');
       });
       const onStartUnsupported = vi.fn();
       render(<EngineReadyGate surface="bots" onStart={onStartUnsupported} onRetry={vi.fn()} />);

--- a/frontend/src/hooks/useEngineAssets.ts
+++ b/frontend/src/hooks/useEngineAssets.ts
@@ -23,6 +23,7 @@ import {
   subscribeEngineAssets,
   type EngineAssetId,
   type EngineAssetStatus,
+  type EngineUnsupportedReason,
 } from '@/lib/engine/engineAssetProgress';
 import type { MaiaFailureKind } from '@/lib/maiaWorkerErrors';
 
@@ -47,6 +48,8 @@ export interface EngineAssetsState {
    * one). Read straight off the snapshot — it needs no per-`required` derivation.
    */
   failureKind: MaiaFailureKind | null;
+  /** Hotfix 2026-09-06 (SEED-158): which gate produced an `'unsupported'` status — drives the gate's copy. */
+  unsupportedReason: EngineUnsupportedReason | null;
 }
 
 /**
@@ -87,6 +90,7 @@ export function useEngineAssets(required: readonly EngineAssetId[]): EngineAsset
       totalBytes: totalSum,
       ready,
       failureKind: snapshot.failureKind,
+      unsupportedReason: snapshot.unsupportedReason,
     };
   }, [snapshot, required]);
 }

--- a/frontend/src/lib/engine/__tests__/engineAssetProgress.test.ts
+++ b/frontend/src/lib/engine/__tests__/engineAssetProgress.test.ts
@@ -493,7 +493,7 @@ describe('reportEngineAssetProgress — coalesced notifications (G-213-35)', () 
 
     listener = vi.fn();
     unsubscribe = subscribeEngineAssets(listener);
-    markEngineAssetsUnsupported();
+    markEngineAssetsUnsupported('no-wasm-simd');
     expect(listener).toHaveBeenCalledTimes(1);
     unsubscribe();
 
@@ -544,5 +544,32 @@ describe('reportEngineAssetProgress — coalesced notifications (G-213-35)', () 
     const MAX_NOTIFICATIONS = 101; // 0..100 inclusive
     expect(listener.mock.calls.length).toBeLessThanOrEqual(MAX_NOTIFICATIONS);
     unsubscribe();
+  });
+});
+
+// ─── Hotfix 2026-09-06 (SEED-158): unsupportedReason ─────────────────────────
+
+describe('unsupportedReason', () => {
+  beforeEach(() => {
+    resetEngineAssetsForTests();
+  });
+
+  it('is null until a gate fires, records the reason with the unsupported status, and resets to null', () => {
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBeNull();
+
+    markEngineAssetsUnsupported('ios-webkit');
+    expect(getEngineAssetsSnapshot().status).toBe('unsupported');
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBe('ios-webkit');
+
+    resetEngineAssetsForTests();
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBeNull();
+  });
+
+  it('is exposed on the useEngineAssets snapshot shape (referential stability preserved between reads)', () => {
+    markEngineAssetsUnsupported('no-wasm-simd');
+    const first = getEngineAssetsSnapshot();
+    const second = getEngineAssetsSnapshot();
+    expect(first).toBe(second);
+    expect(first.unsupportedReason).toBe('no-wasm-simd');
   });
 });

--- a/frontend/src/lib/engine/__tests__/iosWebKit.test.ts
+++ b/frontend/src/lib/engine/__tests__/iosWebKit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * iosWebKit.ts unit tests (hotfix 2026-09-06, SEED-158) — the probe must
+ * catch both UA shapes iOS produces (classic `iPhone`/`iPad` token, and the
+ * iPadOS 13+ desktop-mode macOS masquerade) while leaving real Macs and every
+ * non-Apple platform on the normal spawn path, and it must never throw.
+ */
+import { describe, it, expect } from 'vitest';
+import { isIosWebKit, type NavigatorPlatformInfo } from '../iosWebKit';
+
+const IPHONE_SAFARI_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1';
+const IPHONE_CHROME_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/140.0.0.0 Mobile/15E148 Safari/604.1';
+/** iPadOS 13+ "Request Desktop Website" (the default on iPad): byte-identical to macOS Safari. */
+const MAC_SAFARI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Safari/605.1.15';
+const WINDOWS_CHROME_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+const ANDROID_CHROME_UA =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Mobile Safari/537.36';
+
+const IPAD_TOUCH_POINTS = 5;
+const ANDROID_TOUCH_POINTS = 5;
+
+function nav(userAgent: string, platform: string, maxTouchPoints: number): NavigatorPlatformInfo {
+  return { userAgent, platform, maxTouchPoints };
+}
+
+describe('isIosWebKit', () => {
+  it('detects an iPhone (Safari UA token)', () => {
+    expect(isIosWebKit(nav(IPHONE_SAFARI_UA, 'iPhone', IPAD_TOUCH_POINTS))).toBe(true);
+  });
+
+  it('detects Chrome for iOS — every iOS browser is WebKit, so the gate must cover it too', () => {
+    expect(isIosWebKit(nav(IPHONE_CHROME_UA, 'iPhone', IPAD_TOUCH_POINTS))).toBe(true);
+  });
+
+  it('detects an iPad in desktop-site mode (macOS UA, MacIntel platform, touch points > 1)', () => {
+    expect(isIosWebKit(nav(MAC_SAFARI_UA, 'MacIntel', IPAD_TOUCH_POINTS))).toBe(true);
+  });
+
+  it('does NOT flag a real Mac (macOS UA, MacIntel platform, zero touch points)', () => {
+    expect(isIosWebKit(nav(MAC_SAFARI_UA, 'MacIntel', 0))).toBe(false);
+  });
+
+  it('does NOT flag Windows Chrome', () => {
+    expect(isIosWebKit(nav(WINDOWS_CHROME_UA, 'Win32', 0))).toBe(false);
+  });
+
+  it('does NOT flag Android — a touch device that is not MacIntel and carries no iOS token', () => {
+    expect(isIosWebKit(nav(ANDROID_CHROME_UA, 'Linux armv81', ANDROID_TOUCH_POINTS))).toBe(false);
+  });
+
+  it('falls safe to false (normal spawn path) when the navigator fields are unusable, and never throws', () => {
+    const broken = {
+      get userAgent(): string {
+        throw new Error('no navigator here');
+      },
+      platform: '',
+      maxTouchPoints: 0,
+    } as NavigatorPlatformInfo;
+    expect(() => isIosWebKit(broken)).not.toThrow();
+    expect(isIosWebKit(broken)).toBe(false);
+  });
+
+  it('defaults to the global navigator (jsdom: not iOS) when called without an argument', () => {
+    expect(isIosWebKit()).toBe(false);
+  });
+});

--- a/frontend/src/lib/engine/__tests__/maiaWorkerHost.test.ts
+++ b/frontend/src/lib/engine/__tests__/maiaWorkerHost.test.ts
@@ -526,6 +526,69 @@ describe('maiaWorkerHost', () => {
     expect(getEngineAssetsSnapshot().status).not.toBe('unsupported');
   });
 
+  // ─── Hotfix 2026-09-06 (SEED-158): iOS WebKit -> zero Workers, ever ──────
+
+  const IPHONE_UA =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1';
+  const IPAD_DESKTOP_MODE_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Safari/605.1.15';
+  const IPAD_TOUCH_POINTS = 5;
+
+  it('an iPhone never constructs a Worker, fetches no runtime, and the store reports unsupported with the ios-webkit reason', async () => {
+    vi.stubGlobal('navigator', { userAgent: IPHONE_UA, platform: 'iPhone', maxTouchPoints: IPAD_TOUCH_POINTS });
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const lease = acquireMaiaWorker({ source: 'maia-worker', priority: true });
+    const ready = lease.whenReady();
+
+    expect(createdWorkers).toHaveLength(0);
+    expect(vi.mocked(ensureOrtRuntime)).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchWasmOnlyOrtRuntime)).not.toHaveBeenCalled();
+    expect(getEngineAssetsSnapshot().status).toBe('unsupported');
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBe('ios-webkit');
+    // Rejected with the 'unsupported' marker so useFlawChessEngine/the gate
+    // do not re-report it — same contract as the SIMD case.
+    await expect(ready).rejects.toMatchObject({ kind: 'unsupported' });
+    // The fallback line for browser UAT (the seed's trigger condition).
+    expect(info).toHaveBeenCalledWith(expect.stringContaining('[maia-worker] iOS WebKit detected'));
+  });
+
+  it('an iPad in desktop-site mode (macOS UA + touch points) is gated the same way', () => {
+    vi.stubGlobal('navigator', {
+      userAgent: IPAD_DESKTOP_MODE_UA,
+      platform: 'MacIntel',
+      maxTouchPoints: IPAD_TOUCH_POINTS,
+    });
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const lease = acquireMaiaWorker({ source: 'maia-worker', priority: true });
+    void lease.whenReady().catch(() => {});
+
+    expect(createdWorkers).toHaveLength(0);
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBe('ios-webkit');
+  });
+
+  it('a real Mac (same UA, zero touch points) DOES construct a Worker — proves the iPad tell is the touch count', () => {
+    vi.stubGlobal('navigator', { userAgent: IPAD_DESKTOP_MODE_UA, platform: 'MacIntel', maxTouchPoints: 0 });
+
+    const lease = acquireMaiaWorker({ source: 'maia-worker', priority: true });
+    void lease.whenReady();
+
+    expect(createdWorkers).toHaveLength(1);
+    expect(getEngineAssetsSnapshot().status).not.toBe('unsupported');
+  });
+
+  it('the SIMD probe wins over the iOS gate when both apply (a no-SIMD iOS device reports no-wasm-simd)', () => {
+    vi.spyOn(WebAssembly, 'validate').mockReturnValue(false);
+    vi.stubGlobal('navigator', { userAgent: IPHONE_UA, platform: 'iPhone', maxTouchPoints: IPAD_TOUCH_POINTS });
+
+    const lease = acquireMaiaWorker({ source: 'maia-worker', priority: true });
+    void lease.whenReady().catch(() => {});
+
+    expect(createdWorkers).toHaveLength(0);
+    expect(getEngineAssetsSnapshot().unsupportedReason).toBe('no-wasm-simd');
+  });
+
   // ─── Phase 213-04 D-14/D-15: failure routing into engineAssetProgress ────
 
   it('a pre-ready error (second consecutive fetch failure) marks the store failed', () => {

--- a/frontend/src/lib/engine/engineAssetProgress.ts
+++ b/frontend/src/lib/engine/engineAssetProgress.ts
@@ -28,6 +28,16 @@ export type EngineAssetId = 'maia-model' | 'stockfish-wasm' | 'ort-runtime';
  */
 export type EngineAssetStatus = 'idle' | 'unsupported' | 'downloading' | 'ready' | 'failed';
 
+/**
+ * Why the store reports `'unsupported'` (hotfix 2026-09-06, SEED-158):
+ * `'no-wasm-simd'` is the D-13 probe (the device can never run the model);
+ * `'ios-webkit'` is the iOS/iPadOS gate (the device COULD run it, but Safari
+ * kills the page when it does — see `iosWebKit.ts`). `EngineReadyGate` shows
+ * different copy for each, so the iOS user is not told their device lacks a
+ * capability it actually has.
+ */
+export type EngineUnsupportedReason = 'no-wasm-simd' | 'ios-webkit';
+
 interface EngineAssetEntry {
   loaded: number;
   total: number;
@@ -47,6 +57,8 @@ export interface EngineAssetsSnapshot {
    * field simply stays `null` for those failures.
    */
   failureKind: MaiaFailureKind | null;
+  /** Which gate produced the current `'unsupported'` status, or `null` in every other status. */
+  unsupportedReason: EngineUnsupportedReason | null;
 }
 
 // ─── Named constants (CLAUDE.md no-magic-numbers) ──────────────────────────
@@ -127,6 +139,8 @@ let currentStatus: EngineAssetStatus = 'idle';
 let currentAssets: Partial<Record<EngineAssetId, EngineAssetEntry>> = {};
 /** Quick 260829-tku: the classified kind behind the current `'failed'` status. */
 let currentFailureKind: MaiaFailureKind | null = null;
+/** Hotfix 2026-09-06 (SEED-158): the gate behind the current `'unsupported'` status. */
+let currentUnsupportedReason: EngineUnsupportedReason | null = null;
 /**
  * Cached snapshot object — referentially stable between mutations so
  * `useSyncExternalStore` (in `useEngineAssets.ts`) does not loop forever.
@@ -136,6 +150,7 @@ let cachedSnapshot: EngineAssetsSnapshot = {
   status: currentStatus,
   assets: currentAssets,
   failureKind: currentFailureKind,
+  unsupportedReason: currentUnsupportedReason,
 };
 const listeners = new Set<() => void>();
 
@@ -162,7 +177,12 @@ function roundedAssetPercent(loaded: number, total: number): number {
  * true current bytes and `useSyncExternalStore`'s tearing guarantee holds.
  */
 function refreshSnapshot(): void {
-  cachedSnapshot = { status: currentStatus, assets: currentAssets, failureKind: currentFailureKind };
+  cachedSnapshot = {
+    status: currentStatus,
+    assets: currentAssets,
+    failureKind: currentFailureKind,
+    unsupportedReason: currentUnsupportedReason,
+  };
 }
 
 /** Notifies every subscriber. Only the caller decides whether this runs. */
@@ -313,9 +333,14 @@ export function markEngineAssetReady(id: EngineAssetId): void {
  * D-13: the device cannot run any engine asset at all (WASM-SIMD probe
  * failed). Plan 04 owns this state's UI; Task 1 calls it from the
  * `wasmSimd.ts` choke point in `maiaWorkerHost.ts`.
+ *
+ * Hotfix 2026-09-06 (SEED-158): also reached from the iOS/iPadOS gate at the
+ * same choke point, with `reason: 'ios-webkit'`, so the gate's copy can say
+ * what is actually going on instead of "your device lacks the technology".
  */
-export function markEngineAssetsUnsupported(): void {
+export function markEngineAssetsUnsupported(reason: EngineUnsupportedReason): void {
   currentStatus = 'unsupported';
+  currentUnsupportedReason = reason;
   commit();
 }
 
@@ -483,7 +508,13 @@ export function resetEngineAssetsForTests(): void {
   currentStatus = 'idle';
   currentAssets = {};
   currentFailureKind = null;
-  cachedSnapshot = { status: currentStatus, assets: currentAssets, failureKind: currentFailureKind };
+  currentUnsupportedReason = null;
+  cachedSnapshot = {
+    status: currentStatus,
+    assets: currentAssets,
+    failureKind: currentFailureKind,
+    unsupportedReason: currentUnsupportedReason,
+  };
   listeners.clear();
   lastNotifiedPercentById.clear();
 }

--- a/frontend/src/lib/engine/iosWebKit.ts
+++ b/frontend/src/lib/engine/iosWebKit.ts
@@ -1,0 +1,52 @@
+/**
+ * iosWebKit — a synchronous "is this iOS/iPadOS WebKit?" probe, run at the
+ * same D-13 choke point as `wasmSimd.ts` (`maiaWorkerHost.ts`'s
+ * `ensureSpawned()`), before any Worker is constructed or any byte fetched.
+ *
+ * Hotfix 2026-09-06 (SEED-158, iOS section): with the 1 GB wasm memory cap
+ * from quick task 260906-p54 in place, Maia STARTS on an iPhone 14 Pro
+ * (iOS 26.6.1) and Safari then kills the WebContent process within 10-20 s
+ * of stepping through moves on /analysis ("A problem repeatedly occurred").
+ * Measured on the device: the wasm heap stays flat at ~110 MB, one thread
+ * and one Stockfish worker make no difference, and bypassing `session.run`
+ * survives indefinitely, so executing ORT's wasm kernels is what WebKit's
+ * silent per-page memory-limit termination reacts to (prime suspect: the
+ * optimizing wasm tier compiling ORT's very large SIMD functions). That is
+ * not controllable from the page, and WebGPU also fails on the same device
+ * (adapter present, session/warmup fails, falls back to the fatal wasm
+ * path), so the only lever that keeps /analysis usable on iOS is to not
+ * start Maia there at all. Narrow this gate to "wasm only" once SEED-158
+ * makes WebGPU work on iOS.
+ *
+ * Every browser on iOS/iPadOS is WebKit (Chrome, Firefox and Brave for iOS
+ * wrap WKWebView), so "iOS" is the whole population; there is no
+ * per-browser split to make. Two tells are needed because iPadOS 13+
+ * requests desktop sites with a macOS Safari user agent — its only
+ * remaining giveaway is a touch-capable `MacIntel` platform, which no real
+ * Mac has. Chrome/Brave for iOS carry `iPhone`/`iPad` in the UA like Safari.
+ */
+
+/** Matches the classic iOS UA token; iPadOS 13+ desktop-mode UAs do NOT carry it. */
+const IOS_UA_PATTERN = /iPhone|iPad|iPod/;
+/** `navigator.platform` reported by iPadOS in desktop-site mode and by every Intel/Apple-silicon Mac. */
+const MAC_PLATFORM = 'MacIntel';
+/** Macs report 0 touch points; an iPad reports 5 — anything above one is a touch device. */
+const MIN_TOUCH_POINTS_FOR_IPAD = 1;
+
+/** Minimal local shape so tests can pass a fake without stubbing the global `navigator`. */
+export type NavigatorPlatformInfo = Pick<Navigator, 'userAgent' | 'platform' | 'maxTouchPoints'>;
+
+/**
+ * Returns `true` on iOS and iPadOS (any browser, all WebKit), `false`
+ * everywhere else. Never throws — a missing/garbage `navigator` field reads
+ * as "not iOS", so a non-browser test environment falls safe to the normal
+ * spawn path rather than gating every device off.
+ */
+export function isIosWebKit(nav: NavigatorPlatformInfo = navigator): boolean {
+  try {
+    if (IOS_UA_PATTERN.test(nav.userAgent)) return true;
+    return nav.platform === MAC_PLATFORM && nav.maxTouchPoints > MIN_TOUCH_POINTS_FOR_IPAD;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/lib/engine/maiaWorkerHost.ts
+++ b/frontend/src/lib/engine/maiaWorkerHost.ts
@@ -49,6 +49,7 @@ import {
   type MaiaErrorSource,
 } from '@/lib/maiaWorkerErrors';
 import { supportsWasmSimd } from './wasmSimd';
+import { isIosWebKit } from './iosWebKit';
 import {
   getEngineAssetsSnapshot,
   markEngineAssetFailed,
@@ -327,11 +328,29 @@ function ensureSpawned(source: MaiaErrorSource): void {
     simdSupported = supportsWasmSimd();
   }
   if (!simdSupported) {
-    markEngineAssetsUnsupported();
+    markEngineAssetsUnsupported('no-wasm-simd');
     // Reported by EngineReadyGate's `unsupported` capture (D-17), not here —
     // the MaiaWorkerError marker keeps useFlawChessEngine from reporting the
     // same rejection a second time as "a provider failed to become ready".
     failAllLeasesAndDropWorker(new MaiaWorkerError('Maia worker: device lacks WASM SIMD', 'unsupported'));
+    return;
+  }
+  // Hotfix 2026-09-06 (SEED-158): on iOS/iPadOS WebKit the wasm inference
+  // path kills the whole page (Safari's silent per-page memory-limit
+  // termination, measured on an iPhone 14 Pro after the 1 GB memory cap made
+  // Maia start there at all), and WebGPU fails on the same device before it
+  // can help — so Maia is gated off entirely on iOS, at this same choke
+  // point, BEFORE the 45.7 MB model or either runtime binary is fetched.
+  // Same terminal shape as the SIMD case above (no Retry: a reload runs into
+  // the same kill). Stockfish is unaffected: it lives in `workerPool.ts` and
+  // never reaches this host. See `iosWebKit.ts` for the evidence and for
+  // when to narrow this to a wasm-only ban.
+  if (isIosWebKit()) {
+    console.info('[maia-worker] iOS WebKit detected — Maia gated off (wasm inference kills the page, SEED-158)');
+    markEngineAssetsUnsupported('ios-webkit');
+    failAllLeasesAndDropWorker(
+      new MaiaWorkerError('Maia worker: gated off on iOS WebKit (wasm inference kills the page)', 'unsupported'),
+    );
     return;
   }
   spawn(source, webgpuFailed ? 'wasm' : 'auto');

--- a/frontend/src/pages/__tests__/Analysis.test.tsx
+++ b/frontend/src/pages/__tests__/Analysis.test.tsx
@@ -626,7 +626,7 @@ describe('Analysis page: engine readiness gate (G-213-34)', () => {
   });
 
   it('an unsupported store status mounts no gate, and the page and board containers are both present', () => {
-    markEngineAssetsUnsupported();
+    markEngineAssetsUnsupported('no-wasm-simd');
 
     renderAnalysis();
 
@@ -727,7 +727,7 @@ describe('Analysis page: engine readiness gate (G-213-34)', () => {
 
     // A real status transition — must re-render.
     act(() => {
-      markEngineAssetsUnsupported();
+      markEngineAssetsUnsupported('no-wasm-simd');
     });
     expect(renderCount).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Why

Release #347 shipped the 1 GB ORT wasm memory cap. That let Maia start on iOS for the first time, and Safari then kills the page within 10-20 s of stepping through moves on `/analysis` ("A problem repeatedly occurred"). Measured on an iPhone 14 Pro (iOS 26.6.1): heap flat at ~110 MB, single thread and single Stockfish worker make no difference, bypassing `session.run` survives. WebGPU fails on the same device before it can help. Full evidence in `.planning/seeds/SEED-158-maia-webgpu-fails-on-capable-devices.md`.

## What

- `frontend/src/lib/engine/iosWebKit.ts`: synchronous iOS/iPadOS probe (UA token, or iPadOS desktop-mode `MacIntel` + `maxTouchPoints > 1`).
- `maiaWorkerHost.ensureSpawned()`: on iOS, mark the store `unsupported` with reason `ios-webkit` and fail the leases before any Worker is constructed or any byte is fetched. Same shape as the D-13 no-SIMD gate.
- `engineAssetProgress` / `useEngineAssets`: new `unsupportedReason` field.
- `EngineReadyGate`: iOS-specific terminal copy (`engine-gate-unsupported-ios`, no button); Sentry unsupported capture tagged `unsupported_reason`.
- Stockfish is untouched, so the eval bar and analysis board keep working on iOS. Analysis.tsx already suppresses the gate in the `unsupported` state.

## Verification

- `npx tsc -b`, `npm run lint`, full frontend suite: 257 files / 3995 tests green.
- Mutation check: disabling the gate fails the two new host tests.
- On-device (iPhone) verification pending after deploy.

## Follow-up

Forward-port to `main` after deploy. Narrow the gate to a wasm-only ban once SEED-158 makes WebGPU work on iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
